### PR TITLE
ci: add CI Required aggregator so skipped jobs can't bypass branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,3 +448,44 @@ jobs:
       - name: Build Tauri app
         if: needs.changes.outputs.backend == 'true'
         run: npx tauri build
+
+  # Aggregator job exposed to branch protection / rulesets as the single
+  # required status check. It runs unconditionally (`if: always()`) so a
+  # PR that fails or cancels any upstream job cannot satisfy required
+  # checks by leaving downstream jobs in the "skipped" state — which
+  # GitHub treats as a pass and which previously let red PRs merge.
+  ci-required:
+    name: CI Required
+    needs:
+      - changes
+      - test-frontend
+      - test-e2e
+      - fmt-and-clippy
+      - test-postgres
+      - test-mysql
+      - test-mariadb
+      - test-cockroachdb
+      - test-tidb
+      - test-sqlite
+      - test-cassandra
+      - test-scylladb
+      - build
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify upstream jobs
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          set -euo pipefail
+          echo "Upstream job results:"
+          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
+          # Allowed terminal states. `skipped` is permitted because many
+          # jobs are gated on the `changes` filter (frontend-only PRs
+          # legitimately skip the backend matrix, etc.). `failure` and
+          # `cancelled` always fail this gate.
+          if echo "$NEEDS_JSON" | jq -e 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled")' >/dev/null; then
+            echo "::error::One or more required jobs failed or were cancelled"
+            exit 1
+          fi
+          echo "All required jobs succeeded or were intentionally skipped."


### PR DESCRIPTION
## Summary

- Adds a `CI Required` aggregator job that runs unconditionally (`if: always()`) and fails when any upstream CI job is in `failure` or `cancelled` state.
- `skipped` is allowed so the existing `paths-filter` pattern keeps working (frontend-only PRs legitimately skip the backend matrix and vice versa).
- Designed to be the **single** required status check on the branch protection / ruleset, replacing the per-job entries.

## Why

Two recent Renovate PRs (#35, #36) merged with `E2E Tests` in `failure`. Root cause:

1. The required-checks list only contained `Frontend Tests`, `Format & Clippy`, `Build`.
2. `Format & Clippy` and `Build` are gated on `needs.changes.outputs.backend == 'true'`. Frontend-only PRs resolve them as `SKIPPED`, which GitHub treats as a pass for required checks.
3. `E2E Tests` was not in the required list at all, so its failure didn't block the merge.

A single aggregator avoids the matrix-name bookkeeping (`Postgres 14`, `Postgres 15`, `Cassandra 4.0`, …) and closes the skipped-as-pass loophole.

## Follow-up after this merges

In **Settings → Branches** (or **Rules → Rulesets**) on `master`, replace the existing required checks with just `CI Required`.

## Test plan

- [ ] Open this PR and confirm `CI Required` appears in the checks list.
- [ ] Confirm it transitions to success when every upstream job is success or skipped.
- [ ] (Optional) push a deliberately-broken commit on a throwaway branch and confirm `CI Required` fails.