### PR TITLE
fix(cockroachdb): stop calling pg_total_relation_size / pg_size_pretty

### DIFF
--- a/src-tauri/src/db/cockroachdb.rs
+++ b/src-tauri/src/db/cockroachdb.rs
@@ -121,7 +121,14 @@ impl DatabaseDriver for CockroachdbDriver {
     }
     async fn list_tables(&self, database: &str, schema: &str) -> Result<Vec<TableInfo>> {
         let pool = self.get_pool(database).await?;
-        pg_list_tables(&pool, database, schema).await
+        // CockroachDB exposes a pg_class shim but does NOT implement
+        // `pg_total_relation_size` or the `pg_partitioned_table` /
+        // `pg_get_expr(relpartbound, ...)` catalog calls that the enriched
+        // Postgres listing depends on. Use the basic variant so we get
+        // names and row-count estimates without erroring out on every
+        // missing function. CockroachDB's own zone-based partitioning is
+        // not surfaced as separate pg_class rows anyway.
+        pg_list_tables_basic(&pool, database, schema).await
     }
     async fn list_indexes(
         &self,
@@ -369,13 +376,23 @@ impl DatabaseDriver for CockroachdbDriver {
         table: &str,
     ) -> Result<TableStats> {
         let pool = self.get_pool(database).await?;
-        let sql = "SELECT c.relname AS table_name,
-                   GREATEST(c.reltuples, 0)::bigint AS row_count,
-                   pg_size_pretty(pg_total_relation_size(c.oid)) AS total_size,
-                   pg_size_pretty(pg_indexes_size(c.oid)) AS index_size,
-                   pg_size_pretty(pg_relation_size(c.oid)) AS data_size
-                   FROM pg_class c
-                   JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = $1
+        // CockroachDB doesn't implement `pg_size_pretty`,
+        // `pg_total_relation_size`, `pg_relation_size`, or `pg_indexes_size`,
+        // so we can't compute storage costs the Postgres way. We still
+        // resolve the table via the pg_class shim (so unknown tables
+        // surface as a clean "not found"), pull `reltuples` for an
+        // estimated row count, and report sizes as "N/A" — the same
+        // sentinel the Cassandra driver uses.
+        //
+        // CockroachDB exposes per-range storage data via
+        // `crdb_internal.ranges_no_leases`, but mapping a logical table
+        // back to its ranges is non-trivial and the result wouldn't map
+        // cleanly to PG's data/index/total breakdown. Sentinel strings
+        // are the honest answer here.
+        let sql = "SELECT c.relname AS table_name, \
+                   GREATEST(c.reltuples, 0)::bigint AS row_count \
+                   FROM pg_class c \
+                   JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = $1 \
                    WHERE c.relname = $2 AND c.relkind = 'r'";
         let row = sqlx::query(sql)
             .bind(schema)
@@ -387,9 +404,9 @@ impl DatabaseDriver for CockroachdbDriver {
         Ok(TableStats {
             table_name: row.get("table_name"),
             row_count: row.get("row_count"),
-            total_size: row.get("total_size"),
-            index_size: row.get("index_size"),
-            data_size: row.get("data_size"),
+            total_size: "N/A".to_string(),
+            index_size: "N/A".to_string(),
+            data_size: "N/A".to_string(),
             last_vacuum: None,
             last_analyze: None,
             dead_tuples: None,

--- a/src-tauri/src/db/pg_common.rs
+++ b/src-tauri/src/db/pg_common.rs
@@ -374,11 +374,36 @@ pub async fn pg_list_tables(
     _database: &str,
     schema: &str,
 ) -> Result<Vec<TableInfo>> {
+    // Enriched-with-partitions/storage variant for real PostgreSQL.
+    pg_list_tables_inner(pool, schema, true).await
+}
+
+/// Basic table listing without the PostgreSQL-only catalog enrichment.
+///
+/// Drivers such as CockroachDB share the `pg_class` shim but do **not**
+/// implement `pg_total_relation_size`, `pg_partitioned_table`, or
+/// `pg_get_expr(relpartbound, ...)` — calling them produces
+/// `unknown function: pg_total_relation_size()` and breaks the entire
+/// query. This entry point returns just `name`, `schema`, `table_type`,
+/// and `row_count_estimate`; callers must accept that the partition and
+/// storage fields on `TableInfo` will be `None`.
+pub async fn pg_list_tables_basic(
+    pool: &PgPool,
+    _database: &str,
+    schema: &str,
+) -> Result<Vec<TableInfo>> {
+    pg_list_tables_inner(pool, schema, false).await
+}
+
+async fn pg_list_tables_inner(pool: &PgPool, schema: &str, enrich: bool) -> Result<Vec<TableInfo>> {
     // We pull table_type from information_schema (which is friendly and
-    // distinguishes BASE TABLE / VIEW), then enrich with partition metadata
-    // from pg_class / pg_partitioned_table / pg_inherits.
+    // distinguishes BASE TABLE / VIEW), then optionally enrich with
+    // partition metadata from pg_class / pg_partitioned_table / pg_inherits
+    // and a storage-size column. The enrichment is gated on `enrich`
+    // because CockroachDB's pg_class shim doesn't ship the size functions
+    // or the partition catalogs.
     //
-    // Notes:
+    // Notes (enriched mode):
     //  - relkind 'p' => partitioned parent. partstrat in pg_partitioned_table
     //    is 'r' (range), 'l' (list), 'h' (hash).
     //  - relispartition = true on partition children. We resolve the parent
@@ -388,6 +413,44 @@ pub async fn pg_list_tables(
     //    or "DEFAULT" for the default partition.
     //  - pg_total_relation_size includes indexes + toast; for partitioned
     //    parents that's the sum across children.
+    if !enrich {
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                t.table_name,
+                t.table_type,
+                COALESCE(c.reltuples::bigint, 0) AS row_estimate
+            FROM information_schema.tables t
+            LEFT JOIN pg_namespace n
+                   ON n.nspname = t.table_schema
+            LEFT JOIN pg_class c
+                   ON c.relname = t.table_name
+                  AND c.relnamespace = n.oid
+                  AND c.relkind IN ('r','v','m','f','p')
+            WHERE t.table_schema = $1
+            ORDER BY t.table_name
+            "#,
+        )
+        .bind(schema)
+        .fetch_all(pool)
+        .await?;
+
+        return Ok(rows
+            .iter()
+            .map(|r| TableInfo {
+                name: r.get("table_name"),
+                schema: schema.to_string(),
+                table_type: r.get("table_type"),
+                row_count_estimate: r.try_get("row_estimate").ok(),
+                parent_table: None,
+                partition_strategy: None,
+                partition_bound: None,
+                is_default_partition: None,
+                total_bytes: None,
+            })
+            .collect());
+    }
+
     let rows = sqlx::query(
         r#"
         SELECT

--- a/src-tauri/tests/cockroachdb_integration.rs
+++ b/src-tauri/tests/cockroachdb_integration.rs
@@ -1404,11 +1404,16 @@ async fn crdb_get_table_stats() {
     let stats = driver.get_table_stats(&db, SCHEMA, &tbl).await.unwrap();
     assert_eq!(stats.table_name, tbl);
     // Some CockroachDB versions return reltuples=0 until ANALYZE/auto-stats
-    // catches up; we only assert the field is non-negative and the size
-    // labels are populated to keep the test robust across versions.
+    // catches up; we only assert the field is non-negative.
     assert!(stats.row_count >= 0);
-    assert!(!stats.total_size.is_empty(), "total_size should be set");
-    assert!(!stats.data_size.is_empty(), "data_size should be set");
+    // CockroachDB's pg_class shim does not implement pg_size_pretty /
+    // pg_total_relation_size, so the driver intentionally reports sizes
+    // as the sentinel "N/A". Pin that contract — if a future driver
+    // version starts computing real sizes, this test should be updated
+    // deliberately rather than silently start returning real bytes.
+    assert_eq!(stats.total_size, "N/A");
+    assert_eq!(stats.data_size, "N/A");
+    assert_eq!(stats.index_size, "N/A");
 
     driver
         .drop_object(&db, SCHEMA, &tbl, "TABLE")


### PR DESCRIPTION
## Why

Hotfix for the CockroachDB regression introduced in b352a65 ("feat(table-view): unify Data/Schema inspector with partition-aware stats"). That commit added `pg_total_relation_size`, `pg_partitioned_table`, and `pg_get_expr(relpartbound, ...)` to the shared `pg_common::pg_list_tables` query — none of which CockroachDB's `pg_class` shim implements. As a result every CockroachDB `list_tables` call started failing with:

```
unknown function: pg_total_relation_size()
```

`cockroachdb::get_table_stats` was already silently broken in the same way (it used `pg_size_pretty(pg_total_relation_size(...))` and friends), but no test exercised it end-to-end until the cross-driver coverage in b339e8e landed and exposed the failure on PR #38.

The earlier passing CockroachDB CI runs were a coincidence — `list_tables` and `get_table_stats` weren't actually being executed by any test in the suite at that point.

## What

1. Split `pg_list_tables` in `src-tauri/src/db/pg_common.rs`:
   - `pg_list_tables` → unchanged enriched variant (real Postgres). Now thin-wraps a private `pg_list_tables_inner(..., enrich = true)`.
   - `pg_list_tables_basic` → new entry point that returns just `name` / `schema` / `table_type` / `row_count_estimate` and leaves the partition + storage fields as `None`. Calls `pg_list_tables_inner(..., enrich = false)`.
2. Switch `cockroachdb.rs::list_tables` to use `pg_list_tables_basic`. CockroachDB has no PG-style declarative partitioning, so the partition columns weren't carrying useful information for CRDB anyway.
3. Rewrite `cockroachdb.rs::get_table_stats` to drop every `pg_size_pretty` / `pg_*_size` call. Total / data / index size now come back as the sentinel string `"N/A"` (same approach `cassandra.rs` uses when storage isn't introspectable). Row count still comes from `pg_class.reltuples`, and unknown tables still surface as a clean `Table {schema}.{table} not found` error.
4. Tighten `crdb_get_table_stats` in `src-tauri/tests/cockroachdb_integration.rs` to assert the sentinel exactly (`assert_eq!(stats.total_size, "N/A")`) so a future regression can't silently swap the value.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml --tests` (clean)
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` (clean — same flags CI runs)
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check` (clean)
- [x] Full CockroachDB integration suite locally against `cockroachdb:latest`: **47/47 passing**, including:
  - `crdb_list_tables_after_create` (the regressed path)
  - `crdb_get_table_stats`
  - `crdb_get_table_stats_unknown_table_returns_not_found`
- [x] Postgres path sanity: `pg_list_tables_after_create` + all `pg_get_table_stats_*` tests still green (so the basic-vs-enriched split didn't disturb the real Postgres driver).
- [ ] CI: confirm the `CockroachDB` job goes green again (was failing on master after b339e8e).

## Notes / follow-ups

- Real storage numbers on CockroachDB would require walking `crdb_internal.ranges_no_leases`, which doesn't map cleanly to PG's data/index/total split. Deferring that until there's a concrete ask — `"N/A"` is the honest answer for now.
- This unblocks the `CI Required` aggregator (#37) for any backend-touching PR.