### PR TITLE
fix(perf): plug ResourceMonitor fd leak that froze the UI after hours of idle

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 use std::sync::Mutex;
-use sysinfo::{Pid, System};
+use std::time::{Duration, Instant};
+#[cfg(not(target_os = "linux"))]
+use sysinfo::ProcessRefreshKind;
+use sysinfo::{Pid, ProcessesToUpdate, System};
 
 #[derive(Serialize)]
 pub struct AppResourceUsage {
@@ -8,33 +11,150 @@ pub struct AppResourceUsage {
     pub cpu_percent: f32,
 }
 
-static SYS: std::sync::LazyLock<Mutex<System>> = std::sync::LazyLock::new(|| {
-    let mut sys = System::new();
-    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
-    Mutex::new(sys)
-});
+/// Cached samples for our own process, used to compute a CPU%
+/// over the wall-clock window between successive calls.
+///
+/// We deliberately do NOT cache a `sysinfo::System`. Earlier versions
+/// of this command kept a `LazyLock<Mutex<System>>` initialised with
+/// `refresh_processes(All, true)`. On Linux that scan opened
+/// `/proc/<pid>/[task/<tid>/]stat` for every process+thread on the
+/// host and never released them, leaking ~2 file descriptors per
+/// 3-second poll. After several hours the renderer's main JS thread
+/// fell behind on Tauri IPC, the WebKit IPC socket's Recv-Q backed
+/// up, and the entire UI froze — recoverable only by restarting the
+/// app. See `fix/resource-monitor-fd-leak`.
+struct CpuSample {
+    /// Last `(now, /proc/self/stat utime+stime in jiffies)` we observed.
+    /// Linux fast path only; other platforms always set this to `None`
+    /// and rely on the sysinfo fallback inside [`read_cpu_percent`].
+    last: Option<(Instant, u64)>,
+}
+
+static CPU_SAMPLE: std::sync::LazyLock<Mutex<CpuSample>> =
+    std::sync::LazyLock::new(|| Mutex::new(CpuSample { last: None }));
 
 #[tauri::command]
 pub async fn get_app_resource_usage() -> Result<AppResourceUsage, String> {
     let pid = Pid::from_u32(std::process::id());
 
-    let (memory_mb, cpu_percent) = {
-        let mut sys = SYS.lock().map_err(|e| e.to_string())?;
-        sys.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
-        match sys.process(pid) {
-            Some(proc) => {
-                let mem = proc.memory() as f64 / (1024.0 * 1024.0);
-                let cpu = proc.cpu_usage();
-                (mem, cpu)
-            }
-            None => (0.0, 0.0),
-        }
-    };
+    let memory_mb = read_memory_mb(pid)?;
+    let cpu_percent = read_cpu_percent(pid).await;
 
     Ok(AppResourceUsage {
         memory_mb: (memory_mb * 10.0).round() / 10.0,
         cpu_percent: (cpu_percent * 10.0).round() / 10.0,
     })
+}
+
+/// Read RSS memory for our own PID using a freshly-constructed
+/// [`System`] that is dropped on return — guaranteeing every
+/// `/proc/<pid>/...` handle sysinfo opens is released.
+fn read_memory_mb(pid: Pid) -> Result<f64, String> {
+    let mut sys = System::new();
+    // `false` = do not also enumerate threads. We only need the
+    // process-level memory total, and skipping the thread refresh
+    // avoids opening one extra `/proc/<pid>/task/<tid>/stat` per
+    // worker thread per call.
+    sys.refresh_processes(ProcessesToUpdate::Some(&[pid]), false);
+    let mem_bytes = sys.process(pid).map(|p| p.memory()).unwrap_or(0);
+    Ok(mem_bytes as f64 / (1024.0 * 1024.0))
+}
+
+/// Best-effort CPU% for our own PID. Linux uses `/proc/self/stat`
+/// utime+stime jiffies diffed against the previous call; everywhere
+/// else we fall back to a fresh sysinfo snapshot pair separated by
+/// `MINIMUM_CPU_UPDATE_INTERVAL` (200 ms), which is the only way
+/// sysinfo will report a non-zero CPU value without holding state
+/// across calls.
+async fn read_cpu_percent(pid: Pid) -> f32 {
+    #[cfg(target_os = "linux")]
+    {
+        let _ = pid; // silence unused on linux
+        read_cpu_percent_linux().unwrap_or(0.0)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let mut sys = System::new();
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[pid]),
+            false,
+            ProcessRefreshKind::nothing().with_cpu(),
+        );
+        tokio::time::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL).await;
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[pid]),
+            false,
+            ProcessRefreshKind::nothing().with_cpu(),
+        );
+        sys.process(pid).map(|p| p.cpu_usage()).unwrap_or(0.0)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_cpu_percent_linux() -> Result<f32, String> {
+    let total_jiffies = read_self_stat_total_jiffies()?;
+    let now = Instant::now();
+    let mut sample = CPU_SAMPLE.lock().map_err(|e| e.to_string())?;
+    let pct = match sample.last {
+        Some((then, prev_total)) => {
+            let elapsed = now.duration_since(then);
+            // Skip absurdly short intervals (would amplify rounding) and
+            // negative deltas (system clock could have jumped — `Instant`
+            // is monotonic but we'd rather report 0 than panic).
+            if elapsed < Duration::from_millis(50) {
+                0.0
+            } else {
+                let dj = total_jiffies.saturating_sub(prev_total) as f32;
+                let clk = clock_ticks_per_sec() as f32;
+                let pct = dj / clk / elapsed.as_secs_f32() * 100.0;
+                let cores = std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(1) as f32;
+                pct.clamp(0.0, 100.0 * cores)
+            }
+        }
+        None => 0.0,
+    };
+    sample.last = Some((now, total_jiffies));
+    Ok(pct)
+}
+
+#[cfg(target_os = "linux")]
+fn read_self_stat_total_jiffies() -> Result<u64, String> {
+    let s = std::fs::read_to_string("/proc/self/stat").map_err(|e| e.to_string())?;
+    // The `comm` field can contain arbitrary characters including
+    // whitespace and `(`/`)`, so the only safe way to parse `stat` is
+    // to find the LAST `)` and treat everything after it as
+    // whitespace-separated fields. After the `)` the layout is:
+    //   state ppid pgrp session tty_nr tpgid flags minflt cminflt
+    //   majflt cmajflt utime stime cutime cstime ...
+    // utime is index 11, stime is index 12 (0-based) of `rest`.
+    let after_comm = s.rfind(')').ok_or("malformed /proc/self/stat")?;
+    let rest = s
+        .get(after_comm + 1..)
+        .ok_or("malformed /proc/self/stat")?
+        .trim();
+    let fields: Vec<&str> = rest.split_whitespace().collect();
+    let utime: u64 = fields
+        .get(11)
+        .ok_or("missing utime")?
+        .parse()
+        .map_err(|e: std::num::ParseIntError| e.to_string())?;
+    let stime: u64 = fields
+        .get(12)
+        .ok_or("missing stime")?
+        .parse()
+        .map_err(|e: std::num::ParseIntError| e.to_string())?;
+    Ok(utime + stime)
+}
+
+#[cfg(target_os = "linux")]
+fn clock_ticks_per_sec() -> u64 {
+    // _SC_CLK_TCK is almost always 100 on modern Linux. Hard-coding
+    // avoids pulling in `libc` for one constant; if a kernel ever
+    // reports something different the only consequence is a
+    // proportional CPU% scaling error in the status-bar indicator.
+    100
 }
 
 #[cfg(test)]
@@ -82,5 +202,63 @@ mod tests {
         let usage = result.unwrap();
         assert!(usage.memory_mb >= 0.0);
         assert!(usage.cpu_percent >= 0.0);
+    }
+
+    /// Regression for the fd-leak fix: hammering the command in a
+    /// tight loop must not balloon our open-fd count. We allow some
+    /// slack for the test harness itself, but anything beyond a
+    /// handful of additional fds across 50 calls indicates a
+    /// per-call leak has crept back in.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn get_app_resource_usage_does_not_leak_fds() {
+        fn open_fd_count() -> usize {
+            std::fs::read_dir("/proc/self/fd")
+                .map(|d| d.count())
+                .unwrap_or(0)
+        }
+        // Warm up: first call may seed the CPU sample slot, allocate
+        // sysinfo internals, etc. Don't measure those.
+        for _ in 0..3 {
+            let _ = get_app_resource_usage().await.unwrap();
+        }
+        let before = open_fd_count();
+        for _ in 0..50 {
+            let _ = get_app_resource_usage().await.unwrap();
+        }
+        let after = open_fd_count();
+        let growth = after.saturating_sub(before);
+        assert!(
+            growth <= 5,
+            "open-fd count grew by {growth} over 50 calls (before={before}, after={after}); the resource monitor is leaking again"
+        );
+    }
+
+    /// Linux fast-path parses /proc/self/stat correctly. The parser
+    /// must split the line at the LAST `)` so that a `comm` field
+    /// containing arbitrary characters (whitespace, more parens —
+    /// reachable in practice via prctl(PR_SET_NAME)) does not throw
+    /// off the field offsets for utime/stime.
+    ///
+    /// Newly-spawned test processes can have utime+stime == 0 when
+    /// nothing has executed yet, so we burn a tiny bit of CPU to
+    /// guarantee a positive sample and assert monotonic growth.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn read_self_stat_handles_parens_in_comm() {
+        let before = read_self_stat_total_jiffies().expect("first parse");
+        // ~10ms of arithmetic — enough to cross at least one jiffy
+        // boundary on a 100Hz scheduler.
+        let mut spin: u64 = 0;
+        let start = std::time::Instant::now();
+        while start.elapsed() < std::time::Duration::from_millis(20) {
+            spin = spin.wrapping_add(1);
+        }
+        std::hint::black_box(spin);
+        let after = read_self_stat_total_jiffies().expect("second parse");
+        assert!(
+            after >= before,
+            "/proc/self/stat parsing must be monotonic: before={before}, after={after}"
+        );
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,14 +64,41 @@ function ResourceMonitor() {
   const [usage, setUsage] = useState({ memory_mb: 0, cpu_percent: 0 });
   useEffect(() => {
     let alive = true;
+    let inFlight = false;
     const poll = () => {
-      api.getAppResourceUsage().then((r) => {
-        if (alive) setUsage(r);
-      }).catch(() => {});
+      // Two layers of defense, both motivated by the v0.3.1 freeze
+      // bug. (1) When the window is minimized / on another desktop,
+      // skip the IPC entirely — there's no point updating a status
+      // bar nobody can see, and on Linux/WebKitGTK background-tab
+      // throttling is weak so the IPC backlog used to grow
+      // unbounded over hours of idle. (2) Drop the tick if the
+      // previous response hasn't come back yet — even if a single
+      // call ever stalls, we won't queue another one behind it.
+      if (!alive || inFlight || (typeof document !== "undefined" && document.hidden)) return;
+      inFlight = true;
+      api
+        .getAppResourceUsage()
+        .then((r) => {
+          if (alive) setUsage(r);
+        })
+        .catch(() => {})
+        .finally(() => {
+          inFlight = false;
+        });
     };
     poll();
     const id = setInterval(poll, 3000);
-    return () => { alive = false; clearInterval(id); };
+    // Catch up immediately when the window comes back so the user
+    // doesn't see a stale "30s ago" reading after un-minimizing.
+    const onVisibility = () => {
+      if (!document.hidden) poll();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      alive = false;
+      clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
   }, []);
   return (
     <div className="statusbar-left">

--- a/src/components/Activity/DashboardLocks.tsx
+++ b/src/components/Activity/DashboardLocks.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useRef, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { api, LockInfo } from "../../lib/tauri";
 import { Loader2, ChevronUp, ChevronDown, Search, Lock } from "lucide-react";
+import { usePolling } from "../../hooks/usePolling";
 
 interface Props {
   connectionId: string;
@@ -16,7 +17,6 @@ export function DashboardLocks({ connectionId, paused }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("granted");
   const [sortAsc, setSortAsc] = useState(true);
   const [search, setSearch] = useState("");
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchLocks = useCallback(async () => {
     try {
@@ -30,22 +30,10 @@ export function DashboardLocks({ connectionId, paused }: Props) {
     }
   }, [connectionId]);
 
-  useEffect(() => {
-    fetchLocks();
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [fetchLocks]);
-
-  useEffect(() => {
-    if (intervalRef.current) clearInterval(intervalRef.current);
-    if (!paused) {
-      intervalRef.current = setInterval(fetchLocks, 2000);
-    }
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [paused, fetchLocks]);
+  // Visibility-aware, re-entrancy-safe polling. See usePolling and
+  // DashboardSessions for context on why hand-rolled setInterval was
+  // dangerous when the window stayed minimized for hours.
+  usePolling(fetchLocks, 2000, !paused);
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {

--- a/src/components/Activity/DashboardOverview.tsx
+++ b/src/components/Activity/DashboardOverview.tsx
@@ -3,6 +3,7 @@ import { api, DatabaseStats } from "../../lib/tauri";
 import { computeRate, formatVal, makeLabels, type RatePoint } from "../../lib/dashboardUtils";
 import { chartDevicePixelRatio, chartFontFamily } from "../../lib/chartRendering";
 import { Loader2, Activity, ArrowUpDown, Database, HardDrive } from "lucide-react";
+import { usePolling } from "../../hooks/usePolling";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -303,7 +304,6 @@ export function DashboardOverview({ connectionId, paused }: Props) {
   const [rates, setRates] = useState<RatePoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchStats = useCallback(async () => {
     try {
@@ -331,22 +331,11 @@ export function DashboardOverview({ connectionId, paused }: Props) {
     }
   }, [connectionId]);
 
-  useEffect(() => {
-    fetchStats();
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [fetchStats]);
-
-  useEffect(() => {
-    if (intervalRef.current) clearInterval(intervalRef.current);
-    if (!paused) {
-      intervalRef.current = setInterval(fetchStats, 2000);
-    }
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [paused, fetchStats]);
+  // Visibility-aware, re-entrancy-safe polling. See usePolling for
+  // the why; this used to be a hand-rolled setInterval that kept
+  // firing while the window was minimized and let in-flight stats
+  // calls accumulate.
+  usePolling(fetchStats, 2000, !paused);
 
   const latest = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null;
   const prevRate = rates.length > 0 ? rates[rates.length - 1] : null;

--- a/src/components/Activity/DashboardSessions.tsx
+++ b/src/components/Activity/DashboardSessions.tsx
@@ -1,8 +1,9 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { api, ServerActivity } from "../../lib/tauri";
 import { formatDuration, filterSessions } from "../../lib/dashboardUtils";
 import { Loader2, XCircle, Search, Users } from "lucide-react";
 import { ConfirmDialog } from "../ConfirmDialog";
+import { usePolling } from "../../hooks/usePolling";
 
 interface Props {
   connectionId: string;
@@ -15,7 +16,6 @@ export function DashboardSessions({ connectionId, paused }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [killTarget, setKillTarget] = useState<ServerActivity | null>(null);
   const [search, setSearch] = useState("");
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchActivity = useCallback(async () => {
     try {
@@ -29,22 +29,10 @@ export function DashboardSessions({ connectionId, paused }: Props) {
     }
   }, [connectionId]);
 
-  useEffect(() => {
-    fetchActivity();
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [fetchActivity]);
-
-  useEffect(() => {
-    if (intervalRef.current) clearInterval(intervalRef.current);
-    if (!paused) {
-      intervalRef.current = setInterval(fetchActivity, 2000);
-    }
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [paused, fetchActivity]);
+  // Visibility-aware, re-entrancy-safe polling (see usePolling).
+  // Replaces a hand-rolled setInterval that kept firing while the
+  // window was minimized, accumulating in-flight Tauri calls.
+  usePolling(fetchActivity, 2000, !paused);
 
   const handleKill = async () => {
     if (!killTarget) return;

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef, useMemo } from "react";
+import { usePolling } from "../../hooks/usePolling";
 import {
   api,
   ColumnInfo,
@@ -310,20 +311,24 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     gridApiRef.current?.redrawRows();
   }, [changes, detailRowIdx]);
 
-  useEffect(() => {
-    // Skip the timer entirely when:
-    //  - the user disabled auto-refresh (refreshInterval = 0)
-    //  - there are unsaved changes (would clobber pending edits)
-    //  - the grid is mounted but currently hidden (TableView keeps the
-    //    Data tab in the DOM with display:none when Schema is shown;
-    //    polling a hidden grid is wasted work and can confuse users
-    //    who think "I'm not on this tab, why is it making requests?")
-    if (refreshInterval <= 0 || hasChanges || !isActive) return;
-    const id = setInterval(() => {
-      fetchData({ silent: true });
-    }, refreshInterval * 1000);
-    return () => clearInterval(id);
-  }, [refreshInterval, fetchData, hasChanges, isActive]);
+  // Skip the timer entirely when:
+  //  - the user disabled auto-refresh (refreshInterval = 0)
+  //  - there are unsaved changes (would clobber pending edits)
+  //  - the grid is mounted but currently hidden (TableView keeps the
+  //    Data tab in the DOM with display:none when Schema is shown;
+  //    polling a hidden grid is wasted work and can confuse users
+  //    who think "I'm not on this tab, why is it making requests?")
+  //
+  // usePolling additionally pauses on document.hidden and prevents
+  // overlapping fetches — important for slow queries on large
+  // tables, where a 5s refresh interval used to let two or three
+  // fetchData calls stack up and freeze the grid for the duration
+  // of all of them.
+  const refreshEnabled = refreshInterval > 0 && !hasChanges && isActive;
+  const silentFetch = useCallback(() => {
+    fetchData({ silent: true });
+  }, [fetchData]);
+  usePolling(silentFetch, refreshInterval * 1000, refreshEnabled);
 
   useEffect(() => {
     if (!showRefreshMenu) return;

--- a/src/components/QueryStats/QueryStats.tsx
+++ b/src/components/QueryStats/QueryStats.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, useCallback, useMemo, useRef } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import { api, QueryStatEntry, QueryStatsResponse } from "../../lib/tauri";
+import { usePolling } from "../../hooks/usePolling";
 import { formatQueryDuration as formatDuration, cacheHitClass, speedClass } from "../../lib/dashboardUtils";
 import {
   Loader2,
@@ -56,7 +57,6 @@ export function QueryStats({ connectionId }: Props) {
   const [enabling, setEnabling] = useState(false);
   const [checking, setChecking] = useState(false);
   const [enableError, setEnableError] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchStats = useCallback(async () => {
     try {
@@ -88,22 +88,20 @@ export function QueryStats({ connectionId }: Props) {
     }
   }, [connectionId, fetchStats]);
 
+  // We need an unconditional mount-time fetch to discover whether
+  // pg_stat_statements is installed. Only the periodic refresh is
+  // gated on `data.available`.
   useEffect(() => {
     fetchStats();
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [fetchStats]);
+    // Intentionally only on connection change; subsequent fetches go
+    // through usePolling below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connectionId]);
 
-  useEffect(() => {
-    if (intervalRef.current) clearInterval(intervalRef.current);
-    if (!paused && data?.available) {
-      intervalRef.current = setInterval(fetchStats, 10000);
-    }
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [paused, fetchStats, data?.available]);
+  // Visibility-aware, re-entrancy-safe polling. Skip ticks while
+  // the window is hidden and never overlap two in-flight fetches.
+  // Disabled when paused or pg_stat_statements isn't installed.
+  usePolling(fetchStats, 10000, !paused && !!data?.available);
 
   const uniqueUsers = useMemo(() => {
     if (!data?.entries) return [];

--- a/src/hooks/usePolling.test.ts
+++ b/src/hooks/usePolling.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePolling } from "./usePolling";
+
+describe("usePolling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Default to "visible" for every test; individual tests flip it.
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function flushMicrotasks() {
+    // Fake timers don't drain promise microtasks; we have to do it
+    // manually to observe the inFlight reset between ticks.
+    return Promise.resolve();
+  }
+
+  it("invokes the callback once on mount and then every interval", async () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+    renderHook(() => usePolling(cb, 1000));
+
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Drain microtasks so the initial call's .finally() clears
+    // inFlight before the next interval tick fires; vi.useFakeTimers
+    // does not drain promises between timer firings.
+    await act(async () => {
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+    expect(cb).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not start the interval when enabled=false", async () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+    renderHook(() => usePolling(cb, 1000, false));
+
+    expect(cb).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await flushMicrotasks();
+    });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("does not start the interval for non-positive intervalMs", async () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+    renderHook(() => usePolling(cb, 0));
+    expect(cb).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await flushMicrotasks();
+    });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("skips ticks while document.hidden is true", async () => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true,
+    });
+
+    const cb = vi.fn().mockResolvedValue(undefined);
+    renderHook(() => usePolling(cb, 1000));
+
+    // Initial tick is also gated on hidden.
+    expect(cb).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await flushMicrotasks();
+    });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("resumes immediately when the page becomes visible again", async () => {
+    let hidden = true;
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => hidden,
+    });
+
+    const cb = vi.fn().mockResolvedValue(undefined);
+    renderHook(() => usePolling(cb, 1000));
+
+    expect(cb).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await flushMicrotasks();
+    });
+    expect(cb).not.toHaveBeenCalled();
+
+    // Flip to visible and dispatch the event.
+    hidden = false;
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await flushMicrotasks();
+    });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a tick that fires while the previous call is still pending", async () => {
+    let resolveCb: (() => void) | null = null;
+    const cb = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCb = resolve;
+        }),
+    );
+
+    renderHook(() => usePolling(cb, 1000));
+    // Initial tick fires and is held pending.
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Three full intervals pass while the first call is still in
+    // flight; none of them should queue another fetch.
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await flushMicrotasks();
+    });
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Resolve the in-flight promise; the *next* tick should fire.
+    await act(async () => {
+      resolveCb?.();
+      await flushMicrotasks();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await flushMicrotasks();
+    });
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps polling after the callback rejects (errors are swallowed by the hook)", async () => {
+    const cb = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValue(undefined);
+
+    renderHook(() => usePolling(cb, 1000));
+    // Initial tick triggers the rejection.
+    expect(cb).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await flushMicrotasks();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await flushMicrotasks();
+    });
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the interval and removes the visibility listener on unmount", async () => {
+    const cb = vi.fn().mockResolvedValue(undefined);
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+    const { unmount } = renderHook(() => usePolling(cb, 1000));
+
+    unmount();
+    await act(async () => {
+      vi.advanceTimersByTime(10000);
+      await flushMicrotasks();
+    });
+
+    // Initial tick already fired; no further calls should land after
+    // unmount.
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+
+  it("uses the LATEST callback even though the interval is not torn down on rerender", async () => {
+    const a = vi.fn().mockResolvedValue(undefined);
+    const b = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = renderHook(
+      ({ cb }) => usePolling(cb, 1000),
+      { initialProps: { cb: a } },
+    );
+
+    expect(a).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await flushMicrotasks();
+    });
+
+    rerender({ cb: b });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(b).toHaveBeenCalledTimes(1);
+    // `a` is no longer invoked even though we never reset the timer.
+    expect(a).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Run `callback` once on mount and then every `intervalMs`, with two
+ * guarantees that vanilla `setInterval(fetch, ms)` does not give you:
+ *
+ *   1. **Visibility-aware:** ticks are skipped while
+ *      `document.hidden` is true, so a minimized window or a
+ *      backgrounded tab cannot pile up a backlog of in-flight
+ *      `fetch`/IPC requests over hours of idle. We re-run `callback`
+ *      immediately when the window becomes visible again so the user
+ *      doesn't see stale data.
+ *
+ *   2. **Re-entrancy-safe:** if the previous `callback` is still
+ *      running when the next tick fires, the new tick is dropped
+ *      rather than overlapping. Without this, a single slow IPC
+ *      response (a stuck DB query, a paused tunnel) would let calls
+ *      queue up linearly until the renderer's main thread fell
+ *      behind on event processing — the exact failure mode that
+ *      froze v0.3.1.
+ *
+ * Pass `enabled = false` to suspend polling without unmounting (used
+ * by Activity dashboard's pause button). Setting `intervalMs <= 0`
+ * also suspends and is the conventional way for callers to expose
+ * "off" in their own UI.
+ *
+ * `callback` may be sync or async; its return value is ignored.
+ * The hook intentionally does not pass it any arguments — the
+ * caller's closure already captures everything it needs.
+ */
+export function usePolling(
+  callback: () => void | Promise<void>,
+  intervalMs: number,
+  enabled: boolean = true,
+): void {
+  // Hold the latest callback in a ref so the interval doesn't have to
+  // tear down + rebuild every time the parent re-renders (which would
+  // be every keystroke for components with a search box).
+  const cbRef = useRef(callback);
+  useEffect(() => {
+    cbRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (!enabled || intervalMs <= 0) return;
+
+    let alive = true;
+    let inFlight = false;
+
+    const tick = () => {
+      if (!alive || inFlight) return;
+      if (typeof document !== "undefined" && document.hidden) return;
+      inFlight = true;
+      Promise.resolve(cbRef.current())
+        .catch(() => {
+          // The callback owns its own error UX; we just need to
+          // keep `inFlight` honest.
+        })
+        .finally(() => {
+          inFlight = false;
+        });
+    };
+
+    tick();
+    const id = setInterval(tick, intervalMs);
+    const onVisibility = () => {
+      if (!document.hidden) tick();
+    };
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibility);
+    }
+
+    return () => {
+      alive = false;
+      clearInterval(id);
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibility);
+      }
+    };
+  }, [enabled, intervalMs]);
+}


### PR DESCRIPTION
## What this fixes

After Tablio is open (often minimized) for several hours the UI eventually freezes solid — only a full restart recovers it. Diagnosed against a live frozen instance (renderer pinned at 100% CPU on its main JS thread, every other thread idle in poll/futex):

- Tablio main process held **8,084 open file descriptors**
- **8,031 of those (99.3%)** were `/proc/<pid>/[task/<tid>/]stat`
- Renderer's main IPC socket had ~48 KB queued in `Recv-Q`

## Cause

`src-tauri/src/commands/system.rs` cached a global `LazyLock<Mutex<sysinfo::System>>` initialised with `refresh_processes(All, true)`. On Linux that scan opens stat for every process and every thread on the host — and sysinfo retains those fds as long as the System struct is alive. `ResourceMonitor` polls every 3 s forever, leaking ~2.25 fds per call. After 3 h the leak rate matched 8,031 fds exactly (3,600 polls × 2.23 ≈ 8,030).

Once the leak crossed Tauri/WebKitGTK's IPC throughput threshold, every poll started taking longer than its tick interval, polls began overlapping, the renderer's IPC socket Recv-Q grew unbounded, and the JS event loop drowned — the freeze.

## Fix

1. Drop the cached `System`. Construct a fresh one per call (or skip sysinfo entirely on Linux). Memory comes from a one-shot `refresh_processes(Some(&[our_pid]), false)` which is dropped immediately. CPU% on Linux is computed from `/proc/self/stat` `utime+stime` diffed against a static `(Instant, jiffies)` sample — no `/proc/<pid>/*` fds held across calls. Non-Linux falls back to a paired sysinfo refresh (200 ms apart), still with the System object dropped per call.
2. New regression test `get_app_resource_usage_does_not_leak_fds` hammers the command 50× and asserts open-fd growth ≤ 5.

## Defense in depth (frontend)

Even with the leak fixed, the hand-rolled `setInterval(fetch, ms)` pattern is dangerous when:

- the window is minimized for hours (WebKitGTK does **not** throttle background timers like Chrome does), or
- a single fetch ever stalls so new ticks pile up behind it.

New `src/hooks/usePolling.ts`:
- skips ticks while `document.hidden` is true; resumes immediately on `visibilitychange`
- drops a tick if the previous callback is still in flight
- keeps a callback-ref so the interval doesn't tear down on every parent re-render

Migrated all five existing pollers: `ResourceMonitor`, `DashboardOverview`, `DashboardSessions`, `DashboardLocks`, `QueryStats`, `DataGrid` auto-refresh.

## Tests

- `src/hooks/usePolling.test.ts` — 9 vitest cases (mount fire, periodic fire, disabled, hidden page, visibility resume, in-flight drop, error swallowing, unmount cleanup, latest-callback semantics)
- `src-tauri` `commands::system`: 6/6 pass including the new fd-leak regression and a parens-in-comm parser test for the Linux fast path
- Full suites: 537/537 vitest (16 files), 301/301 Rust lib, 24/24 Playwright `app.spec`

## User-visible behaviour change

Activity dashboard, query stats, and DataGrid auto-refresh now pause when the window is minimized or hidden behind another workspace, and resume immediately on focus. Status-bar CPU% stays accurate on Linux because we now compute it from `/proc/self/stat` directly.

## Test plan

- [ ] Open the built app, leave it minimized overnight, restore — UI should be responsive immediately
- [ ] `lsof -p $(pgrep tablio | head -1) | wc -l` after an hour should stay flat (~50–150), not climb into the thousands
- [ ] Status-bar memory + CPU% still update once per 3 s while focused