### PR TITLE
fix(ui): activity tables, partition open-on-click, query/DDL flash (v0.3.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tablio",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "tablio"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tablio"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Tablio",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.tablio.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { useTabStore } from "./stores/tabStore";
 import { loader } from "@monaco-editor/react";
 import { Database, Plus, Keyboard, Palette, Check, Cpu, MemoryStick } from "lucide-react";
 import { themes, getThemeById, applyTheme } from "./lib/themes";
+import { syncMonacoTheme } from "./lib/monacoTheme";
 import { api } from "./lib/tauri";
 
 const SIDEBAR_WIDTH_MIN = 200;
@@ -173,7 +174,17 @@ export default function App() {
 
   useEffect(() => {
     const warmMonaco = () => {
-      void loader.init().catch(() => {});
+      void loader
+        .init()
+        .then((monaco) => {
+          // Register tablio-dark-0 / tablio-light-0 up-front so the first
+          // <Editor> paint doesn't fall back to Monaco's default white "vs"
+          // theme while beforeMount has not yet run.
+          try {
+            syncMonacoTheme(monaco, 0);
+          } catch {}
+        })
+        .catch(() => {});
     };
 
     if (typeof window.requestIdleCallback === "function") {

--- a/src/components/Activity/ActivityDashboard.css
+++ b/src/components/Activity/ActivityDashboard.css
@@ -79,7 +79,7 @@
 
 .activity-query {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 13px;
   color: var(--text-secondary);
   max-width: 360px;
   overflow: hidden;
@@ -88,7 +88,7 @@
 }
 
 .activity-state {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   padding: 2px 8px;
   border-radius: var(--radius-lg);
@@ -380,7 +380,7 @@
 
 /* Sessions */
 .session-active-badge {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--success);
   background: rgba(61, 214, 140, 0.10);
@@ -398,7 +398,7 @@
 }
 
 .lock-granted-badge {
-  font-size: 11px;
+  font-size: 12px;
   font-weight: 500;
   padding: 2px 8px;
   border-radius: var(--radius-lg);
@@ -416,7 +416,7 @@
 }
 
 .lock-waiting-badge {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--warning);
   background: rgba(245, 183, 49, 0.10);
@@ -428,7 +428,7 @@
 }
 
 .lock-granted-count {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--success);
   background: rgba(61, 214, 140, 0.10);
@@ -438,13 +438,13 @@
 
 .lock-mode {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-secondary);
 }
 
 .lock-relation {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 13px;
   color: var(--accent);
 }
 
@@ -462,6 +462,67 @@
 
 .sortable-th:hover {
   color: var(--text-primary);
+}
+
+/* ── Shared dashboard table (Sessions / Locks / Config) ──────────────
+   Both DashboardSessions and DashboardLocks render
+   `<table className="info-table">` but no rule below `.info-table` ever
+   styled the table itself — it was inheriting browser defaults, which
+   made it shrink to its content width and gave the State / Granted
+   badge cells zero horizontal padding so the badges abutted neighboring
+   cells. */
+.info-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: auto;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.info-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg-secondary);
+  text-align: left;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.info-table tbody td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-subtle, var(--border));
+  vertical-align: middle;
+  line-height: 1.4;
+}
+
+.info-table tbody tr:hover {
+  background: var(--bg-hover);
+}
+
+.info-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Numeric / secondary columns. Mono font + dim color, used for PID,
+   Duration, client address, etc. */
+.info-cell-muted {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* Action / icon trailing column should stay compact. */
+.info-table tbody td:last-child .btn-icon {
+  display: inline-flex;
 }
 
 @media (max-width: 980px) {
@@ -551,7 +612,7 @@
 }
 
 .config-category-count {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-muted);
   background: var(--bg-hover);
   padding: 1px 6px;
@@ -581,7 +642,7 @@
 }
 
 .config-context-badge {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-muted);
   background: var(--bg-hover);
   padding: 1px 6px;

--- a/src/components/DDLViewer/DDLViewer.css
+++ b/src/components/DDLViewer/DDLViewer.css
@@ -25,6 +25,8 @@
 .ddl-editor-wrapper {
   flex: 1;
   overflow: hidden;
+  /* Prevent a white flash before Monaco mounts and applies our custom theme. */
+  background: var(--bg-primary);
 }
 
 /* Match QueryConsole: one rounded hover surface (Monaco adds a square outer frame) */

--- a/src/components/QueryConsole/QueryConsole.css
+++ b/src/components/QueryConsole/QueryConsole.css
@@ -55,6 +55,8 @@
   zoom: calc(1 / var(--app-zoom, 1));
   width: calc(100% * var(--app-zoom, 1));
   height: calc(100% * var(--app-zoom, 1));
+  /* Prevent a white flash before Monaco mounts and applies our custom theme. */
+  background: var(--bg-primary);
 }
 
 /* Monaco suggest widget styling */

--- a/src/components/Sidebar/ObjectTree.tsx
+++ b/src/components/Sidebar/ObjectTree.tsx
@@ -889,7 +889,10 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
           className={`tree-node ${isLeaf ? "leaf" : ""} ${isDefaultPartition ? "tree-node-default-partition" : ""}`}
           style={{ paddingLeft: depth * 12 + 6 }}
           onClick={() => {
-            if (isLeaf) {
+            // Partitioned parent tables are still tables — opening their data
+            // tab on a single click matches a regular table; expansion happens
+            // via the chevron (or double-click on a non-leaf branch type).
+            if (baseLeaf) {
               handleDoubleClick(node);
             } else {
               toggleExpand(node);
@@ -899,7 +902,13 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
           onContextMenu={(e) => handleContextMenu(e, node)}
         >
           {!isLeaf && (
-            <span className="tree-chevron">
+            <span
+              className="tree-chevron"
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleExpand(node);
+              }}
+            >
               {isExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
             </span>
           )}


### PR DESCRIPTION
## Summary

Three UI fixes plus a version bump to **v0.3.1**.

### 1. Activity dashboard tables (Sessions / Locks / Configuration)
The shared `info-table` class had no rules, so the tables were inheriting browser defaults — they shrank to content width, lost cell padding, and badges abutted neighbouring cells. Added proper styling: full-width layout, sticky headers, padded cells, hover row, compact trailing action column. Bumped font sizes one notch in Sessions / Locks / Configuration so they read more comfortably without growing row height.

### 2. Partitioned tables: single-click should open data
Previously a partitioned parent (e.g. a hash-partitioned `events` table) only toggled its Partitions sub-collection on a single click. To open the data tab you had to double-click or right-click → Open. Now:

- Single click on a `table` / `view` / `function` row always opens the data tab — even when the table is a partitioned parent.
- Expansion of the Partitions sub-collection is handled by the chevron, which has its own click handler (`stopPropagation`).
- Double-click and right-click → Open continue to work as fallbacks.
- Pure branch nodes (schemas, table-groups, partition-group) still toggle-expand on row click.

### 3. Query console / DDL viewer white flash
Clicking *Query* (or opening DDL) briefly painted white before switching to the theme. Root cause: `<Editor>` rendered with `theme="tablio-dark-0"` on first paint, but that custom theme only got registered inside `beforeMount` — so Monaco fell back to the built-in white `vs` theme for one frame. Fix:

- Pre-register `tablio-dark-0` / `tablio-light-0` during the existing `loader.init()` warm-up in `App.tsx`.
- Paint `.query-editor-wrapper` and `.ddl-editor-wrapper` with `var(--bg-primary)` as a defensive fallback so even a slow first frame is the right colour.

### 4. Version bump
`0.3.0` → `0.3.1` across `Cargo.toml`, `Cargo.lock`, `package.json`, `tauri.conf.json`. After merge, tag `v0.3.1` to fire the release workflow.

## Test plan

- [ ] CI green (lint, type-check, vitest, playwright, cross-DB integration, ssh-tunnel).
- [ ] Manual: open Activity → Sessions / Locks / Configuration; verify columns are aligned, padded, and slightly larger text.
- [ ] Manual: in the sidebar, single-click a partitioned table — its data tab opens. Click the chevron — Partitions collection expands without opening a tab.
- [ ] Manual: click *Query* on a connection — no white flash; editor renders directly in the active theme.
- [ ] Manual: open DDL viewer for any object — no white flash.