### PR TITLE
fix: harden filter pipeline + dialect-aware SQL builders + cross-driver safety parity

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -31,7 +31,12 @@ pub async fn export_table_data(
     let content = match request.format.as_str() {
         "csv" => export::to_csv(&columns, &data.rows),
         "json" => export::to_json(&columns, &data.rows),
-        "sql" => export::to_sql_inserts(&request.table, &columns, &data.rows),
+        "sql" => export::to_sql_inserts(
+            Some(request.schema.as_str()),
+            &request.table,
+            &columns,
+            &data.rows,
+        ),
         _ => return Err(format!("Unsupported format: {}", request.format)),
     };
 
@@ -66,7 +71,12 @@ pub async fn export_table_to_file(
     let content = match request.format.as_str() {
         "csv" => export::to_csv(&columns, &data.rows),
         "json" => export::to_json(&columns, &data.rows),
-        "sql" => export::to_sql_inserts(&request.table, &columns, &data.rows),
+        "sql" => export::to_sql_inserts(
+            Some(request.schema.as_str()),
+            &request.table,
+            &columns,
+            &data.rows,
+        ),
         _ => return Err(format!("Unsupported format: {}", request.format)),
     };
 
@@ -83,7 +93,9 @@ pub async fn export_query_result(request: ExportResultRequest) -> Result<String,
     let content = match request.format.as_str() {
         "csv" => export::to_csv(&request.columns, &request.rows),
         "json" => export::to_json(&request.columns, &request.rows),
-        "sql" => export::to_sql_inserts(&table_name, &request.columns, &request.rows),
+        // No schema available from the query-result path -- the caller
+        // doesn't know which logical table the rows belong to.
+        "sql" => export::to_sql_inserts(None, &table_name, &request.columns, &request.rows),
         _ => return Err(format!("Unsupported format: {}", request.format)),
     };
     Ok(content)
@@ -100,7 +112,7 @@ pub async fn export_query_result_to_file(
     let content = match request.format.as_str() {
         "csv" => export::to_csv(&request.columns, &request.rows),
         "json" => export::to_json(&request.columns, &request.rows),
-        "sql" => export::to_sql_inserts(&table_name, &request.columns, &request.rows),
+        "sql" => export::to_sql_inserts(None, &table_name, &request.columns, &request.rows),
         _ => return Err(format!("Unsupported format: {}", request.format)),
     };
 

--- a/src-tauri/src/db/cassandra.rs
+++ b/src-tauri/src/db/cassandra.rs
@@ -12,6 +12,45 @@ pub struct CassandraDriver {
     session: Session,
 }
 
+/// Mirrors `pg_common::filter_is_unsafe`. Cassandra/CQL has its own
+/// expression grammar but the threat model (typo or confused-deputy
+/// statement injection from the local UI) is identical, so we apply
+/// the same heuristic across drivers for consistency.
+fn filter_is_unsafe(filter: &str) -> bool {
+    let s = filter.trim();
+    if s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return true;
+    }
+    let u = s.to_uppercase();
+    if u.contains("(SELECT") {
+        return true;
+    }
+    u.contains(" UNION SELECT")
+        || u.contains(" UNION ALL SELECT")
+        || u.contains(" UNION DISTINCT SELECT")
+}
+
+fn filter_unsafe_reason(filter: &str) -> Option<&'static str> {
+    let s = filter.trim();
+    if s.contains(';') {
+        return Some("statement terminator (`;`)");
+    }
+    if s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return Some("CQL comment markers (`--` / `/* */`)");
+    }
+    let u = s.to_uppercase();
+    if u.contains("(SELECT") {
+        return Some("nested `(SELECT ...)` subquery");
+    }
+    if u.contains(" UNION SELECT")
+        || u.contains(" UNION ALL SELECT")
+        || u.contains(" UNION DISTINCT SELECT")
+    {
+        return Some("`UNION SELECT` clause");
+    }
+    None
+}
+
 const SYSTEM_KEYSPACES: &[&str] = &[
     "system",
     "system_auth",
@@ -341,17 +380,50 @@ impl DatabaseDriver for CassandraDriver {
         let columns = self.list_columns(database, database, table).await?;
 
         let qualified = format!("{}.{}", quote_ident(database), quote_ident(table));
-        let mut cql = format!("SELECT * FROM {}", qualified);
 
-        if let Some(ref f) = filter {
-            let f = f.trim();
-            if !f.is_empty() {
-                if f.contains(';') || f.contains("--") || f.contains("/*") || f.contains("*/") {
-                    anyhow::bail!("Filter contains invalid characters (; -- /* */)");
+        // Build the optional WHERE fragment once and reuse it for both
+        // the count query and the data query so the two stay in sync.
+        let where_clause = match filter.as_deref().map(str::trim).filter(|f| !f.is_empty()) {
+            Some(f) => {
+                if let Some(reason) = filter_unsafe_reason(f) {
+                    anyhow::bail!("Filter rejected: {}", reason);
                 }
-                cql.push_str(&format!(" WHERE {}", f));
+                debug_assert!(!filter_is_unsafe(f));
+                format!(" WHERE {}", f)
             }
-        }
+            None => String::new(),
+        };
+
+        // Total row count -- previously we computed `LIMIT (offset + limit)`,
+        // pulled the entire window into memory, then reported the fetched
+        // page size as `total_rows`. That meant pagination UI was wrong
+        // (total stuck at the page boundary) and deep pages OOM'd.
+        //
+        // CQL has no real OFFSET, so we do it in two stages:
+        //   1. `SELECT COUNT(*) ... [WHERE ...]` for the true total.
+        //      `ALLOW FILTERING` is required when the WHERE references
+        //      non-key columns; we always send it for consistency.
+        //   2. `SELECT * ... [WHERE ...] LIMIT (offset + limit)` for the
+        //      data, then skip+take in Rust. We can't avoid loading
+        //      `offset` rows -- that's a CQL limitation -- but at least
+        //      the total is now correct.
+        let count_cql = format!(
+            "SELECT COUNT(*) FROM {}{} ALLOW FILTERING",
+            qualified, where_clause
+        );
+        let count_result = self
+            .session
+            .query_unpaged(count_cql.as_str(), &[])
+            .await
+            .map_err(|e| anyhow!("{}", e))?
+            .into_rows_result()
+            .map_err(|e| anyhow!("{}", e))?;
+        let total_rows: i64 = count_result
+            .first_row::<(i64,)>()
+            .map(|(c,)| c)
+            .unwrap_or(0);
+
+        let mut cql = format!("SELECT * FROM {}{}", qualified, where_clause);
 
         if let Some(ref s) = sort {
             cql.push_str(&format!(
@@ -364,8 +436,12 @@ impl DatabaseDriver for CassandraDriver {
             ));
         }
 
-        let fetch_limit = offset + limit;
-        cql.push_str(&format!(" LIMIT {}", fetch_limit));
+        // Saturating add prevents an integer overflow if the caller
+        // passes hostile pagination parameters; the worst that can
+        // happen is we send the largest representable LIMIT, which
+        // Cassandra will then reject or truncate cleanly.
+        let fetch_limit = offset.saturating_add(limit);
+        cql.push_str(&format!(" LIMIT {} ALLOW FILTERING", fetch_limit));
 
         let result = self
             .session
@@ -376,7 +452,6 @@ impl DatabaseDriver for CassandraDriver {
             .map_err(|e| anyhow!("{}", e))?;
 
         let (_, all_rows) = rows_from_result(&result);
-        let fetched_total = all_rows.len() as i64;
 
         let rows: Vec<Vec<serde_json::Value>> = all_rows
             .into_iter()
@@ -384,12 +459,10 @@ impl DatabaseDriver for CassandraDriver {
             .take(limit as usize)
             .collect();
 
-        let total = fetched_total;
-
         Ok(TableData {
             columns,
             rows,
-            total_rows: total,
+            total_rows,
             offset,
             limit,
         })

--- a/src-tauri/src/db/mssql.rs
+++ b/src-tauri/src/db/mssql.rs
@@ -21,6 +21,44 @@ fn bracket(ident: &str) -> String {
     format!("[{}]", ident.replace(']', "]]"))
 }
 
+/// Mirrors `pg_common::filter_is_unsafe` so the MSSQL driver rejects the
+/// same set of filter patterns as Postgres / MySQL / SQLite. See the
+/// doc comment on the Postgres helper for the threat model.
+fn filter_is_unsafe(filter: &str) -> bool {
+    let s = filter.trim();
+    if s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return true;
+    }
+    let u = s.to_uppercase();
+    if u.contains("(SELECT") {
+        return true;
+    }
+    u.contains(" UNION SELECT")
+        || u.contains(" UNION ALL SELECT")
+        || u.contains(" UNION DISTINCT SELECT")
+}
+
+fn filter_unsafe_reason(filter: &str) -> Option<&'static str> {
+    let s = filter.trim();
+    if s.contains(';') {
+        return Some("statement terminator (`;`)");
+    }
+    if s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return Some("SQL comment markers (`--` / `/* */`)");
+    }
+    let u = s.to_uppercase();
+    if u.contains("(SELECT") {
+        return Some("nested `(SELECT ...)` subquery");
+    }
+    if u.contains(" UNION SELECT")
+        || u.contains(" UNION ALL SELECT")
+        || u.contains(" UNION DISTINCT SELECT")
+    {
+        return Some("`UNION SELECT` clause");
+    }
+    None
+}
+
 fn three_part_table(database: &str, schema: &str, table: &str) -> String {
     format!(
         "{}.{}.{}",
@@ -771,9 +809,10 @@ impl DatabaseDriver for MssqlDriver {
         if let Some(f) = filter {
             let t = f.trim();
             if !t.is_empty() {
-                if t.contains(';') || t.contains("--") || t.contains("/*") || t.contains("*/") {
-                    anyhow::bail!("Filter contains invalid characters (; -- /* */)");
+                if let Some(reason) = filter_unsafe_reason(t) {
+                    anyhow::bail!("Filter rejected: {}", reason);
                 }
+                debug_assert!(!filter_is_unsafe(t));
                 where_clause = format!(" WHERE {}", t);
             }
         }

--- a/src-tauri/src/db/mysql_common.rs
+++ b/src-tauri/src/db/mysql_common.rs
@@ -111,8 +111,19 @@ pub fn json_to_sql_literal(val: &serde_json::Value) -> String {
     }
 }
 
+/// Strict check for SQL fragments that should never contain string
+/// literals (data types, operator names, etc). Bans `'` here because
+/// types never legitimately need one. For `DEFAULT` clauses use
+/// `sql_default_is_unsafe` instead so string defaults survive.
 pub fn sql_fragment_is_unsafe(s: &str) -> bool {
     s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/") || s.contains('\'')
+}
+
+/// Same as `sql_fragment_is_unsafe` but allows `'` so legitimate
+/// string-literal defaults (e.g. `DEFAULT 'pending'`) aren't blocked.
+/// Mirrors `pg_common::sql_default_is_unsafe`.
+pub fn sql_default_is_unsafe(s: &str) -> bool {
+    s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/")
 }
 
 pub fn mysql_variable_category(name: &str) -> &str {
@@ -147,9 +158,45 @@ pub fn mysql_variable_category(name: &str) -> &str {
     }
 }
 
+/// MySQL/MariaDB/TiDB filter safety check. Mirrors the strict
+/// PostgreSQL version (`pg_common::filter_is_unsafe`) so the rejection
+/// matrix is identical across drivers — see the doc comment there for
+/// the rationale and the full list of patterns blocked.
 pub fn filter_is_unsafe(filter: &str) -> bool {
     let s = filter.trim();
-    s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/")
+    if s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return true;
+    }
+    let u = s.to_uppercase();
+    if u.contains("(SELECT") {
+        return true;
+    }
+    u.contains(" UNION SELECT")
+        || u.contains(" UNION ALL SELECT")
+        || u.contains(" UNION DISTINCT SELECT")
+}
+
+/// Mirrors `pg_common::filter_unsafe_reason` so MySQL-family drivers
+/// can produce the same precise error messages.
+pub fn filter_unsafe_reason(filter: &str) -> Option<&'static str> {
+    let s = filter.trim();
+    if s.contains(';') {
+        return Some("statement terminator (`;`)");
+    }
+    if s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return Some("SQL comment markers (`--` / `/* */`)");
+    }
+    let u = s.to_uppercase();
+    if u.contains("(SELECT") {
+        return Some("nested `(SELECT ...)` subquery");
+    }
+    if u.contains(" UNION SELECT")
+        || u.contains(" UNION ALL SELECT")
+        || u.contains(" UNION DISTINCT SELECT")
+    {
+        return Some("`UNION SELECT` clause");
+    }
+    None
 }
 
 pub fn format_bytes(bytes: Option<i64>) -> String {
@@ -401,8 +448,11 @@ pub async fn my_fetch_rows_impl(
     filter: Option<String>,
 ) -> Result<TableData> {
     if let Some(ref f) = filter {
-        if !f.trim().is_empty() && filter_is_unsafe(f) {
-            anyhow::bail!("Filter contains invalid characters (; -- /* */)");
+        if !f.trim().is_empty() {
+            if let Some(reason) = filter_unsafe_reason(f) {
+                anyhow::bail!("Filter rejected: {}", reason);
+            }
+            debug_assert!(!filter_is_unsafe(f));
         }
     }
 
@@ -551,7 +601,10 @@ pub async fn my_create_table(
             anyhow::bail!("Invalid character in data type for column {}", col.name);
         }
         if let Some(d) = &col.default_value {
-            if !d.is_empty() && sql_fragment_is_unsafe(d) {
+            // String defaults like `DEFAULT 'pending'` are valid SQL
+            // and must survive validation; only block statement
+            // terminators / comment markers.
+            if !d.is_empty() && sql_default_is_unsafe(d) {
                 anyhow::bail!("Invalid character in default value for column {}", col.name);
             }
         }
@@ -603,7 +656,7 @@ pub async fn my_alter_table(
                     anyhow::bail!("Invalid character in data type for column {}", column.name);
                 }
                 if let Some(d) = &column.default_value {
-                    if !d.is_empty() && sql_fragment_is_unsafe(d) {
+                    if !d.is_empty() && sql_default_is_unsafe(d) {
                         anyhow::bail!(
                             "Invalid character in default value for column {}",
                             column.name
@@ -620,7 +673,7 @@ pub async fn my_alter_table(
                 default_value: Some(d),
                 ..
             } if !d.is_empty() => {
-                if sql_fragment_is_unsafe(d) {
+                if sql_default_is_unsafe(d) {
                     anyhow::bail!("Invalid character in default value");
                 }
             }
@@ -1169,6 +1222,57 @@ mod tests {
     fn filter_safe_normal_operators() {
         assert!(!filter_is_unsafe("`age` >= 18 AND `status` = 'active'"));
         assert!(!filter_is_unsafe("`price` BETWEEN 10 AND 100"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-driver parity: MySQL's filter_is_unsafe used to only block
+    // `;`, `--`, `/*`, `*/` (no UNION / subquery checks), so a payload
+    // like `1=1 UNION SELECT password FROM mysql.user` was accepted
+    // when it would have been rejected on the Postgres driver. After
+    // the unification it must reject the same set of patterns.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_unsafe_unionless_subquery_now_blocked() {
+        assert!(filter_is_unsafe("1=1 OR (SELECT 1)"));
+        assert!(filter_is_unsafe("(SELECT count(*) FROM mysql.user) > 0"));
+    }
+
+    #[test]
+    fn filter_unsafe_union_without_comments_now_blocked() {
+        // Previously slipped through because there's no `;`, `--`, `/*`, `*/`.
+        assert!(filter_is_unsafe("1=1 UNION SELECT user FROM mysql.user"));
+        assert!(filter_is_unsafe("1=1 UNION ALL SELECT 1"));
+        assert!(filter_is_unsafe("1=1 UNION DISTINCT SELECT 1"));
+    }
+
+    #[test]
+    fn filter_unsafe_reason_descriptive_messages() {
+        assert_eq!(
+            filter_unsafe_reason("x; DROP TABLE t"),
+            Some("statement terminator (`;`)")
+        );
+        assert_eq!(
+            filter_unsafe_reason("1=1 UNION SELECT 1"),
+            Some("`UNION SELECT` clause")
+        );
+        assert!(filter_unsafe_reason("`id` = 1").is_none());
+    }
+
+    #[test]
+    fn sql_default_allows_string_literals_mysql() {
+        // Same regression class as pg_common: legitimate `DEFAULT 'val'`
+        // must not be rejected for containing a single quote.
+        assert!(!sql_default_is_unsafe("'pending'"));
+        assert!(!sql_default_is_unsafe("'O''Brien'"));
+        assert!(!sql_default_is_unsafe("CURRENT_TIMESTAMP"));
+    }
+
+    #[test]
+    fn sql_default_still_blocks_injection() {
+        assert!(sql_default_is_unsafe("'x'; DROP TABLE users"));
+        assert!(sql_default_is_unsafe("'x' -- comment"));
+        assert!(sql_default_is_unsafe("'x' /* comment */"));
     }
 
     #[test]

--- a/src-tauri/src/db/pg_common.rs
+++ b/src-tauri/src/db/pg_common.rs
@@ -123,6 +123,20 @@ pub fn quote_ident(name: &str) -> String {
     format!("\"{}\"", name.replace('"', "\"\""))
 }
 
+/// Standard "is this filter fragment too risky to splice into a WHERE
+/// clause" check. The Tauri command interface only accepts filter strings
+/// from the local Tablio UI, so the threat model is "stop a typo or
+/// confused-deputy from accidentally executing a second statement", not
+/// "defend against an attacker with arbitrary network access".
+///
+/// The same heuristic is exposed verbatim on every driver so behaviour
+/// is consistent across Postgres / MySQL / SQLite / MSSQL / Cassandra:
+///  * `;`, `--`, `/*`, `*/`     -> statement terminator / comment injection
+///  * `(SELECT`                  -> subquery splice
+///  * ` UNION [ALL|DISTINCT] SELECT` -> classic union-based shape change
+///
+/// Drivers should call this directly (not roll their own) so the matrix
+/// stays uniform — that's why the function is `pub`.
 pub fn filter_is_unsafe(filter: &str) -> bool {
     let s = filter.trim();
     if s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/") {
@@ -138,8 +152,49 @@ pub fn filter_is_unsafe(filter: &str) -> bool {
         || u.contains(" UNION DISTINCT SELECT")
 }
 
+/// Human-readable explanation of *what* `filter_is_unsafe` rejected, so
+/// drivers can surface a better error than "invalid characters".
+/// Returns `None` when the fragment is safe.
+pub fn filter_unsafe_reason(filter: &str) -> Option<&'static str> {
+    let s = filter.trim();
+    if s.contains(';') {
+        return Some("statement terminator (`;`)");
+    }
+    if s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return Some("SQL comment markers (`--` / `/* */`)");
+    }
+    let u = s.to_uppercase();
+    if u.contains("(SELECT") {
+        return Some("nested `(SELECT ...)` subquery");
+    }
+    if u.contains(" UNION SELECT")
+        || u.contains(" UNION ALL SELECT")
+        || u.contains(" UNION DISTINCT SELECT")
+    {
+        return Some("`UNION SELECT` clause");
+    }
+    None
+}
+
+/// Strict check for SQL fragments that should never contain string
+/// literals: column data types, operator names, sort directions, etc.
+/// Bans `'` here because a type or operator never legitimately needs
+/// one — anything quoted in those contexts is almost certainly a typo
+/// or an injection attempt.
+///
+/// For places that DO need to accept user-authored expressions (column
+/// `DEFAULT` clauses, check constraints, generated columns), use
+/// `sql_default_is_unsafe` instead — it allows `'` so string defaults
+/// like `DEFAULT 'pending'` work.
 pub fn sql_fragment_is_unsafe(s: &str) -> bool {
     s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/") || s.contains('\'')
+}
+
+/// Same as `sql_fragment_is_unsafe` but tolerates `'` so legitimate
+/// string-literal `DEFAULT 'value'` clauses survive validation. Still
+/// blocks the statement-terminator / comment-injection vectors.
+pub fn sql_default_is_unsafe(s: &str) -> bool {
+    s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/")
 }
 
 pub fn json_to_sql_literal(val: &serde_json::Value) -> String {
@@ -860,8 +915,11 @@ pub async fn pg_fetch_rows_impl(
     filter: Option<String>,
 ) -> Result<TableData> {
     if let Some(ref f) = filter {
-        if !f.trim().is_empty() && filter_is_unsafe(f) {
-            anyhow::bail!("Filter contains invalid characters (; -- /* */)");
+        if !f.trim().is_empty() {
+            if let Some(reason) = filter_unsafe_reason(f) {
+                anyhow::bail!("Filter rejected: {}", reason);
+            }
+            debug_assert!(!filter_is_unsafe(f));
         }
     }
 
@@ -1083,7 +1141,11 @@ pub async fn pg_create_table(
             anyhow::bail!("Invalid character in data type for column {}", col.name);
         }
         if let Some(d) = &col.default_value {
-            if !d.is_empty() && sql_fragment_is_unsafe(d) {
+            // `sql_default_is_unsafe` (not `sql_fragment_is_unsafe`)
+            // here so that legitimate string defaults like
+            // `DEFAULT 'pending'` survive — only statement terminators
+            // and comment markers are rejected.
+            if !d.is_empty() && sql_default_is_unsafe(d) {
                 anyhow::bail!("Invalid character in default value for column {}", col.name);
             }
         }
@@ -1140,7 +1202,7 @@ pub async fn pg_alter_table(
                 default_value: Some(d),
                 ..
             } if !d.is_empty() => {
-                if sql_fragment_is_unsafe(d) {
+                if sql_default_is_unsafe(d) {
                     anyhow::bail!("Invalid character in default value");
                 }
             }
@@ -1658,6 +1720,94 @@ mod tests {
     #[test]
     fn filter_unsafe_subquery_attempt() {
         assert!(filter_is_unsafe("1=1) OR (SELECT password FROM pg_shadow)"));
+    }
+
+    // -----------------------------------------------------------------------
+    // `sql_default_is_unsafe`: same as `sql_fragment_is_unsafe` but tolerates
+    // single quotes so legitimate string-literal DEFAULTs survive validation.
+    // Regression for the bug that previously rejected `DEFAULT 'pending'`.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn sql_default_allows_string_literals() {
+        // Repro: previously `'pending'` triggered the strict check and the
+        // user couldn't set ANY string default through the UI.
+        assert!(!sql_default_is_unsafe("'pending'"));
+        assert!(!sql_default_is_unsafe("'O''Brien'"));
+        assert!(!sql_default_is_unsafe("'multi word string'"));
+    }
+
+    #[test]
+    fn sql_default_allows_function_calls_with_args() {
+        // PG accepts scalar subqueries and function calls in DEFAULT
+        // expressions; only statement terminators / comment markers
+        // should be rejected.
+        assert!(!sql_default_is_unsafe("now()"));
+        assert!(!sql_default_is_unsafe("CURRENT_TIMESTAMP"));
+        assert!(!sql_default_is_unsafe("nextval('seq_id')"));
+    }
+
+    #[test]
+    fn sql_default_still_blocks_statement_terminators() {
+        assert!(sql_default_is_unsafe("'x'; DROP TABLE users"));
+        assert!(sql_default_is_unsafe("'x' -- comment"));
+        assert!(sql_default_is_unsafe("'x' /* comment */"));
+        assert!(sql_default_is_unsafe("'x' */"));
+    }
+
+    // -----------------------------------------------------------------------
+    // `filter_unsafe_reason`: returns a precise explanation when a filter
+    // is rejected, replacing the generic "(; -- /* */)" message.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_unsafe_reason_safe_returns_none() {
+        assert!(filter_unsafe_reason("\"id\" = 1").is_none());
+        assert!(filter_unsafe_reason("").is_none());
+    }
+
+    #[test]
+    fn filter_unsafe_reason_pinpoints_each_pattern() {
+        assert_eq!(
+            filter_unsafe_reason("x; DROP TABLE t"),
+            Some("statement terminator (`;`)")
+        );
+        assert_eq!(
+            filter_unsafe_reason("x -- comment"),
+            Some("SQL comment markers (`--` / `/* */`)")
+        );
+        assert_eq!(
+            filter_unsafe_reason("1=1 UNION SELECT * FROM users"),
+            Some("`UNION SELECT` clause")
+        );
+        assert_eq!(
+            filter_unsafe_reason("1=1) OR (SELECT * FROM users)"),
+            Some("nested `(SELECT ...)` subquery")
+        );
+    }
+
+    #[test]
+    fn filter_unsafe_reason_matches_filter_is_unsafe() {
+        // Any input flagged by `filter_is_unsafe` MUST produce a Some(_)
+        // from `filter_unsafe_reason`, otherwise we'd bail with an empty
+        // explanation. Lock that invariant.
+        let cases = [
+            "x; y",
+            "x -- y",
+            "x /* y",
+            "x */",
+            "id = 1 UNION SELECT 1",
+            "id = 1 UNION ALL SELECT 1",
+            "id = 1 UNION DISTINCT SELECT 1",
+            "(SELECT 1)",
+        ];
+        for c in cases {
+            assert!(filter_is_unsafe(c), "{c:?} should be unsafe");
+            assert!(
+                filter_unsafe_reason(c).is_some(),
+                "{c:?} flagged unsafe but no reason returned"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/db/sqlite.rs
+++ b/src-tauri/src/db/sqlite.rs
@@ -87,13 +87,54 @@ fn json_to_sql_literal(val: &serde_json::Value) -> String {
     }
 }
 
+/// Strict — types/operators must never legitimately contain `'`.
 fn sql_fragment_is_unsafe(s: &str) -> bool {
     s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/") || s.contains('\'')
 }
 
+/// Same as `sql_fragment_is_unsafe` but allows `'` so legitimate
+/// string-literal defaults survive validation.
+fn sql_default_is_unsafe(s: &str) -> bool {
+    s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/")
+}
+
+/// Mirrors `pg_common::filter_is_unsafe` so SQLite rejects the same set
+/// of patterns as the Postgres path: statement terminator `;`, comment
+/// markers `--` / `/* */`, nested `(SELECT ...)` subqueries, and
+/// `UNION SELECT` shape changes.
 fn filter_is_unsafe(filter: &str) -> bool {
     let s = filter.trim();
-    s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/")
+    if s.contains(';') || s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return true;
+    }
+    let u = s.to_uppercase();
+    if u.contains("(SELECT") {
+        return true;
+    }
+    u.contains(" UNION SELECT")
+        || u.contains(" UNION ALL SELECT")
+        || u.contains(" UNION DISTINCT SELECT")
+}
+
+fn filter_unsafe_reason(filter: &str) -> Option<&'static str> {
+    let s = filter.trim();
+    if s.contains(';') {
+        return Some("statement terminator (`;`)");
+    }
+    if s.contains("--") || s.contains("/*") || s.contains("*/") {
+        return Some("SQL comment markers (`--` / `/* */`)");
+    }
+    let u = s.to_uppercase();
+    if u.contains("(SELECT") {
+        return Some("nested `(SELECT ...)` subquery");
+    }
+    if u.contains(" UNION SELECT")
+        || u.contains(" UNION ALL SELECT")
+        || u.contains(" UNION DISTINCT SELECT")
+    {
+        return Some("`UNION SELECT` clause");
+    }
+    None
 }
 
 fn format_bytes(bytes: i64) -> String {
@@ -282,8 +323,11 @@ impl DatabaseDriver for SqliteDriver {
         filter: Option<String>,
     ) -> Result<TableData> {
         if let Some(ref f) = filter {
-            if !f.trim().is_empty() && filter_is_unsafe(f) {
-                anyhow::bail!("Filter contains invalid characters (; -- /* */)");
+            if !f.trim().is_empty() {
+                if let Some(reason) = filter_unsafe_reason(f) {
+                    anyhow::bail!("Filter rejected: {}", reason);
+                }
+                debug_assert!(!filter_is_unsafe(f));
             }
         }
 
@@ -504,7 +548,7 @@ impl DatabaseDriver for SqliteDriver {
                 anyhow::bail!("Invalid character in data type for column {}", col.name);
             }
             if let Some(d) = &col.default_value {
-                if !d.is_empty() && sql_fragment_is_unsafe(d) {
+                if !d.is_empty() && sql_default_is_unsafe(d) {
                     anyhow::bail!("Invalid character in default value for column {}", col.name);
                 }
             }
@@ -643,7 +687,7 @@ impl DatabaseDriver for SqliteDriver {
                     anyhow::bail!("Invalid character in data type for column {}", column.name);
                 }
                 if let Some(d) = &column.default_value {
-                    if !d.is_empty() && sql_fragment_is_unsafe(d) {
+                    if !d.is_empty() && sql_default_is_unsafe(d) {
                         anyhow::bail!(
                             "Invalid character in default value for column {}",
                             column.name
@@ -1093,5 +1137,52 @@ mod tests {
     fn json_to_sql_string_injection_attempt() {
         let val = json_to_sql_literal(&serde_json::Value::String("'; DROP TABLE t; --".into()));
         assert_eq!(val, "'''; DROP TABLE t; --'");
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-driver parity: the SQLite filter check now matches Postgres.
+    // Previously it only blocked `;`, `--`, `/*`, `*/`, so `UNION SELECT`
+    // and `(SELECT ...)` payloads slipped through.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_unsafe_unionless_subquery_now_blocked() {
+        assert!(filter_is_unsafe("1=1 OR (SELECT 1)"));
+        assert!(filter_is_unsafe("(SELECT count(*) FROM sqlite_master) > 0"));
+    }
+
+    #[test]
+    fn filter_unsafe_union_without_comments_now_blocked() {
+        assert!(filter_is_unsafe("1=1 UNION SELECT * FROM sqlite_master"));
+        assert!(filter_is_unsafe("1=1 UNION ALL SELECT 1"));
+        assert!(filter_is_unsafe("1=1 UNION DISTINCT SELECT 1"));
+    }
+
+    #[test]
+    fn filter_unsafe_reason_descriptive_messages() {
+        assert_eq!(
+            filter_unsafe_reason("x; DROP TABLE t"),
+            Some("statement terminator (`;`)")
+        );
+        assert_eq!(
+            filter_unsafe_reason("(SELECT 1)"),
+            Some("nested `(SELECT ...)` subquery")
+        );
+        assert!(filter_unsafe_reason("\"id\" = 1").is_none());
+    }
+
+    #[test]
+    fn sql_default_allows_string_literals_sqlite() {
+        // Same regression class as pg_common / mysql_common.
+        assert!(!sql_default_is_unsafe("'pending'"));
+        assert!(!sql_default_is_unsafe("'O''Brien'"));
+        assert!(!sql_default_is_unsafe("CURRENT_TIMESTAMP"));
+    }
+
+    #[test]
+    fn sql_default_still_blocks_injection() {
+        assert!(sql_default_is_unsafe("'x'; DROP TABLE users"));
+        assert!(sql_default_is_unsafe("'x' -- comment"));
+        assert!(sql_default_is_unsafe("'x' /* comment */"));
     }
 }

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -44,13 +44,43 @@ pub fn to_json(columns: &[String], rows: &[Vec<Value>]) -> String {
     serde_json::to_string_pretty(&objects).unwrap_or_else(|_| "[]".to_string())
 }
 
-pub fn to_sql_inserts(table_name: &str, columns: &[String], rows: &[Vec<Value>]) -> String {
+/// Render rows as `INSERT INTO ... VALUES (...);` statements.
+///
+/// `schema` is optional: when provided the output emits a fully
+/// qualified `"schema"."table"` reference so the dump can be replayed
+/// in a database that doesn't have a matching `search_path` /
+/// `current_schema`. Previously this argument was missing entirely and
+/// every export silently dropped to `INSERT INTO "table"`, which round-
+/// tripped fine on single-schema databases (SQLite, MySQL when
+/// `database == schema`) but broke restores in PostgreSQL multi-schema
+/// setups.
+///
+/// The output uses standard `"…"` identifier quoting (PG / SQLite /
+/// MSSQL with `QUOTED_IDENTIFIER ON` / Cassandra all accept this).
+/// MySQL with default `sql_mode` would need backticks — the dialect
+/// mismatch is tracked separately; this fix at least makes
+/// schema-qualified targets correct on the dialects that already work.
+pub fn to_sql_inserts(
+    schema: Option<&str>,
+    table_name: &str,
+    columns: &[String],
+    rows: &[Vec<Value>],
+) -> String {
     let mut out = String::new();
     let cols_str = columns
         .iter()
         .map(|c| format!("\"{}\"", c.replace('"', "\"\"")))
         .collect::<Vec<_>>()
         .join(", ");
+
+    let qualified = match schema {
+        Some(s) if !s.is_empty() => format!(
+            "\"{}\".\"{}\"",
+            s.replace('"', "\"\""),
+            table_name.replace('"', "\"\"")
+        ),
+        _ => format!("\"{}\"", table_name.replace('"', "\"\"")),
+    };
 
     for row in rows {
         let vals: Vec<String> = row
@@ -65,8 +95,8 @@ pub fn to_sql_inserts(table_name: &str, columns: &[String], rows: &[Vec<Value>])
             .collect();
 
         out.push_str(&format!(
-            "INSERT INTO \"{}\" ({}) VALUES ({});\n",
-            table_name.replace('"', "\"\""),
+            "INSERT INTO {} ({}) VALUES ({});\n",
+            qualified,
             cols_str,
             vals.join(", ")
         ));
@@ -198,15 +228,47 @@ mod tests {
     fn sql_inserts_basic() {
         let cols = ["name".to_string()];
         let rows = vec![vec![Value::String("O'Brien".into())]];
-        let out = to_sql_inserts("users", &cols, &rows);
+        let out = to_sql_inserts(None, "users", &cols, &rows);
         assert!(out.contains("INSERT INTO \"users\""));
         assert!(out.contains("'O''Brien'"));
     }
 
     #[test]
+    fn sql_inserts_with_schema_qualifies_target() {
+        // Regression test: previously the schema was dropped on the
+        // floor, producing `INSERT INTO "events"` for a table named
+        // `analytics.events`. That file would re-import into the wrong
+        // table (or fail) when restored against a multi-schema database.
+        let cols = ["id".to_string()];
+        let rows = vec![vec![Value::Number(1i64.into())]];
+        let out = to_sql_inserts(Some("analytics"), "events", &cols, &rows);
+        assert!(
+            out.contains(r#"INSERT INTO "analytics"."events""#),
+            "expected schema-qualified target, got: {out}"
+        );
+    }
+
+    #[test]
+    fn sql_inserts_with_empty_schema_falls_back_to_unqualified() {
+        let cols = ["id".to_string()];
+        let rows = vec![vec![Value::Number(1i64.into())]];
+        let out = to_sql_inserts(Some(""), "t", &cols, &rows);
+        assert!(out.contains(r#"INSERT INTO "t""#));
+        assert!(!out.contains("\"\".\"t\""));
+    }
+
+    #[test]
+    fn sql_inserts_with_quoted_schema_escapes_correctly() {
+        let cols = ["v".to_string()];
+        let rows = vec![vec![Value::Number(1i64.into())]];
+        let out = to_sql_inserts(Some(r#"weird"schema"#), "t", &cols, &rows);
+        assert!(out.contains(r#""weird""schema"."t""#));
+    }
+
+    #[test]
     fn sql_inserts_empty_rows() {
         let cols = ["id".to_string()];
-        let out = to_sql_inserts("t", &cols, &[]);
+        let out = to_sql_inserts(None, "t", &cols, &[]);
         assert_eq!(out, "");
     }
 
@@ -214,7 +276,7 @@ mod tests {
     fn sql_inserts_null_and_number() {
         let cols = ["a".to_string(), "b".to_string()];
         let rows = vec![vec![Value::Null, Value::Number(42i64.into())]];
-        let out = to_sql_inserts("t", &cols, &rows);
+        let out = to_sql_inserts(None, "t", &cols, &rows);
         assert!(out.contains("NULL, 42"));
     }
 
@@ -222,7 +284,7 @@ mod tests {
     fn sql_inserts_bool() {
         let cols = ["flag".to_string()];
         let rows = vec![vec![Value::Bool(true)]];
-        let out = to_sql_inserts("t", &cols, &rows);
+        let out = to_sql_inserts(None, "t", &cols, &rows);
         assert!(out.contains("true"));
     }
 
@@ -230,7 +292,7 @@ mod tests {
     fn sql_inserts_table_name_with_quote() {
         let cols = ["v".to_string()];
         let rows = vec![vec![Value::Number(1i64.into())]];
-        let out = to_sql_inserts(r#"my"table"#, &cols, &rows);
+        let out = to_sql_inserts(None, r#"my"table"#, &cols, &rows);
         assert!(out.contains(r#""my""table""#));
     }
 
@@ -238,7 +300,7 @@ mod tests {
     fn sql_inserts_column_name_with_quote() {
         let cols = [r#"col"umn"#.to_string()];
         let rows = vec![vec![Value::Number(1i64.into())]];
-        let out = to_sql_inserts("t", &cols, &rows);
+        let out = to_sql_inserts(None, "t", &cols, &rows);
         assert!(out.contains(r#""col""umn""#));
     }
 
@@ -250,7 +312,7 @@ mod tests {
             vec![Value::Number(2i64.into())],
             vec![Value::Number(3i64.into())],
         ];
-        let out = to_sql_inserts("t", &cols, &rows);
+        let out = to_sql_inserts(None, "t", &cols, &rows);
         assert_eq!(out.matches("INSERT INTO").count(), 3);
     }
 
@@ -337,7 +399,7 @@ mod tests {
     fn sql_inserts_array_value() {
         let cols = ["arr".to_string()];
         let rows = vec![vec![Value::Array(vec![Value::Number(1i64.into())])]];
-        let out = to_sql_inserts("t", &cols, &rows);
+        let out = to_sql_inserts(None, "t", &cols, &rows);
         assert!(out.contains("[1]"));
         assert!(out.contains("'"));
     }
@@ -349,7 +411,7 @@ mod tests {
             "k".to_string(),
             Value::String("v".into()),
         )]))]];
-        let out = to_sql_inserts("t", &cols, &rows);
+        let out = to_sql_inserts(None, "t", &cols, &rows);
         assert!(out.contains("INSERT INTO"));
     }
 

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -19,6 +19,7 @@ import { ColumnOrganizer, ColumnSettings, loadColumnSettings, saveColumnSettings
 import { useToastStore } from "../../stores/toastStore";
 import { useTabStore, TabInfo } from "../../stores/tabStore";
 import { useConnectionStore } from "../../stores/connectionStore";
+import { boolLiteral, paginationClause, quoteIdent, quoteQualified } from "../../lib/sqlDialect";
 import {
   Save,
   Undo2,
@@ -123,6 +124,11 @@ interface Props {
   schema: string;
   table: string;
   hideTitle?: boolean;
+  /** When false, the periodic auto-refresh interval is suspended.
+   *  Used by `TableView` to pause polling when the grid is hidden
+   *  behind the Schema tab — otherwise the network keeps churning
+   *  on a panel the user isn't even looking at. Defaults to `true`. */
+  isActive?: boolean;
 }
 
 interface PendingChanges {
@@ -149,7 +155,7 @@ const REFRESH_OPTIONS = [
   { label: "5m", value: 300 },
 ];
 
-export function DataGrid({ connectionId, database, schema, table, hideTitle = false }: Props) {
+export function DataGrid({ connectionId, database, schema, table, hideTitle = false, isActive = true }: Props) {
   const addToast = useToastStore((s) => s.addToast);
   const openTab = useTabStore((s) => s.openTab);
   const connections = useConnectionStore((s) => s.connections);
@@ -305,12 +311,19 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
   }, [changes, detailRowIdx]);
 
   useEffect(() => {
-    if (refreshInterval <= 0 || hasChanges) return;
+    // Skip the timer entirely when:
+    //  - the user disabled auto-refresh (refreshInterval = 0)
+    //  - there are unsaved changes (would clobber pending edits)
+    //  - the grid is mounted but currently hidden (TableView keeps the
+    //    Data tab in the DOM with display:none when Schema is shown;
+    //    polling a hidden grid is wasted work and can confuse users
+    //    who think "I'm not on this tab, why is it making requests?")
+    if (refreshInterval <= 0 || hasChanges || !isActive) return;
     const id = setInterval(() => {
       fetchData({ silent: true });
     }, refreshInterval * 1000);
     return () => clearInterval(id);
-  }, [refreshInterval, fetchData, hasChanges]);
+  }, [refreshInterval, fetchData, hasChanges, isActive]);
 
   useEffect(() => {
     if (!showRefreshMenu) return;
@@ -752,17 +765,21 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
 
   const formatRowAsInsert = useCallback((row: unknown[]): string => {
     if (!data) return "";
-    const cols = data.columns.map((c) => `"${c.name}"`).join(", ");
+    // Dialect-aware: previously hardcoded `"col"` / `"schema"."table"`
+    // / `TRUE` regardless of connection type, producing snippets that
+    // didn't run as-is on default-mode MySQL or MSSQL.
+    const dbType = connections.find((c) => c.id === connectionId)?.db_type;
+    const cols = data.columns.map((c) => quoteIdent(dbType, c.name)).join(", ");
     const vals = row
       .map((v) => {
         if (v === null) return "NULL";
         if (typeof v === "number") return String(v);
-        if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
+        if (typeof v === "boolean") return boolLiteral(dbType, v);
         return `'${String(v).replace(/'/g, "''")}'`;
       })
       .join(", ");
-    return `INSERT INTO "${schema}"."${table}" (${cols}) VALUES (${vals});`;
-  }, [data, schema, table]);
+    return `INSERT INTO ${quoteQualified(dbType, schema, table)} (${cols}) VALUES (${vals});`;
+  }, [data, schema, table, connections, connectionId]);
 
   const handleCopyAllAsInsert = () => {
     navigator.clipboard.writeText(editingRows.map(formatRowAsInsert).join("\n"));
@@ -829,10 +846,18 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     setExplainLoading(true);
     setShowExplain(true);
     try {
-      let sql = `SELECT * FROM "${schema}"."${table}"`;
+      const dbType = connections.find((c) => c.id === connectionId)?.db_type;
+      let sql = `SELECT * FROM ${quoteQualified(dbType, schema, table)}`;
       if (activeFilter) sql += ` WHERE ${activeFilter}`;
-      if (sort) sql += ` ORDER BY "${sort.column}" ${sort.direction}`;
-      sql += ` LIMIT ${PAGE_SIZE} OFFSET ${page * PAGE_SIZE}`;
+      if (sort) {
+        sql += ` ORDER BY ${quoteIdent(dbType, sort.column)} ${sort.direction}`;
+      } else if (dbType === "mssql") {
+        // MSSQL's `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY` syntax
+        // requires an `ORDER BY`. Use a NULL-sort sentinel so the
+        // pagination clause is always valid even without a user sort.
+        sql += ` ORDER BY (SELECT NULL)`;
+      }
+      sql += ` ${paginationClause(dbType, PAGE_SIZE, page * PAGE_SIZE)}`;
       const result = await api.explainQuery({
         connection_id: connectionId,
         database,
@@ -845,12 +870,18 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     } finally {
       setExplainLoading(false);
     }
-  }, [connectionId, database, schema, table, activeFilter, sort, page, addToast, showExplain]);
+  }, [connectionId, database, schema, table, activeFilter, sort, page, addToast, showExplain, connections]);
 
   const handleGenerateTestData = useCallback(() => {
     if (!data) return;
     const generateValue = (col: ColumnInfo): unknown => {
-      const t = col.data_type.toLowerCase();
+      // `data_type` should always be a non-null string from the
+      // backend, but Cassandra's collection types and a handful of
+      // synthetic columns (e.g. computed views) have produced
+      // undefined here in the wild. Fall back to a typeless string
+      // bucket so we never crash the dialog with `cannot read
+      // properties of undefined (reading 'toLowerCase')`.
+      const t = (col.data_type ?? "").toLowerCase();
       if (col.is_auto_generated || col.is_primary_key) return null;
       if (t.includes("smallint") || t === "smallserial")
         return Math.floor(Math.random() * 30000);
@@ -1145,6 +1176,7 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
           columns={data.columns}
           onApply={handleFilterApply}
           onClose={() => setShowFilter(false)}
+          dbType={connections.find((c) => c.id === connectionId)?.db_type}
         />
       )}
 

--- a/src/components/DataGrid/FilterBar.tsx
+++ b/src/components/DataGrid/FilterBar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Plus, X, Play } from "lucide-react";
 import { ColumnInfo } from "../../lib/tauri";
 import { buildWhereClause as buildWhereClauseFromConditions, NO_VALUE_OPS, type FilterCondition } from "../../lib/filterBuilder";
+import type { DbType } from "../../lib/sqlDialect";
 import { CustomSelect } from "../CustomSelect/CustomSelect";
 import "./FilterBar.css";
 
@@ -9,6 +10,10 @@ interface Props {
   columns: ColumnInfo[];
   onApply: (filter: string | null) => void;
   onClose: () => void;
+  /** Optional — when provided, filters are emitted in dialect-correct
+   *  identifier quoting and `ILIKE` is rewritten to `LOWER(...) LIKE
+   *  LOWER(...)` on engines that don't support `ILIKE` natively. */
+  dbType?: DbType;
 }
 
 const OPERATORS = [
@@ -24,7 +29,7 @@ const OPERATORS = [
   { value: "IS NOT NULL", label: "IS NOT NULL" },
 ];
 
-export function FilterBar({ columns, onApply, onClose }: Props) {
+export function FilterBar({ columns, onApply, onClose, dbType }: Props) {
   const [conditions, setConditions] = useState<FilterCondition[]>([
     { id: "1", column: columns[0]?.name || "", operator: "=", value: "", join: "AND" },
   ]);
@@ -62,7 +67,7 @@ export function FilterBar({ columns, onApply, onClose }: Props) {
   };
 
   const handleApply = () => {
-    onApply(buildWhereClauseFromConditions(conditions, columns));
+    onApply(buildWhereClauseFromConditions(conditions, columns, dbType));
   };
 
   const handleClear = () => {

--- a/src/components/QueryConsole/QueryConsole.tsx
+++ b/src/components/QueryConsole/QueryConsole.tsx
@@ -128,13 +128,19 @@ export function QueryConsole({ connectionId, database }: Props) {
   }, []);
 
   const loadColumnsForTable = useCallback(async (tableName: string, schema: string) => {
-    const cached = columnsCache.current.get(tableName);
+    // Key by `schema.table`, not just `table`. With the previous key
+    // two same-named tables in different schemas (e.g. `auth.users`
+    // and `app.users`) collided in this cache and autocomplete
+    // returned the first-loaded set for both — wrong columns,
+    // confusing UX, and very hard to spot once cached.
+    const key = `${schema}.${tableName}`;
+    const cached = columnsCache.current.get(key);
     if (cached) return cached;
     const { connectionId: cid, database: db } = connRef.current;
     try {
       const colInfos = await api.listColumns(cid, db, schema, tableName);
       const cols = colInfos.map((c) => ({ name: c.name, type: c.data_type }));
-      columnsCache.current.set(tableName, cols);
+      columnsCache.current.set(key, cols);
       return cols;
     } catch { return []; }
   }, []);

--- a/src/components/QueryConsole/ResultTable.tsx
+++ b/src/components/QueryConsole/ResultTable.tsx
@@ -8,6 +8,7 @@ import { ExportMenu } from "../ExportMenu";
 import { useToastStore } from "../../stores/toastStore";
 import { useTabStore, TabInfo } from "../../stores/tabStore";
 import { useConnectionStore } from "../../stores/connectionStore";
+import { boolLiteral, quoteIdent, quoteQualified } from "../../lib/sqlDialect";
 import "../DataGrid/ag-grid-theme.css";
 import "./QueryConsole.css";
 
@@ -741,18 +742,23 @@ export function ResultTable({ result, resultMode, onToggleChart, onExport, conne
 
   const formatRowAsInsert = useCallback((row: unknown[]): string => {
     if (!sourceTable) return "";
-    const cols = result.columns.map((c) => `"${c}"`).join(", ");
+    // Dialect-aware: previously emitted PG-style `"..."` quoting and
+    // `TRUE` / `FALSE` literals regardless of the source connection,
+    // so the snippet wasn't runnable as-is on default-mode MySQL or
+    // MSSQL.
+    const dbType = connections.find((c) => c.id === connectionId)?.db_type;
+    const cols = result.columns.map((c) => quoteIdent(dbType, c)).join(", ");
     const vals = row
       .map((v) => {
         if (v === null) return "NULL";
         if (typeof v === "number") return String(v);
-        if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
+        if (typeof v === "boolean") return boolLiteral(dbType, v);
         return `'${String(v).replace(/'/g, "''")}'`;
       })
       .join(", ");
-    const tbl = sourceTable.schema ? `"${sourceTable.schema}"."${sourceTable.table}"` : `"${sourceTable.table}"`;
+    const tbl = quoteQualified(dbType, sourceTable.schema, sourceTable.table);
     return `INSERT INTO ${tbl} (${cols}) VALUES (${vals});`;
-  }, [sourceTable, result.columns]);
+  }, [sourceTable, result.columns, connections, connectionId]);
 
   const handleCopyAsInsert = useCallback(() => {
     if (contextMenu === null) return;

--- a/src/components/TableView/TableView.tsx
+++ b/src/components/TableView/TableView.tsx
@@ -212,6 +212,7 @@ export function TableView({
               schema={schema}
               table={table}
               hideTitle
+              isActive={mode === "data"}
             />
           </div>
         )}

--- a/src/lib/filterBuilder.test.ts
+++ b/src/lib/filterBuilder.test.ts
@@ -186,4 +186,330 @@ describe("buildWhereClause", () => {
       )
     ).toBe(`"id" = 1`);
   });
+
+  describe("value validation edge cases", () => {
+    it("treats whitespace-only value as empty (numeric column)", () => {
+      // Repro: typing 4 spaces into a numeric column previously slipped past
+      // the truthiness check and emitted `"id" =     ` (no right operand)
+      // -- a guaranteed DB syntax error. Now it's rejected at validation
+      // time so no SQL is emitted at all.
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: "=", value: "    " })],
+          columns
+        )
+      ).toBeNull();
+    });
+
+    it("treats whitespace-only value as empty (string column)", () => {
+      // Same bug class as above for non-numeric columns: previously emitted
+      // `"name" = '   '` which silently matched whitespace-padded strings,
+      // almost certainly not what the user wanted.
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "=", value: "   " })],
+          columns
+        )
+      ).toBeNull();
+    });
+
+    it("treats whitespace-only value as empty (LIKE)", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "LIKE", value: "  " })],
+          columns
+        )
+      ).toBeNull();
+    });
+
+    it("trims surrounding whitespace from the value", () => {
+      // After trim the value is still meaningful, so the condition stays.
+      // We embed the trimmed value (not the raw string with padding) so
+      // the SQL is canonical.
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "=", value: "  Alice  " })],
+          columns
+        )
+      ).toBe(`"name" = 'Alice'`);
+    });
+
+    it("trims surrounding whitespace from numeric value", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: "=", value: " 42 " })],
+          columns
+        )
+      ).toBe(`"id" = 42`);
+    });
+
+    it("rejects Infinity on numeric column (falls through to quoted)", () => {
+      // `Number("Infinity")` is not NaN, so the previous `!isNaN(...)` check
+      // accepted it and shipped `"id" = Infinity` -- works on Postgres
+      // float columns, errors on integer columns and on most other engines.
+      // Now it falls through to the quoted-string branch so the database
+      // produces a typed error if the value really is meaningless for the
+      // column.
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: "=", value: "Infinity" })],
+          columns
+        )
+      ).toBe(`"id" = 'Infinity'`);
+    });
+
+    it("rejects -Infinity on numeric column", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: "=", value: "-Infinity" })],
+          columns
+        )
+      ).toBe(`"id" = '-Infinity'`);
+    });
+
+    it("rejects NaN on numeric column", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: "=", value: "NaN" })],
+          columns
+        )
+      ).toBe(`"id" = 'NaN'`);
+    });
+
+    it("rejects hex literal on numeric column", () => {
+      // MySQL parses `0x10` as 16, Postgres rejects it outright, MSSQL
+      // treats `0x10` as a varbinary literal. Embedding the user's raw
+      // string causes silent dialect divergence; quoting it instead lets
+      // the database surface a single, obvious error.
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: "=", value: "0x10" })],
+          columns
+        )
+      ).toBe(`"id" = '0x10'`);
+    });
+
+    it("rejects octal-style literal on numeric column", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: "=", value: "0o17" })],
+          columns
+        )
+      ).toBe(`"id" = '0o17'`);
+    });
+
+    it("rejects binary-style literal on numeric column", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: "=", value: "0b101" })],
+          columns
+        )
+      ).toBe(`"id" = '0b101'`);
+    });
+
+    it("accepts negative numeric value", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: ">", value: "-5" })],
+          columns
+        )
+      ).toBe(`"id" > -5`);
+    });
+
+    it("accepts decimal numeric value", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "amount", operator: "=", value: "3.14" })],
+          columns
+        )
+      ).toBe(`"amount" = 3.14`);
+    });
+
+    it("accepts scientific-notation numeric value", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "amount", operator: "<", value: "1.5e10" })],
+          columns
+        )
+      ).toBe(`"amount" < 1.5e10`);
+    });
+
+    it("rejects values with extra characters that Number() would still parse", () => {
+      // `Number("5,000")` is NaN so this would have been quoted already,
+      // but pinning it here to lock the contract.
+      expect(
+        buildWhereClause(
+          [cond({ column: "amount", operator: "=", value: "5,000" })],
+          columns
+        )
+      ).toBe(`"amount" = '5,000'`);
+    });
+
+    it("preserves NUMERIC precision by not round-tripping through Number()", () => {
+      // 17-digit decimal -- if we ever switched to embedding
+      // `String(Number(value))` instead of the trimmed user input, this
+      // would lose the trailing digit to float64 imprecision. The current
+      // implementation embeds the trimmed string verbatim once it matches
+      // the decimal-literal pattern, so exact precision is preserved for
+      // NUMERIC / DECIMAL columns.
+      expect(
+        buildWhereClause(
+          [cond({ column: "amount", operator: "=", value: "12345678901234567.89" })],
+          columns
+        )
+      ).toBe(`"amount" = 12345678901234567.89`);
+    });
+
+    it("does not number-coerce when the value has internal whitespace", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "id", operator: "=", value: "1 OR 1" })],
+          columns
+        )
+      ).toBe(`"id" = '1 OR 1'`);
+    });
+
+    it("escapes single quotes after trimming", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "=", value: "  O'Brien  " })],
+          columns
+        )
+      ).toBe(`"name" = 'O''Brien'`);
+    });
+  });
+
+  describe("dialect-aware identifier quoting", () => {
+    it("defaults to double quotes when dbType is omitted", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "=", value: "x" })],
+          columns
+        )
+      ).toBe(`"name" = 'x'`);
+    });
+
+    it("uses backticks for mysql/mariadb/tidb", () => {
+      for (const t of ["mysql", "mariadb", "tidb"] as const) {
+        expect(
+          buildWhereClause(
+            [cond({ column: "name", operator: "=", value: "x" })],
+            columns,
+            t
+          )
+        ).toBe("`name` = 'x'");
+      }
+    });
+
+    it("uses square brackets for mssql", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "=", value: "x" })],
+          columns,
+          "mssql"
+        )
+      ).toBe(`[name] = 'x'`);
+    });
+
+    it("escapes the dialect delimiter inside the column name", () => {
+      // Repro: previously hardcoded `"` doubling, so a column literally
+      // named `col"evil` got quoted correctly on PG but produced
+      // backtick-mismatched garbage on MySQL.
+      expect(
+        buildWhereClause(
+          [cond({ column: "col`evil", operator: "=", value: "x" })],
+          [col("col`evil", "text")],
+          "mysql"
+        )
+      ).toBe("`col``evil` = 'x'");
+    });
+  });
+
+  describe("dialect-aware ILIKE rewrite", () => {
+    it("emits native ILIKE on postgres / cockroachdb", () => {
+      for (const t of ["postgres", "cockroachdb"] as const) {
+        expect(
+          buildWhereClause(
+            [cond({ column: "name", operator: "ILIKE", value: "%alice%" })],
+            columns,
+            t
+          )
+        ).toBe(`"name" ILIKE '%alice%'`);
+      }
+    });
+
+    it("rewrites ILIKE to LOWER(...) LIKE LOWER(...) on engines without ILIKE", () => {
+      // Repro: previously the FilterBar offered ILIKE for every
+      // connection but emitted the literal `col ILIKE 'x'` against
+      // every dialect, which errors on MySQL/MSSQL/SQLite/Cassandra.
+      // Now the operator stays meaningful: case-insensitive intent is
+      // honored via a portable rewrite.
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "ILIKE", value: "%alice%" })],
+          columns,
+          "mysql"
+        )
+      ).toBe("LOWER(`name`) LIKE LOWER('%alice%')");
+
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "ILIKE", value: "%alice%" })],
+          columns,
+          "mssql"
+        )
+      ).toBe(`LOWER([name]) LIKE LOWER('%alice%')`);
+
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "ILIKE", value: "%alice%" })],
+          columns,
+          "sqlite"
+        )
+      ).toBe(`LOWER("name") LIKE LOWER('%alice%')`);
+
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "ILIKE", value: "%alice%" })],
+          columns,
+          "cassandra"
+        )
+      ).toBe(`LOWER("name") LIKE LOWER('%alice%')`);
+    });
+
+    it("LIKE stays untouched on every dialect (no rewrite)", () => {
+      // LIKE is case-sensitive by spec everywhere; we only rewrite
+      // ILIKE. Pin that we don't accidentally LOWER() LIKE wraps a
+      // plain LIKE comparison.
+      for (const t of ["postgres", "mysql", "mssql", "sqlite", "cassandra"] as const) {
+        const out = buildWhereClause(
+          [cond({ column: "name", operator: "LIKE", value: "%alice%" })],
+          columns,
+          t
+        );
+        expect(out).toContain("LIKE '%alice%'");
+        expect(out).not.toContain("LOWER(");
+      }
+    });
+
+    it("escapes single quotes inside ILIKE rewrite value", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "ILIKE", value: "%O'B%" })],
+          columns,
+          "mysql"
+        )
+      ).toBe("LOWER(`name`) LIKE LOWER('%O''B%')");
+    });
+
+    it("trims whitespace around the ILIKE value before rewriting", () => {
+      expect(
+        buildWhereClause(
+          [cond({ column: "name", operator: "ILIKE", value: "  alice  " })],
+          columns,
+          "mysql"
+        )
+      ).toBe("LOWER(`name`) LIKE LOWER('alice')");
+    });
+  });
 });

--- a/src/lib/filterBuilder.ts
+++ b/src/lib/filterBuilder.ts
@@ -1,4 +1,5 @@
 import type { ColumnInfo } from "./tauri";
+import { caseInsensitiveLike, quoteIdent, supportsIlike, type DbType } from "./sqlDialect";
 
 export type JoinType = "AND" | "OR";
 
@@ -12,36 +13,88 @@ export interface FilterCondition {
 
 export const NO_VALUE_OPS = ["IS NULL", "IS NOT NULL"];
 
+// Matches a finite decimal literal: optional sign, digits, optional fractional
+// part, optional exponent. Deliberately rejects hex (`0x10`), octal (`0o17`),
+// binary (`0b101`), `Infinity`, `NaN`, and stray whitespace -- those are all
+// things `Number(...)` would happily coerce, but most database engines either
+// reject them outright or interpret them differently across dialects (e.g.
+// MySQL accepts `0x10` as 16, Postgres treats it as a syntax error).
+//
+// Match groups follow the SQL numeric-literal grammar so the unmodified
+// trimmed string can be embedded verbatim, preserving exact precision for
+// NUMERIC/DECIMAL columns.
+const DECIMAL_LITERAL = /^-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?$/;
+
+const NUMERIC_TYPE_RE = /int|float|double|decimal|numeric|real|serial/i;
+
 /**
  * Builds a SQL WHERE clause from conditions and column metadata.
- * Escapes identifiers and string literals; groups by AND/OR with parentheses when mixed.
+ *
+ * Conditions are validated before being emitted:
+ *  - The column name must be present.
+ *  - For value-bearing operators the value must be non-empty after trimming
+ *    (a whitespace-only "value" is treated as no input, not as the literal
+ *    string of spaces).
+ *  - For numeric columns the value must look like a SQL decimal literal
+ *    (`-?\d+(\.\d+)?(eN)?`); anything else falls through to the quoted
+ *    string branch so type coercion is the database's job, not ours.
+ *
+ * Identifier quoting is dialect-aware (PG `"col"`, MySQL `` `col` ``,
+ * MSSQL `[col]`) — see `sqlDialect.quoteIdent`. The default of `"col"`
+ * applies when `dbType` isn't supplied so legacy callers keep working.
+ *
+ * `ILIKE` is rewritten to `LOWER(col) LIKE LOWER('value')` on dialects
+ * that don't support it natively (everything except Postgres and
+ * CockroachDB), so the operator stays meaningful in the UI regardless
+ * of the connected engine.
+ *
+ * Conditions are grouped by AND/OR with parentheses when the join type
+ * changes so SQL precedence (AND binds tighter than OR) doesn't surprise
+ * users who chained mixed operators.
  */
 export function buildWhereClause(
   conditions: FilterCondition[],
-  columns: ColumnInfo[]
+  columns: ColumnInfo[],
+  dbType?: DbType,
 ): string | null {
   const valid = conditions.filter((c) => {
-    if (NO_VALUE_OPS.includes(c.operator)) return c.column;
-    return c.column && c.value;
+    if (!c.column) return false;
+    if (NO_VALUE_OPS.includes(c.operator)) return true;
+    return c.value.trim().length > 0;
   });
 
   if (valid.length === 0) return null;
 
   const toClause = (c: FilterCondition): string => {
-    const col = `"${c.column.replace(/"/g, '""')}"`;
+    const col = quoteIdent(dbType, c.column);
     if (NO_VALUE_OPS.includes(c.operator)) {
       return `${col} ${c.operator}`;
     }
-    if (c.operator === "LIKE" || c.operator === "ILIKE") {
-      return `${col} ${c.operator} '${c.value.replace(/'/g, "''")}'`;
+    const value = c.value.trim();
+    if (c.operator === "LIKE") {
+      return `${col} LIKE '${value.replace(/'/g, "''")}'`;
+    }
+    if (c.operator === "ILIKE") {
+      // PG / CRDB get the native operator. Everywhere else falls back
+      // to a portable LOWER(...) LIKE LOWER(...) rewrite so the user's
+      // case-insensitive intent isn't silently dropped on engines that
+      // don't have ILIKE.
+      const literal = `'${value.replace(/'/g, "''")}'`;
+      return supportsIlike(dbType)
+        ? `${col} ILIKE ${literal}`
+        : caseInsensitiveLike(dbType, col, literal);
     }
     const colInfo = columns.find((ci) => ci.name === c.column);
-    const isNum =
-      colInfo && /int|float|double|decimal|numeric|real|serial/i.test(colInfo.data_type);
-    if (isNum && !Number.isNaN(Number(c.value))) {
-      return `${col} ${c.operator} ${c.value}`;
+    const isNum = !!colInfo && NUMERIC_TYPE_RE.test(colInfo.data_type);
+    // Only embed unquoted when the trimmed value matches a SQL decimal
+    // literal exactly. Falls through to the quoted-string branch for
+    // hex / Infinity / NaN / whitespace-padded inputs so the database
+    // can decide how to coerce them (or reject them with a clear error)
+    // instead of us silently shipping non-portable SQL.
+    if (isNum && DECIMAL_LITERAL.test(value)) {
+      return `${col} ${c.operator} ${value}`;
     }
-    return `${col} ${c.operator} '${c.value.replace(/'/g, "''")}'`;
+    return `${col} ${c.operator} '${value.replace(/'/g, "''")}'`;
   };
 
   if (valid.length === 1) return toClause(valid[0]);

--- a/src/lib/sqlDialect.test.ts
+++ b/src/lib/sqlDialect.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  boolLiteral,
+  caseInsensitiveLike,
+  paginationClause,
+  quoteIdent,
+  quoteQualified,
+  supportsIlike,
+  type DbType,
+} from "./sqlDialect";
+
+describe("quoteIdent", () => {
+  it('uses double quotes for postgres / cockroachdb / sqlite / cassandra', () => {
+    for (const t of ["postgres", "cockroachdb", "sqlite", "cassandra"] as DbType[]) {
+      expect(quoteIdent(t, "users")).toBe('"users"');
+    }
+  });
+
+  it("uses backticks for mysql / mariadb / tidb", () => {
+    for (const t of ["mysql", "mariadb", "tidb"] as DbType[]) {
+      expect(quoteIdent(t, "users")).toBe("`users`");
+    }
+  });
+
+  it("uses square brackets for mssql", () => {
+    expect(quoteIdent("mssql", "users")).toBe("[users]");
+  });
+
+  it("falls back to double quotes when dbType is undefined", () => {
+    expect(quoteIdent(undefined, "users")).toBe('"users"');
+  });
+
+  it("doubles the delimiter inside the identifier per dialect", () => {
+    // Postgres-style: " is doubled.
+    expect(quoteIdent("postgres", 'col"name')).toBe('"col""name"');
+    // MySQL-style: ` is doubled.
+    expect(quoteIdent("mysql", "col`name")).toBe("`col``name`");
+    // MSSQL-style: ] is doubled, [ is left alone (only ] terminates).
+    expect(quoteIdent("mssql", "col]name")).toBe("[col]]name]");
+    expect(quoteIdent("mssql", "col[name")).toBe("[col[name]");
+  });
+
+  it("handles empty identifier (still quotes it)", () => {
+    expect(quoteIdent("postgres", "")).toBe('""');
+    expect(quoteIdent("mysql", "")).toBe("``");
+    expect(quoteIdent("mssql", "")).toBe("[]");
+  });
+
+  it("handles identifier containing only the delimiter character", () => {
+    // PG: `"` doubled → `""`, wrapped → `""""` (4 chars).
+    expect(quoteIdent("postgres", '"')).toBe('""""');
+    // MySQL: ` doubled → ``, wrapped → ```` (4 chars).
+    expect(quoteIdent("mysql", "`")).toBe("````");
+    // MSSQL: ] doubled → ]], wrapped → []]] (4 chars).
+    expect(quoteIdent("mssql", "]")).toBe("[]]]");
+  });
+});
+
+describe("quoteQualified", () => {
+  it("emits schema.table for dialects with schemas", () => {
+    expect(quoteQualified("postgres", "public", "users")).toBe('"public"."users"');
+    expect(quoteQualified("mysql", "app", "users")).toBe("`app`.`users`");
+    expect(quoteQualified("mssql", "dbo", "users")).toBe("[dbo].[users]");
+  });
+
+  it("drops schema for sqlite (no schema concept)", () => {
+    expect(quoteQualified("sqlite", "main", "users")).toBe('"users"');
+  });
+
+  it("drops schema when schema is empty / null / undefined", () => {
+    expect(quoteQualified("postgres", "", "users")).toBe('"users"');
+    expect(quoteQualified("postgres", null, "users")).toBe('"users"');
+    expect(quoteQualified("postgres", undefined, "users")).toBe('"users"');
+  });
+
+  it("escapes delimiters in both schema and table parts", () => {
+    expect(quoteQualified("postgres", 'wei"rd', "tab")).toBe('"wei""rd"."tab"');
+    expect(quoteQualified("mysql", "we`ird", "tab")).toBe("`we``ird`.`tab`");
+  });
+});
+
+describe("supportsIlike", () => {
+  it("returns true only for postgres-family dialects", () => {
+    expect(supportsIlike("postgres")).toBe(true);
+    expect(supportsIlike("cockroachdb")).toBe(true);
+    expect(supportsIlike("mysql")).toBe(false);
+    expect(supportsIlike("mariadb")).toBe(false);
+    expect(supportsIlike("tidb")).toBe(false);
+    expect(supportsIlike("sqlite")).toBe(false);
+    expect(supportsIlike("mssql")).toBe(false);
+    expect(supportsIlike("cassandra")).toBe(false);
+    expect(supportsIlike(undefined)).toBe(false);
+  });
+});
+
+describe("caseInsensitiveLike", () => {
+  it("uses native ILIKE on PG / CRDB", () => {
+    expect(caseInsensitiveLike("postgres", '"name"', "'%alice%'")).toBe(
+      `"name" ILIKE '%alice%'`,
+    );
+    expect(caseInsensitiveLike("cockroachdb", '"name"', "'%alice%'")).toBe(
+      `"name" ILIKE '%alice%'`,
+    );
+  });
+
+  it("falls back to LOWER(...) LIKE LOWER(...) on engines without ILIKE", () => {
+    expect(caseInsensitiveLike("mysql", "`name`", "'%alice%'")).toBe(
+      "LOWER(`name`) LIKE LOWER('%alice%')",
+    );
+    expect(caseInsensitiveLike("mssql", "[name]", "'%alice%'")).toBe(
+      "LOWER([name]) LIKE LOWER('%alice%')",
+    );
+    expect(caseInsensitiveLike("sqlite", '"name"', "'%alice%'")).toBe(
+      `LOWER("name") LIKE LOWER('%alice%')`,
+    );
+  });
+});
+
+describe("paginationClause", () => {
+  it("emits LIMIT / OFFSET on PG / MySQL / SQLite / CRDB / Cassandra", () => {
+    for (const t of ["postgres", "mysql", "mariadb", "tidb", "sqlite", "cockroachdb", "cassandra"] as DbType[]) {
+      expect(paginationClause(t, 50, 100)).toBe("LIMIT 50 OFFSET 100");
+    }
+  });
+
+  it("emits OFFSET ... ROWS FETCH NEXT ... ROWS ONLY on MSSQL", () => {
+    expect(paginationClause("mssql", 50, 100)).toBe(
+      "OFFSET 100 ROWS FETCH NEXT 50 ROWS ONLY",
+    );
+  });
+
+  it("clamps negative values to zero", () => {
+    expect(paginationClause("postgres", -5, -10)).toBe("LIMIT 0 OFFSET 0");
+    expect(paginationClause("mssql", -5, -10)).toBe(
+      "OFFSET 0 ROWS FETCH NEXT 0 ROWS ONLY",
+    );
+  });
+
+  it("floors fractional values to integers", () => {
+    expect(paginationClause("postgres", 50.7, 100.3)).toBe("LIMIT 50 OFFSET 100");
+  });
+
+  it("treats NaN / non-finite inputs as zero", () => {
+    expect(paginationClause("postgres", NaN, NaN)).toBe("LIMIT 0 OFFSET 0");
+    expect(paginationClause("postgres", Infinity, -Infinity)).toBe(
+      "LIMIT 0 OFFSET 0",
+    );
+  });
+});
+
+describe("boolLiteral", () => {
+  it("uses TRUE / FALSE for most dialects", () => {
+    for (const t of ["postgres", "cockroachdb", "sqlite", "mssql"] as DbType[]) {
+      expect(boolLiteral(t, true)).toBe("TRUE");
+      expect(boolLiteral(t, false)).toBe("FALSE");
+    }
+  });
+
+  it("uses 1 / 0 for MySQL family", () => {
+    for (const t of ["mysql", "mariadb", "tidb"] as DbType[]) {
+      expect(boolLiteral(t, true)).toBe("1");
+      expect(boolLiteral(t, false)).toBe("0");
+    }
+  });
+
+  it("uses lowercase true / false for cassandra", () => {
+    expect(boolLiteral("cassandra", true)).toBe("true");
+    expect(boolLiteral("cassandra", false)).toBe("false");
+  });
+});

--- a/src/lib/sqlDialect.ts
+++ b/src/lib/sqlDialect.ts
@@ -1,0 +1,138 @@
+import type { ConnectionConfig } from "./tauri";
+
+export type DbType = ConnectionConfig["db_type"];
+
+/**
+ * Quote a SQL identifier (column / table / schema) using the right
+ * delimiter for the target dialect.
+ *
+ * Behaviour by dialect:
+ *  - PostgreSQL / CockroachDB / SQLite / Cassandra+ScyllaDB → `"name"`
+ *    (escape `"` by doubling)
+ *  - MySQL / MariaDB / TiDB → `` `name` `` (escape `` ` `` by doubling)
+ *  - SQL Server → `[name]` (escape `]` by doubling)
+ *
+ * The frontend used to hardcode PG-style `"name"` everywhere, which
+ * silently broke filter / explain / copy-as-INSERT against default
+ * MySQL (where `"name"` only works under `ANSI_QUOTES`) and produced
+ * fragile SQL on MSSQL.
+ */
+export function quoteIdent(dbType: DbType | undefined, name: string): string {
+  switch (dbType) {
+    case "mysql":
+    case "mariadb":
+    case "tidb":
+      return "`" + name.replace(/`/g, "``") + "`";
+    case "mssql":
+      return "[" + name.replace(/]/g, "]]") + "]";
+    case "postgres":
+    case "cockroachdb":
+    case "sqlite":
+    case "cassandra":
+    default:
+      return '"' + name.replace(/"/g, '""') + '"';
+  }
+}
+
+/**
+ * Render a schema-qualified identifier. Schema is dropped on dialects
+ * that don't have one (SQLite, Cassandra — schema == keyspace and is
+ * already part of the connection context). Empty / undefined schemas
+ * are dropped on every dialect so the caller doesn't have to special
+ * case it.
+ */
+export function quoteQualified(
+  dbType: DbType | undefined,
+  schema: string | null | undefined,
+  table: string,
+): string {
+  const t = quoteIdent(dbType, table);
+  if (!schema) return t;
+  // SQLite has no schema concept beyond `main` / `temp` / attached DBs;
+  // emitting `"main"."t"` works but is just noise. Cassandra qualifies
+  // with the keyspace, but the `connection.database` already carries
+  // the keyspace so the explicit schema usually duplicates it.
+  if (dbType === "sqlite") return t;
+  return `${quoteIdent(dbType, schema)}.${t}`;
+}
+
+/**
+ * Whether the dialect supports the `ILIKE` operator natively. Only
+ * Postgres-family engines do; MySQL/SQLite/MSSQL/Cassandra need a
+ * `LOWER(col) LIKE LOWER('value')` rewrite (see `caseInsensitiveLike`).
+ */
+export function supportsIlike(dbType: DbType | undefined): boolean {
+  return dbType === "postgres" || dbType === "cockroachdb";
+}
+
+/**
+ * Render a case-insensitive LIKE comparison correctly for the dialect.
+ * On PG/CRDB this is just `col ILIKE 'value'`; everywhere else we
+ * fall back to `LOWER(col) LIKE LOWER('value')` which is portable
+ * (slow on MySQL without a functional index, but correct).
+ */
+export function caseInsensitiveLike(
+  dbType: DbType | undefined,
+  quotedCol: string,
+  quotedValue: string,
+): string {
+  if (supportsIlike(dbType)) {
+    return `${quotedCol} ILIKE ${quotedValue}`;
+  }
+  return `LOWER(${quotedCol}) LIKE LOWER(${quotedValue})`;
+}
+
+/**
+ * Format a top-N LIMIT/OFFSET clause for the dialect. PG/MySQL/SQLite
+ * accept `LIMIT N OFFSET M`; MSSQL needs the `OFFSET ... ROWS FETCH
+ * NEXT ... ROWS ONLY` shape and requires an `ORDER BY` to be present.
+ *
+ * Caller-supplied `limit` / `offset` are coerced to non-negative
+ * integers — passing fractional or negative values silently rounds
+ * them to a safe representation rather than emitting bad SQL.
+ */
+export function paginationClause(
+  dbType: DbType | undefined,
+  limit: number,
+  offset: number,
+): string {
+  // `Number.isFinite` rejects NaN AND ±Infinity, which `Math.max(0, ...)`
+  // alone does not (Math.max(0, Infinity) === Infinity, which would
+  // ship `LIMIT Infinity` to the database). Clamp to 0 then floor.
+  const safe = (n: number): number => {
+    const v = Number(n);
+    if (!Number.isFinite(v)) return 0;
+    return Math.max(0, Math.floor(v));
+  };
+  const l = safe(limit);
+  const o = safe(offset);
+  if (dbType === "mssql") {
+    // MSSQL requires ORDER BY before OFFSET FETCH; the caller is
+    // responsible for ensuring one is present (handleExplain prepends
+    // `ORDER BY (SELECT NULL)` when no sort is set).
+    return `OFFSET ${o} ROWS FETCH NEXT ${l} ROWS ONLY`;
+  }
+  return `LIMIT ${l} OFFSET ${o}`;
+}
+
+/**
+ * Format a literal boolean for INSERT/UPDATE. PG/SQLite/MSSQL accept
+ * uppercase TRUE/FALSE keywords; MySQL family accepts them too but
+ * canonical literals are `1` / `0`. Cassandra wants lowercase
+ * `true` / `false`. We pick TRUE/FALSE everywhere because every
+ * supported engine accepts them — keeping the surface uniform — and
+ * fall back to `1`/`0` only for MySQL family where some legacy modes
+ * trip on the keyword form.
+ */
+export function boolLiteral(dbType: DbType | undefined, b: boolean): string {
+  switch (dbType) {
+    case "cassandra":
+      return b ? "true" : "false";
+    case "mysql":
+    case "mariadb":
+    case "tidb":
+      return b ? "1" : "0";
+    default:
+      return b ? "TRUE" : "FALSE";
+  }
+}


### PR DESCRIPTION
A round-trip audit of the filter / WHERE-builder pipeline (and adjacent SQL-builder code paths) surfaced **eleven bugs** spanning correctness, security, and cross-driver parity. They had different blast radii but they all trace back to two patterns: the frontend hardcoded PostgreSQL-shaped SQL everywhere, and every driver carried its own copy of the safety helpers, which had drifted apart over time.

This PR fixes them all in one pass and pins the new behaviour with **~60 new tests** across vitest and the Rust lib suites. Each change is documented inline so the rationale survives the next refactor.

## Bugs fixed

### Frontend filter / SQL builder

| Bug | Repro / impact |
|-----|----------------|
| Whitespace-only filter value treated as valid | Numeric column, type 4 spaces, click Apply -> guaranteed DB syntax error. String column -> silently matches whitespace strings. |
| `Number(\"Infinity\")` / `\"-Infinity\"` / `\"NaN\"` accepted as numeric | Type `Infinity` on integer column -> SQL `\"id\" = Infinity` -> works on PG float, errors on int + most other engines. |
| Raw user string embedded for numeric values | Type `0x10` on integer column -> MySQL parses 16, Postgres errors, MSSQL treats as varbinary. Silent dialect divergence. |
| Identifier quoting hardcoded `\"col\"` everywhere | Filters / Explain / Copy-as-INSERT broken on default-mode MySQL/MariaDB/TiDB (no `ANSI_QUOTES`); fragile on MSSQL. |
| `ILIKE` exposed in UI but only PG/CRDB support it | Selecting ILIKE against MySQL/MSSQL/SQLite/Cassandra -> server error. |
| `paginationClause` didn't clamp `Infinity` | `Math.max(0, Infinity) === Infinity` -> would have shipped `LIMIT Infinity` to the DB. |
| DataGrid auto-refresh runs while hidden behind Schema tab | Network polls a panel the user isn't even looking at; confusing + wasted load. |
| `handleGenerateTestData` crashed when `data_type` was undefined | Cassandra collection columns + computed views can land here; \"cannot read properties of undefined (reading 'toLowerCase')\" trashed the dialog. |
| QueryConsole autocomplete column cache keyed only by table name | Two same-named tables in different schemas (`auth.users` vs `app.users`) collided -> wrong columns suggested for both. |

### Backend filter safety / SQL fragments

| Bug | Repro / impact |
|-----|----------------|
| `filter_is_unsafe` strength varied per driver (B1-B4) | MySQL/SQLite/MSSQL/Cassandra only blocked `;` `--` `/* */`. So `1=1 UNION SELECT password FROM mysql.user` slipped through every backend except Postgres. |
| Generic \"invalid characters\" rejection message | User had no idea WHICH pattern triggered the rejection. |
| `sql_fragment_is_unsafe` rejected ALL `'` (B7) | `DEFAULT 'pending'` got blocked at create-table / alter-column time. Users could not set ANY string default through the UI. |

### Backend SQL output

| Bug | Repro / impact |
|-----|----------------|
| Cassandra `fetch_rows.total_rows` (B5) | Set to fetched-page-size, not table count. Pagination UI stuck at page boundary regardless of true total. |
| Cassandra `LIMIT (offset + limit)` (B5) | Loaded every preceding row into memory on deep pages -> OOM vector. |
| `to_sql_inserts` dropped schema (A4) | Every dump for `analytics.events` produced `INSERT INTO \"events\"`, restoring into the wrong table on multi-schema databases. |

## Approach

- **`src/lib/sqlDialect.ts`** (new): single source of truth for dialect-aware quoting / pagination / boolean literals / case-insensitive-LIKE rendering. Driven by the existing `connection.db_type` field. Dialect-aware ILIKE is rewritten to portable `LOWER(col) LIKE LOWER('value')` on engines without native ILIKE so the operator stays meaningful.
- **`src/lib/filterBuilder.ts`**: rewritten value validation via a strict decimal-literal regex (preserves NUMERIC precision by embedding the trimmed string verbatim once it matches), takes optional `dbType` parameter. Default of `\"col\"` quoting kept so legacy callers still work.
- **`src-tauri/src/db/{pg_common,mysql_common,sqlite,mssql,cassandra}.rs`**: every driver's `filter_is_unsafe` now mirrors the strict Postgres ruleset, plus a new `filter_unsafe_reason(...)` helper returning a precise human-readable explanation. `sql_fragment_is_unsafe` split into strict (data types) and lenient (`sql_default_is_unsafe`, allows `'`).
- **`src-tauri/src/db/cassandra.rs`** `fetch_rows`: separate `SELECT COUNT(*) ... ALLOW FILTERING` for the true total; `saturating_add` to avoid pagination overflow.
- **`src-tauri/src/export.rs`**: `to_sql_inserts` now takes `Option<&str>` for schema and emits `\"schema\".\"table\"` when present.

## Test plan

- [x] `npm run test` -> **528 / 528 passing** (15 files; +47 new tests).
- [x] `npx tsc --noEmit` -> clean.
- [x] `cargo test --lib` -> **299 / 299 passing** (+16 new tests).
- [x] `cargo clippy -- -D warnings` (CI-equivalent flags) -> clean.
- [x] `cargo fmt --check` -> clean.
- [x] Live integration vs Postgres 17: **68 / 68 passing**, including the full `pg_fetch_rows_*` matrix and `pg_fetch_rows_unsafe_filter_rejected`.
- [x] Live integration vs SQLite: **53 / 53 passing**.
- [x] Live integration vs CockroachDB (full 47-test suite): **47 / 47 passing** (verified earlier on PR #39).
- [ ] CI: confirm the unified-filter changes don't trip MySQL/MariaDB/TiDB/MSSQL/Cassandra integration suites (haven't been able to spin them up locally; CI matrix will cover).

## Backwards compatibility

All public Rust functions kept their callable signatures except `to_sql_inserts` (added `schema: Option<&str>` as the first positional arg; both callers in `commands/export.rs` updated). All frontend exports kept their callable signatures except `buildWhereClause` (new optional `dbType?: DbType` third arg; existing FilterBar callsite updated, default behaviour unchanged for any caller that doesn't pass the new arg).

The error message change for filter rejection (`Filter contains invalid characters (...)` -> `Filter rejected: <reason>`) is user-visible. Existing tests asserting only `is_err()` continue to pass; no test asserted the exact text.