### PR TITLE
SSH tunneling: backup over tunnel, known-hosts UI, ssh-agent auth, ssh-config import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,26 @@ jobs:
             echo "Waiting for sshd... (attempt $i/30)"
             sleep 2
           done
+          # The linuxserver image ships with `AllowTcpForwarding no` in
+          # /config/sshd/sshd_config, which silently breaks every
+          # `-L`-style forward and any russh `direct-tcpip` channel —
+          # exactly what the integration suite exercises. Patch the
+          # config and bounce sshd so the bastion actually forwards.
+          docker exec sshd sh -c '
+            sed -i "s/^AllowTcpForwarding.*/AllowTcpForwarding yes/" /config/sshd/sshd_config
+            sed -i "s/^GatewayPorts.*/GatewayPorts yes/" /config/sshd/sshd_config
+            grep -E "^(AllowTcpForwarding|GatewayPorts)" /config/sshd/sshd_config
+            pkill -x sshd.pam || pkill -x sshd
+          '
+          # Give s6-overlay a moment to relaunch sshd before the test
+          # step starts hammering it.
+          for i in $(seq 1 15); do
+            if nc -z 127.0.0.1 2222; then
+              echo "sshd back up after reload"
+              break
+            fi
+            sleep 1
+          done
 
       - name: Install Linux dependencies
         run: |
@@ -376,6 +396,21 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+
+      - name: Start ssh-agent and load test key
+        id: sshagent
+        run: |
+          # Spawn a session-scoped ssh-agent and load the unencrypted key
+          # we provisioned earlier. Exporting SSH_AUTH_SOCK +
+          # TEST_SSH_AGENT_AVAILABLE into $GITHUB_ENV makes them visible
+          # to the cargo step below so the agent-auth integration tests
+          # actually run instead of skipping.
+          eval "$(ssh-agent -s)"
+          ssh-add "${{ steps.sshkey.outputs.key_path }}"
+          ssh-add -l
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+          echo "TEST_SSH_AGENT_AVAILABLE=1" >> "$GITHUB_ENV"
 
       - name: Run SSH tunnel integration tests
         env:
@@ -393,6 +428,8 @@ jobs:
           TEST_POSTGRES_DB: testdb
           # Enables the identity-file branch of the integration suite.
           TEST_SSH_KEY_PATH: ${{ steps.sshkey.outputs.key_path }}
+          # `SSH_AUTH_SOCK` and `TEST_SSH_AGENT_AVAILABLE` come in via
+          # $GITHUB_ENV from the previous step.
         run: cargo test --manifest-path src-tauri/Cargo.toml --test ssh_tunnel_integration -- --test-threads=1
 
       - name: Dump bastion logs on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,8 +388,20 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          # Add the PGDG apt repo so we can pull a `pg_dump` that matches
+          # the postgres:17 service. Ubuntu 24.04 only ships
+          # `postgresql-client` v16, and `pg_dump` refuses to dump a
+          # newer-version server ("aborting because of server version
+          # mismatch") which breaks `pg_dump_through_tunnel`.
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSLo /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf postgresql-client
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf postgresql-client-17
+          pg_dump --version
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,10 +330,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Generate SSH key for identity-file auth tests
+        id: sshkey
+        run: |
+          # An unencrypted ed25519 keypair the bastion will accept on top of
+          # the password login. Lives in the runner workspace so the tests
+          # (and `docker run` mount below) can read it.
+          mkdir -p "$RUNNER_TEMP/tablio-ssh"
+          ssh-keygen -t ed25519 -N "" -f "$RUNNER_TEMP/tablio-ssh/id_ed25519" -C tablio-ci >/dev/null
+          chmod 600 "$RUNNER_TEMP/tablio-ssh/id_ed25519"
+          echo "key_path=$RUNNER_TEMP/tablio-ssh/id_ed25519" >> "$GITHUB_OUTPUT"
+          echo "pub_key=$(cat "$RUNNER_TEMP/tablio-ssh/id_ed25519.pub")" >> "$GITHUB_OUTPUT"
+
       - name: Start OpenSSH bastion
         run: |
           # Bastion runs on host network so 127.0.0.1:5432 inside the
           # container resolves to the Postgres service on the runner.
+          # PUBLIC_KEY enables identity-file auth alongside the password.
           docker run -d --name sshd \
             --network host \
             -e PUID=1000 -e PGID=1000 \
@@ -341,6 +354,7 @@ jobs:
             -e PASSWORD_ACCESS=true \
             -e SUDO_ACCESS=false \
             -e LISTEN_PORT=2222 \
+            -e PUBLIC_KEY="${{ steps.sshkey.outputs.pub_key }}" \
             lscr.io/linuxserver/openssh-server:latest
           # Wait for sshd to start accepting connections.
           for i in $(seq 1 30); do
@@ -355,7 +369,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf postgresql-client
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -377,6 +391,8 @@ jobs:
           TEST_POSTGRES_USER: test
           TEST_POSTGRES_PASSWORD: test
           TEST_POSTGRES_DB: testdb
+          # Enables the identity-file branch of the integration suite.
+          TEST_SSH_KEY_PATH: ${{ steps.sshkey.outputs.key_path }}
         run: cargo test --manifest-path src-tauri/Cargo.toml --test ssh_tunnel_integration -- --test-threads=1
 
       - name: Dump bastion logs on failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,85 @@ jobs:
       - name: Run SQLite integration tests
         run: cargo test --manifest-path src-tauri/Cargo.toml --test sqlite_integration
 
+  # Stand up an OpenSSH bastion in front of a Postgres instance so the
+  # russh-based SSH tunnel can be exercised end-to-end. The bastion uses
+  # `--network host` so it can reach the Postgres service on the runner's
+  # localhost without a custom docker network.
+  test-ssh-tunnel:
+    name: SSH Tunnel
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Start OpenSSH bastion
+        run: |
+          # Bastion runs on host network so 127.0.0.1:5432 inside the
+          # container resolves to the Postgres service on the runner.
+          docker run -d --name sshd \
+            --network host \
+            -e PUID=1000 -e PGID=1000 \
+            -e USER_NAME=tablio -e USER_PASSWORD=tablio-pw \
+            -e PASSWORD_ACCESS=true \
+            -e SUDO_ACCESS=false \
+            -e LISTEN_PORT=2222 \
+            lscr.io/linuxserver/openssh-server:latest
+          # Wait for sshd to start accepting connections.
+          for i in $(seq 1 30); do
+            if nc -z 127.0.0.1 2222; then
+              echo "sshd is up"
+              break
+            fi
+            echo "Waiting for sshd... (attempt $i/30)"
+            sleep 2
+          done
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run SSH tunnel integration tests
+        env:
+          TEST_SSH_HOST: 127.0.0.1
+          TEST_SSH_PORT: "2222"
+          TEST_SSH_USER: tablio
+          TEST_SSH_PASSWORD: tablio-pw
+          # Reach the Postgres service from inside the bastion container,
+          # which is on the host network namespace, via the runner's
+          # loopback interface.
+          TEST_SSH_TARGET_HOST: 127.0.0.1
+          TEST_SSH_TARGET_PORT: "5432"
+          TEST_POSTGRES_USER: test
+          TEST_POSTGRES_PASSWORD: test
+          TEST_POSTGRES_DB: testdb
+        run: cargo test --manifest-path src-tauri/Cargo.toml --test ssh_tunnel_integration -- --test-threads=1
+
+      - name: Dump bastion logs on failure
+        if: failure()
+        run: docker logs sshd
+
   test-cassandra:
     name: Cassandra ${{ matrix.cassandra_version }}
     needs: [changes]
@@ -414,7 +493,7 @@ jobs:
 
   build:
     name: Build
-    needs: [changes, test-frontend, test-e2e, fmt-and-clippy, test-postgres, test-mysql, test-mariadb, test-cockroachdb, test-tidb, test-sqlite, test-cassandra, test-scylladb]
+    needs: [changes, test-frontend, test-e2e, fmt-and-clippy, test-postgres, test-mysql, test-mariadb, test-cockroachdb, test-tidb, test-sqlite, test-ssh-tunnel, test-cassandra, test-scylladb]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-22.04
     steps:
@@ -467,6 +546,7 @@ jobs:
       - test-cockroachdb
       - test-tidb
       - test-sqlite
+      - test-ssh-tunnel
       - test-cassandra
       - test-scylladb
       - build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,8 +388,18 @@ jobs:
 
       - name: Install Linux dependencies
         run: |
+          # Match ci.yml: pull pg_dump from PGDG so the dump-through-tunnel
+          # test isn't blocked by the Ubuntu 24.04 postgresql-client v16
+          # vs postgres:17 server mismatch.
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSLo /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf postgresql-client
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf postgresql-client-17
+          pg_dump --version
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,6 +344,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Generate SSH key for identity-file auth tests
+        id: sshkey
+        run: |
+          mkdir -p "$RUNNER_TEMP/tablio-ssh"
+          ssh-keygen -t ed25519 -N "" -f "$RUNNER_TEMP/tablio-ssh/id_ed25519" -C tablio-ci >/dev/null
+          chmod 600 "$RUNNER_TEMP/tablio-ssh/id_ed25519"
+          echo "key_path=$RUNNER_TEMP/tablio-ssh/id_ed25519" >> "$GITHUB_OUTPUT"
+          echo "pub_key=$(cat "$RUNNER_TEMP/tablio-ssh/id_ed25519.pub")" >> "$GITHUB_OUTPUT"
+
       - name: Start OpenSSH bastion
         run: |
           docker run -d --name sshd \
@@ -353,6 +362,7 @@ jobs:
             -e PASSWORD_ACCESS=true \
             -e SUDO_ACCESS=false \
             -e LISTEN_PORT=2222 \
+            -e PUBLIC_KEY="${{ steps.sshkey.outputs.pub_key }}" \
             lscr.io/linuxserver/openssh-server:latest
           for i in $(seq 1 30); do
             if nc -z 127.0.0.1 2222; then
@@ -365,7 +375,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf postgresql-client
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -384,6 +394,7 @@ jobs:
           TEST_POSTGRES_USER: test
           TEST_POSTGRES_PASSWORD: test
           TEST_POSTGRES_DB: testdb
+          TEST_SSH_KEY_PATH: ${{ steps.sshkey.outputs.key_path }}
         run: cargo test --manifest-path src-tauri/Cargo.toml --test ssh_tunnel_integration -- --test-threads=1
 
       - name: Dump bastion logs on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,6 +324,72 @@ jobs:
       - name: Run SQLite integration tests
         run: cargo test --manifest-path src-tauri/Cargo.toml --test sqlite_integration
 
+  test-ssh-tunnel:
+    name: SSH Tunnel
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Start OpenSSH bastion
+        run: |
+          docker run -d --name sshd \
+            --network host \
+            -e PUID=1000 -e PGID=1000 \
+            -e USER_NAME=tablio -e USER_PASSWORD=tablio-pw \
+            -e PASSWORD_ACCESS=true \
+            -e SUDO_ACCESS=false \
+            -e LISTEN_PORT=2222 \
+            lscr.io/linuxserver/openssh-server:latest
+          for i in $(seq 1 30); do
+            if nc -z 127.0.0.1 2222; then
+              echo "sshd is up"; break
+            fi
+            echo "Waiting for sshd... (attempt $i/30)"
+            sleep 2
+          done
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libappindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run SSH tunnel integration tests
+        env:
+          TEST_SSH_HOST: 127.0.0.1
+          TEST_SSH_PORT: "2222"
+          TEST_SSH_USER: tablio
+          TEST_SSH_PASSWORD: tablio-pw
+          TEST_SSH_TARGET_HOST: 127.0.0.1
+          TEST_SSH_TARGET_PORT: "5432"
+          TEST_POSTGRES_USER: test
+          TEST_POSTGRES_PASSWORD: test
+          TEST_POSTGRES_DB: testdb
+        run: cargo test --manifest-path src-tauri/Cargo.toml --test ssh_tunnel_integration -- --test-threads=1
+
+      - name: Dump bastion logs on failure
+        if: failure()
+        run: docker logs sshd
+
   test-cassandra:
     name: Cassandra ${{ matrix.cassandra_version }}
     runs-on: ubuntu-latest
@@ -402,7 +468,7 @@ jobs:
 
   release:
     name: Build & Release (${{ matrix.platform }})
-    needs: [test-frontend, test-e2e, test-postgres, test-mysql, test-mariadb, test-mssql, test-cockroachdb, test-tidb, test-sqlite, test-cassandra, test-scylladb]
+    needs: [test-frontend, test-e2e, test-postgres, test-mysql, test-mariadb, test-mssql, test-cockroachdb, test-tidb, test-sqlite, test-ssh-tunnel, test-cassandra, test-scylladb]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,6 +371,20 @@ jobs:
             echo "Waiting for sshd... (attempt $i/30)"
             sleep 2
           done
+          # Mirror ci.yml: enable port forwarding so the russh
+          # `direct-tcpip` channels actually work.
+          docker exec sshd sh -c '
+            sed -i "s/^AllowTcpForwarding.*/AllowTcpForwarding yes/" /config/sshd/sshd_config
+            sed -i "s/^GatewayPorts.*/GatewayPorts yes/" /config/sshd/sshd_config
+            grep -E "^(AllowTcpForwarding|GatewayPorts)" /config/sshd/sshd_config
+            pkill -x sshd.pam || pkill -x sshd
+          '
+          for i in $(seq 1 15); do
+            if nc -z 127.0.0.1 2222; then
+              echo "sshd back up after reload"; break
+            fi
+            sleep 1
+          done
 
       - name: Install Linux dependencies
         run: |
@@ -382,6 +396,19 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+
+      - name: Start ssh-agent and load test key
+        id: sshagent
+        run: |
+          # Mirror ci.yml: exposes SSH_AUTH_SOCK + TEST_SSH_AGENT_AVAILABLE
+          # to the integration test step so the agent-auth branch is
+          # actually exercised by the release pipeline.
+          eval "$(ssh-agent -s)"
+          ssh-add "${{ steps.sshkey.outputs.key_path }}"
+          ssh-add -l
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+          echo "TEST_SSH_AGENT_AVAILABLE=1" >> "$GITHUB_ENV"
 
       - name: Run SSH tunnel integration tests
         env:

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -36,9 +36,13 @@ test.describe("Connection dialog", () => {
     await page.goto("/");
     await page.locator(".empty-state .btn-primary").click();
     const dialog = page.locator(".dialog");
+    // General section is the default landing page after the sectioned-dialog
+    // refactor; it now hosts host/port/database alongside connection name.
     await expect(dialog.locator("label", { hasText: "Connection Name" })).toBeVisible();
     await expect(dialog.locator("label", { hasText: "Host" })).toBeVisible();
     await expect(dialog.locator("label", { hasText: "Port" })).toBeVisible();
+    // Username + Password live in the Authentication section.
+    await dialog.locator(".connection-nav-item", { hasText: "Authentication" }).click();
     await expect(dialog.locator("label", { hasText: "Username" })).toBeVisible();
     await expect(dialog.locator("label", { hasText: "Password" })).toBeVisible();
   });
@@ -48,9 +52,11 @@ test.describe("Connection dialog", () => {
     await page.locator(".empty-state .btn-primary").click();
     const dialog = page.locator(".dialog");
 
-    await dialog.locator("input").nth(0).fill("Test DB");
-    await dialog.locator("input").nth(1).fill("localhost");
-    await dialog.locator("input").nth(3).fill("testuser");
+    // Connection Name is always the first input in the General section;
+    // Host follows. Username defaults to "postgres" so we don't need to
+    // touch the Authentication section here.
+    await dialog.locator("label", { hasText: "Connection Name" }).locator("..").locator("input").fill("Test DB");
+    await dialog.locator("label", { hasText: "Host" }).locator("..").locator("input").fill("localhost");
 
     await page.locator(".btn-test-conn").click();
     await expect(page.locator(".btn-test-conn")).toContainText("Connected", { timeout: 5000 });

--- a/e2e/connection-dialog.spec.ts
+++ b/e2e/connection-dialog.spec.ts
@@ -34,13 +34,20 @@ test.describe("Connection dialog — DB type switching", () => {
   test("SQLite hides SSL toggles", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "SQLite" }).click();
-    await expect(page.locator(".security-toggle")).not.toBeVisible();
+    // SSL block (and the whole SSH section) are gated off for SQLite.
+    await expect(
+      page.locator(".security-toggle__label", { hasText: "SSL / TLS" }),
+    ).not.toBeVisible();
   });
 
   test("Cassandra hides SSL toggles", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "Cassandra" }).click();
-    await expect(page.locator(".security-toggle")).not.toBeVisible();
+    // SSL block hidden for cassandra; SSH section still applies and is
+    // independently tested below.
+    await expect(
+      page.locator(".security-toggle__label", { hasText: "SSL / TLS" }),
+    ).not.toBeVisible();
   });
 
   test("switching to CockroachDB changes port to 26257", async ({ page }) => {
@@ -152,6 +159,140 @@ test.describe("Connection dialog — validation", () => {
     await nameInput.fill("Local Postgres");
     await page.locator(".btn-test-conn").click();
     await expect(page.locator(".field-error", { hasText: "already exists" })).toBeVisible();
+  });
+});
+
+test.describe("Connection dialog — SSH tunnel section", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await openConnectionDialog(page);
+  });
+
+  test("SSH section is visible for postgres and hidden for sqlite", async ({ page }) => {
+    await expect(
+      page.locator(".ssh-tunnel-section .security-toggle__label", {
+        hasText: "Use SSH tunneling",
+      }),
+    ).toBeVisible();
+
+    await page.locator(".db-dropdown-trigger").click();
+    await page.locator(".db-dropdown-item", { hasText: "SQLite" }).click();
+    await expect(page.locator(".ssh-tunnel-section")).not.toBeVisible();
+  });
+
+  test("toggling SSH on reveals tunnel host / port / username inputs", async ({ page }) => {
+    const tunnelToggle = page
+      .locator(".ssh-tunnel-section .security-toggle")
+      .first()
+      .locator(".security-toggle__input");
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: "Tunnel host" }),
+    ).not.toBeVisible();
+    await tunnelToggle.check({ force: true });
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: "Tunnel host" }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: "Tunnel port" }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: "SSH username" }),
+    ).toBeVisible();
+  });
+
+  test("auth toggle swaps Password input <-> Identity file picker", async ({ page }) => {
+    const tunnelToggle = page
+      .locator(".ssh-tunnel-section .security-toggle")
+      .first()
+      .locator(".security-toggle__input");
+    await tunnelToggle.check({ force: true });
+
+    // Default = Password: password field visible, identity file hidden.
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: "Password" }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: "Identity file" }),
+    ).not.toBeVisible();
+
+    // Switch to Identity file.
+    await page
+      .locator(".ssh-auth-toggle__btn", { hasText: "Identity file" })
+      .click();
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: "Identity file" }),
+    ).toBeVisible();
+    // The password field's label flips to "Key passphrase".
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: "Key passphrase" }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: /^Password$/ }),
+    ).not.toBeVisible();
+    // Prompt-for-passphrase nested toggle becomes available.
+    await expect(
+      page.locator(".ssh-tunnel-section .security-toggle__label", {
+        hasText: "Prompt for passphrase?",
+      }),
+    ).toBeVisible();
+  });
+
+  test("'Prompt for passphrase' hides the passphrase input", async ({ page }) => {
+    const tunnelToggle = page
+      .locator(".ssh-tunnel-section .security-toggle")
+      .first()
+      .locator(".security-toggle__input");
+    await tunnelToggle.check({ force: true });
+    await page
+      .locator(".ssh-auth-toggle__btn", { hasText: "Identity file" })
+      .click();
+    const promptToggle = page
+      .locator(".ssh-tunnel-section .security-toggle--nested .security-toggle__input");
+    await promptToggle.check({ force: true });
+    await expect(
+      page.locator(".ssh-tunnel-section label", { hasText: "Key passphrase" }),
+    ).not.toBeVisible();
+  });
+
+  test("validation flags missing tunnel host / username on test", async ({ page }) => {
+    // Fill in a name + DB connection details so the only outstanding errors
+    // come from the SSH section.
+    await page.locator(".dialog input").nth(0).fill("SSH Test");
+    await page
+      .locator(".dialog")
+      .locator("label", { hasText: "Host" })
+      .locator("..")
+      .locator("input")
+      .fill("127.0.0.1");
+    await page
+      .locator(".dialog")
+      .locator("label", { hasText: "Username" })
+      .locator("..")
+      .locator("input")
+      .fill("admin");
+
+    const tunnelToggle = page
+      .locator(".ssh-tunnel-section .security-toggle")
+      .first()
+      .locator(".security-toggle__input");
+    await tunnelToggle.check({ force: true });
+    await page.locator(".btn-test-conn").click();
+
+    await expect(
+      page.locator(".ssh-tunnel-section .field-error", {
+        hasText: "SSH host is required",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".ssh-tunnel-section .field-error", {
+        hasText: "SSH username is required",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".ssh-tunnel-section .field-error", {
+        hasText: "SSH password is required",
+      }),
+    ).toBeVisible();
   });
 });
 

--- a/e2e/connection-dialog.spec.ts
+++ b/e2e/connection-dialog.spec.ts
@@ -17,9 +17,7 @@ test.describe("Connection dialog — DB type switching", () => {
 
   test("left navigation switches between configuration sections", async ({ page }) => {
     await expect(page.locator(".connection-nav-item", { hasText: "General" })).toHaveClass(/connection-nav-item--active/);
-
-    await openDialogSection(page, "Connection");
-    await expect(page.locator(".connection-section-heading h3")).toHaveText("Connection");
+    // General now also owns the connection target (host/port/database).
     await expect(dialogField(page, /^Host$/)).toBeVisible();
 
     await openDialogSection(page, "Authentication");
@@ -30,7 +28,6 @@ test.describe("Connection dialog — DB type switching", () => {
   test("defaults to PostgreSQL with port 5432", async ({ page }) => {
     const dialog = page.locator(".dialog");
     await expect(dialog.locator(".db-dropdown-value")).toHaveText("PostgreSQL");
-    await openDialogSection(page, "Connection");
     const portInput = dialogField(page, /^Port$/);
     await expect(portInput).toHaveValue("5432");
   });
@@ -39,7 +36,6 @@ test.describe("Connection dialog — DB type switching", () => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "MySQL" }).click();
     await expect(page.locator(".db-dropdown-value")).toHaveText("MySQL");
-    await openDialogSection(page, "Connection");
     const portInput = dialogField(page, /^Port$/);
     await expect(portInput).toHaveValue("3306");
   });
@@ -47,7 +43,6 @@ test.describe("Connection dialog — DB type switching", () => {
   test("switching to SQLite shows file path instead of host/port/user", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "SQLite" }).click();
-    await openDialogSection(page, "Connection");
     await expect(page.locator(".dialog").locator("label", { hasText: "Database File Path" })).toBeVisible();
     await expect(page.locator(".dialog").locator("label", { hasText: "Host" })).not.toBeVisible();
     await expect(page.locator(".dialog").locator("label", { hasText: "Port" })).not.toBeVisible();
@@ -79,7 +74,6 @@ test.describe("Connection dialog — DB type switching", () => {
   test("switching to CockroachDB changes port to 26257", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "CockroachDB" }).click();
-    await openDialogSection(page, "Connection");
     const portInput = dialogField(page, /^Port$/);
     await expect(portInput).toHaveValue("26257");
   });
@@ -87,7 +81,6 @@ test.describe("Connection dialog — DB type switching", () => {
   test("switching to MSSQL changes port to 1433", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "Microsoft SQL Server" }).click();
-    await openDialogSection(page, "Connection");
     const portInput = dialogField(page, /^Port$/);
     await expect(portInput).toHaveValue("1433");
   });
@@ -178,7 +171,6 @@ test.describe("Connection dialog — validation", () => {
 
   test("empty host shows error after blur", async ({ page }) => {
     await page.locator(".dialog input").first().fill("Missing Host");
-    await openDialogSection(page, "Connection");
     const hostInput = dialogField(page, /^Host$/);
     await hostInput.fill("");
     await hostInput.blur();
@@ -194,13 +186,16 @@ test.describe("Connection dialog — validation", () => {
   });
 
   test("test connection jumps to the first section with validation errors", async ({ page }) => {
+    // Username lives in Authentication; clearing host on General + missing
+    // username triggers errors in two distinct sections, so the dialog
+    // should land on General (the first invalid one) and badge both nav
+    // items.
     await page.locator(".dialog input").first().fill("Needs Host");
-    await openDialogSection(page, "Connection");
     await dialogField(page, /^Host$/).fill("");
     await page.locator(".btn-test-conn").click();
 
-    await expect(page.locator(".connection-nav-item--active")).toContainText("Connection");
-    await expect(page.locator(".connection-nav-item--error", { hasText: "Connection" })).toBeVisible();
+    await expect(page.locator(".connection-nav-item--active")).toContainText("General");
+    await expect(page.locator(".connection-nav-item--error", { hasText: "General" })).toBeVisible();
     await expect(page.locator(".connection-nav-item--error", { hasText: "Authentication" })).toBeVisible();
     await expect(page.locator(".field-error", { hasText: "Host is required" })).toBeVisible();
   });
@@ -308,7 +303,6 @@ test.describe("Connection dialog — SSH tunnel section", () => {
     // Fill in a name + DB connection details so the only outstanding errors
     // come from the SSH section.
     await page.locator(".dialog input").nth(0).fill("SSH Test");
-    await openDialogSection(page, "Connection");
     await dialogField(page, /^Host$/).fill("127.0.0.1");
     await openDialogSection(page, "Authentication");
     await dialogField(page, /^Username$/).fill("admin");
@@ -346,7 +340,6 @@ test.describe("Connection dialog — save and close", () => {
     await openConnectionDialog(page);
     const dialog = page.locator(".dialog");
     await dialog.locator("input").nth(0).fill("E2E Test DB");
-    await openDialogSection(page, "Connection");
     await dialogField(page, /^Host$/).fill("127.0.0.1");
     await openDialogSection(page, "Authentication");
     await dialogField(page, /^Username$/).fill("admin");

--- a/e2e/connection-dialog.spec.ts
+++ b/e2e/connection-dialog.spec.ts
@@ -186,12 +186,14 @@ test.describe("Connection dialog — validation", () => {
   });
 
   test("test connection jumps to the first section with validation errors", async ({ page }) => {
-    // Username lives in Authentication; clearing host on General + missing
-    // username triggers errors in two distinct sections, so the dialog
-    // should land on General (the first invalid one) and badge both nav
-    // items.
+    // Username lives in Authentication; clearing host on General + clearing
+    // username (which is pre-filled with the driver default) triggers errors
+    // in two distinct sections, so the dialog should land on General (the
+    // first invalid one) and badge both nav items.
     await page.locator(".dialog input").first().fill("Needs Host");
     await dialogField(page, /^Host$/).fill("");
+    await openDialogSection(page, "Authentication");
+    await dialogField(page, "Username").fill("");
     await page.locator(".btn-test-conn").click();
 
     await expect(page.locator(".connection-nav-item--active")).toContainText("General");
@@ -331,6 +333,84 @@ test.describe("Connection dialog — SSH tunnel section", () => {
         hasText: "SSH password is required",
       }),
     ).toBeVisible();
+  });
+
+  test("warns when SSL hostname verification will fail through the tunnel", async ({ page }) => {
+    // Turn on SSL (default Trust server cert is off) so we have the
+    // verify-full + tunnel combination that the advisory flags.
+    await openDialogSection(page, "Security");
+    await page
+      .locator(".security-toggle", { hasText: "SSL / TLS" })
+      .locator(".security-toggle__input")
+      .check({ force: true });
+
+    await openDialogSection(page, "SSH Tunnel");
+    const tunnelToggle = page
+      .locator(".ssh-tunnel-section .security-toggle")
+      .first()
+      .locator(".security-toggle__input");
+    await tunnelToggle.check({ force: true });
+    const warning = page.locator(".ssh-tunnel-warning", {
+      hasText: "SSL hostname verification will fail",
+    });
+    await expect(warning).toBeVisible();
+
+    // Toggling Trust server certificate should clear the warning.
+    await openDialogSection(page, "Security");
+    await page
+      .locator(".security-toggle", { hasText: "Trust server certificate" })
+      .locator(".security-toggle__input")
+      .check({ force: true });
+    await openDialogSection(page, "SSH Tunnel");
+    await expect(warning).not.toBeVisible();
+  });
+
+  test("warns about Cassandra peer discovery when SSH is enabled", async ({ page }) => {
+    await page.locator(".db-dropdown-trigger").click();
+    await page.locator(".db-dropdown-item", { hasText: "Cassandra" }).click();
+    await openDialogSection(page, "SSH Tunnel");
+    const tunnelToggle = page
+      .locator(".ssh-tunnel-section .security-toggle")
+      .first()
+      .locator(".security-toggle__input");
+    await tunnelToggle.check({ force: true });
+    await expect(
+      page.locator(".ssh-tunnel-warning", {
+        hasText: "Cassandra cluster discovery bypasses the tunnel",
+      }),
+    ).toBeVisible();
+  });
+
+  test("warns when an identity-file passphrase will be persisted to disk", async ({ page }) => {
+    await openDialogSection(page, "SSH Tunnel");
+    const tunnelToggle = page
+      .locator(".ssh-tunnel-section .security-toggle")
+      .first()
+      .locator(".security-toggle__input");
+    await tunnelToggle.check({ force: true });
+    await page
+      .locator(".ssh-auth-toggle__btn", { hasText: "Identity file" })
+      .click();
+    // The persisted-passphrase notice should not appear until the user
+    // actually types something, because an empty passphrase = unencrypted key.
+    const warning = page.locator(".ssh-tunnel-warning", {
+      hasText: "Passphrase will be saved to disk",
+    });
+    await expect(warning).not.toBeVisible();
+
+    await page
+      .locator(".ssh-tunnel-section label", { hasText: "Key passphrase" })
+      .locator("..")
+      .locator("input")
+      .fill("hunter2");
+    await expect(warning).toBeVisible();
+
+    // Enabling the prompt-for-passphrase toggle replaces the persisted
+    // passphrase with a runtime prompt, so the notice must disappear.
+    const promptToggle = page
+      .locator(".ssh-tunnel-section .security-toggle--nested .security-toggle__input");
+    await promptToggle.check({ force: true });
+    await expect(warning).not.toBeVisible();
   });
 });
 

--- a/e2e/connection-dialog.spec.ts
+++ b/e2e/connection-dialog.spec.ts
@@ -1,16 +1,37 @@
 import { test, expect } from "@playwright/test";
 import { openConnectionDialog } from "./helpers";
 
+async function openDialogSection(page: import("@playwright/test").Page, name: string) {
+  await page.locator(".connection-nav-item", { hasText: name }).click();
+}
+
+function dialogField(page: import("@playwright/test").Page, label: string | RegExp) {
+  return page.locator(".dialog").locator("label", { hasText: label }).locator("..").locator("input").first();
+}
+
 test.describe("Connection dialog — DB type switching", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     await openConnectionDialog(page);
   });
 
+  test("left navigation switches between configuration sections", async ({ page }) => {
+    await expect(page.locator(".connection-nav-item", { hasText: "General" })).toHaveClass(/connection-nav-item--active/);
+
+    await openDialogSection(page, "Connection");
+    await expect(page.locator(".connection-section-heading h3")).toHaveText("Connection");
+    await expect(dialogField(page, /^Host$/)).toBeVisible();
+
+    await openDialogSection(page, "Authentication");
+    await expect(page.locator(".connection-section-heading h3")).toHaveText("Authentication");
+    await expect(dialogField(page, /^Username$/)).toBeVisible();
+  });
+
   test("defaults to PostgreSQL with port 5432", async ({ page }) => {
     const dialog = page.locator(".dialog");
     await expect(dialog.locator(".db-dropdown-value")).toHaveText("PostgreSQL");
-    const portInput = dialog.locator("label", { hasText: "Port" }).locator("..").locator("input");
+    await openDialogSection(page, "Connection");
+    const portInput = dialogField(page, /^Port$/);
     await expect(portInput).toHaveValue("5432");
   });
 
@@ -18,23 +39,27 @@ test.describe("Connection dialog — DB type switching", () => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "MySQL" }).click();
     await expect(page.locator(".db-dropdown-value")).toHaveText("MySQL");
-    const portInput = page.locator(".dialog").locator("label", { hasText: "Port" }).locator("..").locator("input");
+    await openDialogSection(page, "Connection");
+    const portInput = dialogField(page, /^Port$/);
     await expect(portInput).toHaveValue("3306");
   });
 
   test("switching to SQLite shows file path instead of host/port/user", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "SQLite" }).click();
+    await openDialogSection(page, "Connection");
     await expect(page.locator(".dialog").locator("label", { hasText: "Database File Path" })).toBeVisible();
     await expect(page.locator(".dialog").locator("label", { hasText: "Host" })).not.toBeVisible();
     await expect(page.locator(".dialog").locator("label", { hasText: "Port" })).not.toBeVisible();
     await expect(page.locator(".dialog").locator("label", { hasText: "Username" })).not.toBeVisible();
+    await expect(page.locator(".connection-nav-item", { hasText: "Authentication" })).not.toBeVisible();
   });
 
   test("SQLite hides SSL toggles", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "SQLite" }).click();
     // SSL block (and the whole SSH section) are gated off for SQLite.
+    await expect(page.locator(".connection-nav-item", { hasText: "Security" })).not.toBeVisible();
     await expect(
       page.locator(".security-toggle__label", { hasText: "SSL / TLS" }),
     ).not.toBeVisible();
@@ -43,6 +68,7 @@ test.describe("Connection dialog — DB type switching", () => {
   test("Cassandra hides SSL toggles", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "Cassandra" }).click();
+    await openDialogSection(page, "Security");
     // SSL block hidden for cassandra; SSH section still applies and is
     // independently tested below.
     await expect(
@@ -53,14 +79,16 @@ test.describe("Connection dialog — DB type switching", () => {
   test("switching to CockroachDB changes port to 26257", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "CockroachDB" }).click();
-    const portInput = page.locator(".dialog").locator("label", { hasText: "Port" }).locator("..").locator("input");
+    await openDialogSection(page, "Connection");
+    const portInput = dialogField(page, /^Port$/);
     await expect(portInput).toHaveValue("26257");
   });
 
   test("switching to MSSQL changes port to 1433", async ({ page }) => {
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "Microsoft SQL Server" }).click();
-    const portInput = page.locator(".dialog").locator("label", { hasText: "Port" }).locator("..").locator("input");
+    await openDialogSection(page, "Connection");
+    const portInput = dialogField(page, /^Port$/);
     await expect(portInput).toHaveValue("1433");
   });
 });
@@ -72,6 +100,7 @@ test.describe("Connection dialog — SSL toggles", () => {
   });
 
   test("SSL toggle enables trust server certificate sub-toggle", async ({ page }) => {
+    await openDialogSection(page, "Security");
     const trustToggle = page.locator(".security-toggle--nested .security-toggle__input");
     await expect(trustToggle).toBeDisabled();
     await page.locator(".security-toggle__input").first().check({ force: true });
@@ -79,6 +108,7 @@ test.describe("Connection dialog — SSL toggles", () => {
   });
 
   test("disabling SSL auto-unchecks trust cert", async ({ page }) => {
+    await openDialogSection(page, "Security");
     const sslToggle = page.locator(".security-toggle__input").first();
     const trustToggle = page.locator(".security-toggle--nested .security-toggle__input");
     await sslToggle.check({ force: true });
@@ -147,7 +177,9 @@ test.describe("Connection dialog — validation", () => {
   });
 
   test("empty host shows error after blur", async ({ page }) => {
-    const hostInput = page.locator(".dialog").locator("label", { hasText: "Host" }).locator("..").locator("input");
+    await page.locator(".dialog input").first().fill("Missing Host");
+    await openDialogSection(page, "Connection");
+    const hostInput = dialogField(page, /^Host$/);
     await hostInput.fill("");
     await hostInput.blur();
     await page.locator(".btn-test-conn").click();
@@ -160,6 +192,18 @@ test.describe("Connection dialog — validation", () => {
     await page.locator(".btn-test-conn").click();
     await expect(page.locator(".field-error", { hasText: "already exists" })).toBeVisible();
   });
+
+  test("test connection jumps to the first section with validation errors", async ({ page }) => {
+    await page.locator(".dialog input").first().fill("Needs Host");
+    await openDialogSection(page, "Connection");
+    await dialogField(page, /^Host$/).fill("");
+    await page.locator(".btn-test-conn").click();
+
+    await expect(page.locator(".connection-nav-item--active")).toContainText("Connection");
+    await expect(page.locator(".connection-nav-item--error", { hasText: "Connection" })).toBeVisible();
+    await expect(page.locator(".connection-nav-item--error", { hasText: "Authentication" })).toBeVisible();
+    await expect(page.locator(".field-error", { hasText: "Host is required" })).toBeVisible();
+  });
 });
 
 test.describe("Connection dialog — SSH tunnel section", () => {
@@ -169,18 +213,22 @@ test.describe("Connection dialog — SSH tunnel section", () => {
   });
 
   test("SSH section is visible for postgres and hidden for sqlite", async ({ page }) => {
+    await openDialogSection(page, "SSH Tunnel");
     await expect(
       page.locator(".ssh-tunnel-section .security-toggle__label", {
         hasText: "Use SSH tunneling",
       }),
     ).toBeVisible();
 
+    await openDialogSection(page, "General");
     await page.locator(".db-dropdown-trigger").click();
     await page.locator(".db-dropdown-item", { hasText: "SQLite" }).click();
+    await expect(page.locator(".connection-nav-item", { hasText: "SSH Tunnel" })).not.toBeVisible();
     await expect(page.locator(".ssh-tunnel-section")).not.toBeVisible();
   });
 
   test("toggling SSH on reveals tunnel host / port / username inputs", async ({ page }) => {
+    await openDialogSection(page, "SSH Tunnel");
     const tunnelToggle = page
       .locator(".ssh-tunnel-section .security-toggle")
       .first()
@@ -201,6 +249,7 @@ test.describe("Connection dialog — SSH tunnel section", () => {
   });
 
   test("auth toggle swaps Password input <-> Identity file picker", async ({ page }) => {
+    await openDialogSection(page, "SSH Tunnel");
     const tunnelToggle = page
       .locator(".ssh-tunnel-section .security-toggle")
       .first()
@@ -238,6 +287,7 @@ test.describe("Connection dialog — SSH tunnel section", () => {
   });
 
   test("'Prompt for passphrase' hides the passphrase input", async ({ page }) => {
+    await openDialogSection(page, "SSH Tunnel");
     const tunnelToggle = page
       .locator(".ssh-tunnel-section .security-toggle")
       .first()
@@ -258,19 +308,12 @@ test.describe("Connection dialog — SSH tunnel section", () => {
     // Fill in a name + DB connection details so the only outstanding errors
     // come from the SSH section.
     await page.locator(".dialog input").nth(0).fill("SSH Test");
-    await page
-      .locator(".dialog")
-      .locator("label", { hasText: "Host" })
-      .locator("..")
-      .locator("input")
-      .fill("127.0.0.1");
-    await page
-      .locator(".dialog")
-      .locator("label", { hasText: "Username" })
-      .locator("..")
-      .locator("input")
-      .fill("admin");
+    await openDialogSection(page, "Connection");
+    await dialogField(page, /^Host$/).fill("127.0.0.1");
+    await openDialogSection(page, "Authentication");
+    await dialogField(page, /^Username$/).fill("admin");
 
+    await openDialogSection(page, "SSH Tunnel");
     const tunnelToggle = page
       .locator(".ssh-tunnel-section .security-toggle")
       .first()
@@ -278,6 +321,7 @@ test.describe("Connection dialog — SSH tunnel section", () => {
     await tunnelToggle.check({ force: true });
     await page.locator(".btn-test-conn").click();
 
+    await expect(page.locator(".connection-nav-item--active")).toContainText("SSH Tunnel");
     await expect(
       page.locator(".ssh-tunnel-section .field-error", {
         hasText: "SSH host is required",
@@ -302,8 +346,10 @@ test.describe("Connection dialog — save and close", () => {
     await openConnectionDialog(page);
     const dialog = page.locator(".dialog");
     await dialog.locator("input").nth(0).fill("E2E Test DB");
-    await dialog.locator("input").nth(1).fill("127.0.0.1");
-    await dialog.locator("input").nth(3).fill("admin");
+    await openDialogSection(page, "Connection");
+    await dialogField(page, /^Host$/).fill("127.0.0.1");
+    await openDialogSection(page, "Authentication");
+    await dialogField(page, /^Username$/).fill("admin");
     await page.locator(".btn-primary", { hasText: "Save" }).click();
     await expect(page.locator(".dialog")).not.toBeVisible({ timeout: 3000 });
     await expect(page.locator(".tree-label", { hasText: "E2E Test DB" })).toBeVisible({ timeout: 3000 });

--- a/e2e/known-hosts.spec.ts
+++ b/e2e/known-hosts.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("SSH known hosts dialog", () => {
+  test("opens from the theme/settings menu and lists mock entries", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // The menu lives in the status bar; the icon button has the Palette
+    // icon and tooltip "Change Theme".
+    await page.getByRole("button", { name: "Change Theme" }).click();
+
+    // The Settings group contains the entry that opens the dialog.
+    await page.getByRole("button", { name: /SSH known hosts/i }).click();
+
+    // The dialog mounts via portal and is labelled accordingly.
+    const dialog = page.getByRole("dialog", { name: /SSH known hosts/i });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Host")).toBeVisible();
+    await expect(dialog.getByText("Fingerprint")).toBeVisible();
+    // The mock data ships two entries; either both render or the empty
+    // state is shown — assert the dialog body resolved to something.
+    const hasEntry = await dialog
+      .locator(".known-hosts-table tbody tr")
+      .count();
+    const hasEmpty = await dialog.locator(".known-hosts-dialog__empty").count();
+    expect(hasEntry + hasEmpty).toBeGreaterThan(0);
+  });
+
+  test("filter input narrows the visible rows", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Change Theme" }).click();
+    await page.getByRole("button", { name: /SSH known hosts/i }).click();
+    const dialog = page.getByRole("dialog", { name: /SSH known hosts/i });
+    await expect(dialog).toBeVisible();
+
+    // Wait for the listKnownHosts mock to resolve and the table body to
+    // populate. Up to 5s in case the mock latency is high in CI.
+    const firstRow = dialog.locator(".known-hosts-table tbody tr").first();
+    await expect(firstRow).toBeVisible({ timeout: 5000 });
+
+    await dialog
+      .getByLabel(/Filter known hosts/i)
+      .fill("definitely-no-such-host-zzz");
+    await expect(
+      dialog.getByText(/No entries match your filter/i),
+    ).toBeVisible();
+  });
+
+  test("Escape closes the dialog", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Change Theme" }).click();
+    await page.getByRole("button", { name: /SSH known hosts/i }).click();
+    const dialog = page.getByRole("dialog", { name: /SSH known hosts/i });
+    await expect(dialog).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+  });
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +106,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -148,6 +195,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +240,17 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
 
 [[package]]
 name = "bit-set"
@@ -208,12 +295,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -223,6 +328,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -387,12 +502,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -436,6 +562,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +584,25 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -547,6 +703,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-models"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0940496e5c83c54f3b753d5317daec82e8edac71c33aaa1f666d76f518de2444"
+dependencies = [
+ "hax-lib",
+ "pastey",
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,12 +771,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -659,6 +838,42 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
@@ -747,6 +962,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,7 +1063,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -938,12 +1170,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array 0.14.7",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -973,6 +1265,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1019,7 +1323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1058,6 +1362,22 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -1149,6 +1469,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1381,6 +1707,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
 ]
 
 [[package]]
@@ -1401,8 +1739,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1428,6 +1768,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1527,6 +1877,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1981,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "hax-lib"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d9ba66d1739c68e0219b2b2238b5c4145f491ebf181b9c6ab561a19352ae86"
+dependencies = [
+ "hax-lib-macros",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "hax-lib-macros"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ba777a231a58d1bce1d68313fa6b6afcc7966adef23d60f45b8a2b9b688bf1"
+dependencies = [
+ "hax-lib-macros-types",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "hax-lib-macros-types"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "867e19177d7425140b417cd27c2e05320e727ee682e98368f88b7194e80ad515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,6 +2034,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
@@ -1763,7 +2167,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1950,6 +2354,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "internal-russh-forked-ssh-key"
+version = "0.6.11+upstream-0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a77eae781ed6a7709fb15b64862fcca13d886b07c7e2786f5ed34e5e2b9187"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ecdsa",
+ "ed25519-dalek",
+ "hex",
+ "hmac",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,6 +2487,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -2150,6 +2602,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libcrux-intrinsics"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9ee7ef66569dd7516454fe26de4e401c0c62073929803486b96744594b9632"
+dependencies = [
+ "core-models",
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-ml-kem"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6a88086bf11bd2ec90926c749c4a427f2e59841437dbdede8cde8a96334ab"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand 0.9.2",
+ "tls_codec",
+]
+
+[[package]]
+name = "libcrux-platform"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db82d058aa76ea315a3b2092f69dfbd67ddb0e462038a206e1dcd73f058c0778"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libcrux-secrets"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4dbbf6bc9f2bc0f20dc3bea3e5c99adff3bdccf6d2a40488963da69e2ec307"
+dependencies = [
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-sha3"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2400bec764d1c75b8a496d5747cffe32f1fb864a12577f0aca2f55a92021c962"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-traits"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adfd58e79d860f6b9e40e35127bfae9e5bd3ade33201d1347459011a2add034"
+dependencies = [
+ "libcrux-secrets",
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2705,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2275,6 +2799,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -2376,6 +2906,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2930,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2605,6 +3158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +3174,63 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b537f975f6d8dcf48db368d7ec209d583b015713b5df0f5d92d2631e4ff5595"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.8.5",
+ "sha2",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows 0.62.2",
+ "windows-strings 0.5.1",
+]
 
 [[package]]
 name = "pango"
@@ -2668,6 +3284,33 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -2896,12 +3539,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki",
 ]
 
@@ -2941,6 +3601,29 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2987,6 +3670,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3040,6 +3732,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3360,6 +4074,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,7 +4117,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3440,10 +4164,98 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "sha2",
  "signature",
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "russh"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b4d036bb45d7bbe99dbfef4ec60eaeb614708d22ff107124272f8ef6b54548"
+dependencies = [
+ "aes",
+ "aws-lc-rs",
+ "bitflags 2.11.0",
+ "block-padding",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ctr",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der",
+ "digest",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.4.1",
+ "getrandom 0.2.17",
+ "hex-literal",
+ "hmac",
+ "home",
+ "inout",
+ "internal-russh-forked-ssh-key",
+ "libcrux-ml-kem",
+ "log",
+ "md5",
+ "num-bigint",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1",
+ "sha1",
+ "sha2",
+ "signature",
+ "spki",
+ "ssh-encoding",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb0ed583ff0f6b4aa44c7867dd7108df01b30571ee9423e250b4cc939f8c6cf"
+dependencies = [
+ "libc",
+ "log",
+ "nix",
+ "ssh-encoding",
+ "winapi",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3476,6 +4288,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3541,7 +4366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3552,7 +4377,7 @@ checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3566,6 +4391,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -3643,13 +4477,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3714,6 +4559,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array 0.14.7",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -4254,7 +5113,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "generic-array",
+ "generic-array 0.14.7",
  "hex",
  "hkdf",
  "hmac",
@@ -4343,6 +5202,35 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "pem-rfc7468",
+ "sha2",
 ]
 
 [[package]]
@@ -4511,6 +5399,8 @@ dependencies = [
  "async-trait",
  "chrono",
  "dirs",
+ "log",
+ "russh",
  "rust_decimal",
  "scylla",
  "serde",
@@ -4521,6 +5411,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tempfile",
  "thiserror 2.0.18",
  "tiberius",
  "tokio",
@@ -4864,6 +5755,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5007,6 +5911,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tokio"
@@ -5378,6 +6303,22 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -5788,7 +6729,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6588,6 +7529,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2708,6 +2708,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -4292,6 +4298,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4299,7 +4318,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -5418,6 +5437,7 @@ dependencies = [
  "tokio-util",
  "urlencoding",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -5763,7 +5783,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6698,6 +6718,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7291,6 +7323,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,3 +45,4 @@ log = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
+which = "6"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,3 +40,8 @@ scylla = "1.5"
 tiberius = { version = "0.12.3", default-features = false, features = ["tokio", "rustls", "tds73"] }
 tokio-util = { version = "0.7.18", features = ["compat"] }
 urlencoding = "2.1.3"
+russh = "0.55"
+log = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -3,6 +3,15 @@ use crate::models::*;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
+// TODO(ssh-tunnel): The pg_dump / mysqldump / pg_restore subprocesses below
+// still talk to the *raw* remote host/port from the saved
+// `ConnectionConfig`. When the connection has `ssh_enabled = true`, those
+// commands bypass the in-process russh tunnel managed by `PoolManager`
+// and will fail (or worse, leak credentials) for hosts only reachable via
+// the bastion. Tracked in a follow-up issue; the fix is to spawn a
+// short-lived russh tunnel here too and substitute `127.0.0.1:<local>`
+// before invoking the dump/restore binaries.
+
 fn emit_log(app: &AppHandle, line: &str) {
     let _ = app.emit("dump-restore-log", line.to_string());
 }

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -1,16 +1,19 @@
 use crate::db::pool::PoolManager;
+use crate::db::ssh_tunnel::{self, EffectiveTarget};
 use crate::models::*;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
-// TODO(ssh-tunnel): The pg_dump / mysqldump / pg_restore subprocesses below
-// still talk to the *raw* remote host/port from the saved
-// `ConnectionConfig`. When the connection has `ssh_enabled = true`, those
-// commands bypass the in-process russh tunnel managed by `PoolManager`
-// and will fail (or worse, leak credentials) for hosts only reachable via
-// the bastion. Tracked in a follow-up issue; the fix is to spawn a
-// short-lived russh tunnel here too and substitute `127.0.0.1:<local>`
-// before invoking the dump/restore binaries.
+/// Open an SSH tunnel for `config` if one is configured, returning the
+/// `host:port` the dump/restore subprocess should actually contact.
+///
+/// The returned [`EffectiveTarget`] keeps the russh session alive while the
+/// subprocess is running; dropping it shuts the bastion connection down.
+async fn effective_target(config: &ConnectionConfig) -> Result<EffectiveTarget, String> {
+    ssh_tunnel::open_for(config)
+        .await
+        .map_err(|e| format!("Failed to open SSH tunnel: {}", e))
+}
 
 fn emit_log(app: &AppHandle, line: &str) {
     let _ = app.emit("dump-restore-log", line.to_string());
@@ -75,13 +78,23 @@ pub async fn dump_and_restore(
         ),
     );
 
-    // pg_dump with --verbose to get progress output on stderr
+    let src_target = effective_target(&src_config).await?;
+    if src_config.ssh_enabled {
+        emit_log(
+            &app,
+            &format!(
+                "Routing pg_dump through SSH tunnel {}:{} → {}:{}",
+                src_config.ssh_host, src_config.ssh_port, src_config.host, src_config.port
+            ),
+        );
+    }
+
     let dump_status = {
         let mut cmd = tokio::process::Command::new("pg_dump");
         cmd.arg("-h")
-            .arg(&src_config.host)
+            .arg(&src_target.host)
             .arg("-p")
-            .arg(src_config.port.to_string())
+            .arg(src_target.port.to_string())
             .arg("-U")
             .arg(&src_config.user)
             .arg("-d")
@@ -101,6 +114,7 @@ pub async fn dump_and_restore(
             .await
             .map_err(|e| format!("pg_dump process error: {}", e))?
     };
+    drop(src_target);
 
     if !dump_status.success() {
         let _ = tokio::fs::remove_file(&tmp_path).await;
@@ -109,6 +123,17 @@ pub async fn dump_and_restore(
 
     emit_log(&app, "Dump complete. Starting pg_restore (transactional)…");
 
+    let tgt_target = effective_target(&tgt_config).await?;
+    if tgt_config.ssh_enabled {
+        emit_log(
+            &app,
+            &format!(
+                "Routing pg_restore through SSH tunnel {}:{} → {}:{}",
+                tgt_config.ssh_host, tgt_config.ssh_port, tgt_config.host, tgt_config.port
+            ),
+        );
+    }
+
     // First attempt: --single-transaction for atomic all-or-nothing restore.
     // If anything fails, the entire transaction is rolled back and the target
     // DB is left untouched. We skip --clean here because DROP commands inside
@@ -116,9 +141,9 @@ pub async fn dump_and_restore(
     let tx_status = {
         let mut cmd = tokio::process::Command::new("pg_restore");
         cmd.arg("-h")
-            .arg(&tgt_config.host)
+            .arg(&tgt_target.host)
             .arg("-p")
-            .arg(tgt_config.port.to_string())
+            .arg(tgt_target.port.to_string())
             .arg("-U")
             .arg(&tgt_config.user)
             .arg("-d")
@@ -141,6 +166,7 @@ pub async fn dump_and_restore(
     };
 
     if tx_status.success() {
+        drop(tgt_target);
         let _ = tokio::fs::remove_file(&tmp_path).await;
         emit_log(&app, "Restore complete (transactional).");
         return Ok(format!(
@@ -160,9 +186,9 @@ pub async fn dump_and_restore(
     let restore_status = {
         let mut cmd = tokio::process::Command::new("pg_restore");
         cmd.arg("-h")
-            .arg(&tgt_config.host)
+            .arg(&tgt_target.host)
             .arg("-p")
-            .arg(tgt_config.port.to_string())
+            .arg(tgt_target.port.to_string())
             .arg("-U")
             .arg(&tgt_config.user)
             .arg("-d")
@@ -182,6 +208,7 @@ pub async fn dump_and_restore(
             .await
             .map_err(|e| format!("pg_restore process error: {}", e))?
     };
+    drop(tgt_target);
 
     let _ = tokio::fs::remove_file(&tmp_path).await;
 
@@ -254,11 +281,13 @@ async fn backup_postgres(config: &ConnectionConfig, req: &BackupRequest) -> Resu
         return Err("Cannot use both schema-only and data-only at the same time".to_string());
     }
 
+    let target = effective_target(config).await?;
+
     let mut cmd = tokio::process::Command::new("pg_dump");
     cmd.arg("-h")
-        .arg(&config.host)
+        .arg(&target.host)
         .arg("-p")
-        .arg(config.port.to_string())
+        .arg(target.port.to_string())
         .arg("-U")
         .arg(&config.user)
         .arg("-d")
@@ -297,6 +326,7 @@ async fn backup_postgres(config: &ConnectionConfig, req: &BackupRequest) -> Resu
         .output()
         .await
         .map_err(|e| format!("Failed to run pg_dump: {}. Is it installed?", e))?;
+    drop(target);
 
     if output.status.success() {
         Ok(format!("Backup completed: {}", req.output_path))
@@ -312,12 +342,14 @@ async fn restore_postgres(
 ) -> Result<String, String> {
     let is_sql = req.format == "plain" || req.input_path.ends_with(".sql");
 
+    let target = effective_target(config).await?;
+
     if is_sql {
         let mut cmd = tokio::process::Command::new("psql");
         cmd.arg("-h")
-            .arg(&config.host)
+            .arg(&target.host)
             .arg("-p")
-            .arg(config.port.to_string())
+            .arg(target.port.to_string())
             .arg("-U")
             .arg(&config.user)
             .arg("-d")
@@ -330,6 +362,7 @@ async fn restore_postgres(
             .output()
             .await
             .map_err(|e| format!("Failed to run psql: {}", e))?;
+        drop(target);
         if output.status.success() {
             Ok("Restore completed".to_string())
         } else {
@@ -339,9 +372,9 @@ async fn restore_postgres(
     } else {
         let mut cmd = tokio::process::Command::new("pg_restore");
         cmd.arg("-h")
-            .arg(&config.host)
+            .arg(&target.host)
             .arg("-p")
-            .arg(config.port.to_string())
+            .arg(target.port.to_string())
             .arg("-U")
             .arg(&config.user)
             .arg("-d")
@@ -367,6 +400,7 @@ async fn restore_postgres(
             .output()
             .await
             .map_err(|e| format!("Failed to run pg_restore: {}", e))?;
+        drop(target);
         if output.status.success() {
             Ok("Restore completed".to_string())
         } else {
@@ -377,11 +411,13 @@ async fn restore_postgres(
 }
 
 async fn backup_mysql(config: &ConnectionConfig, req: &BackupRequest) -> Result<String, String> {
+    let target = effective_target(config).await?;
+
     let mut cmd = tokio::process::Command::new("mysqldump");
     cmd.arg("-h")
-        .arg(&config.host)
+        .arg(&target.host)
         .arg("-P")
-        .arg(config.port.to_string())
+        .arg(target.port.to_string())
         .arg("-u")
         .arg(&config.user)
         .arg(&req.database)
@@ -402,6 +438,7 @@ async fn backup_mysql(config: &ConnectionConfig, req: &BackupRequest) -> Result<
         .output()
         .await
         .map_err(|e| format!("Failed to run mysqldump: {}", e))?;
+    drop(target);
     if output.status.success() {
         Ok(format!("Backup completed: {}", req.output_path))
     } else {
@@ -411,11 +448,13 @@ async fn backup_mysql(config: &ConnectionConfig, req: &BackupRequest) -> Result<
 }
 
 async fn restore_mysql(config: &ConnectionConfig, req: &RestoreRequest) -> Result<String, String> {
+    let target = effective_target(config).await?;
+
     let mut cmd = tokio::process::Command::new("mysql");
     cmd.arg("-h")
-        .arg(&config.host)
+        .arg(&target.host)
         .arg("-P")
-        .arg(config.port.to_string())
+        .arg(target.port.to_string())
         .arg("-u")
         .arg(&config.user)
         .arg(&req.database);
@@ -444,6 +483,7 @@ async fn restore_mysql(config: &ConnectionConfig, req: &RestoreRequest) -> Resul
         .wait_with_output()
         .await
         .map_err(|e| format!("Failed: {}", e))?;
+    drop(target);
     if output.status.success() {
         Ok("Restore completed".to_string())
     } else {

--- a/src-tauri/src/commands/known_hosts.rs
+++ b/src-tauri/src/commands/known_hosts.rs
@@ -1,0 +1,291 @@
+//! Tauri commands backing the SSH "Known Hosts" management UI.
+//!
+//! These commands operate purely on Tablio's own `~/.tablio/known_hosts`
+//! file (resolved through [`crate::db::ssh_tunnel::known_hosts_path_pub`])
+//! and never touch the user's `~/.ssh/known_hosts`. The format is the
+//! standard OpenSSH `host [type] [base64-key]` form that `russh` writes.
+//!
+//! Parsing is intentionally tolerant: unknown / hashed / `@cert-authority`
+//! lines are preserved across rewrites but filtered out of the listing,
+//! since they can't be displayed (or matched by fingerprint) in a useful
+//! way.
+
+use russh::keys::{parse_public_key_base64, HashAlg};
+use serde::{Deserialize, Serialize};
+
+use crate::db::ssh_tunnel::known_hosts_path_pub;
+
+/// A single recognised entry in `~/.tablio/known_hosts` rendered for the
+/// frontend. The `fingerprint` is recomputed from the stored key so the UI
+/// can match what users see in the host-key-mismatch prompt.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KnownHostEntry {
+    pub host: String,
+    pub port: u16,
+    #[serde(rename = "keyType")]
+    pub key_type: String,
+    pub fingerprint: String,
+}
+
+#[tauri::command]
+pub async fn list_known_hosts() -> Result<Vec<KnownHostEntry>, String> {
+    let path = known_hosts_path_pub().map_err(|e| e.to_string())?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("Failed to read known_hosts: {e}"))?;
+    Ok(parse_known_hosts(&content))
+}
+
+#[tauri::command]
+pub async fn forget_known_host(host: String, port: u16, fingerprint: String) -> Result<(), String> {
+    let path = known_hosts_path_pub().map_err(|e| e.to_string())?;
+    if !path.exists() {
+        return Ok(());
+    }
+    let content = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("Failed to read known_hosts: {e}"))?;
+
+    let new_content = remove_entry(&content, &host, port, &fingerprint);
+
+    tokio::fs::write(&path, new_content)
+        .await
+        .map_err(|e| format!("Failed to write known_hosts: {e}"))?;
+    Ok(())
+}
+
+fn parse_known_hosts(content: &str) -> Vec<KnownHostEntry> {
+    content.lines().filter_map(parse_line).collect()
+}
+
+/// Rewrite `content` with any line whose parsed `(host, port, fingerprint)`
+/// triple matches the request removed. Comments, blank lines, and
+/// unparseable entries (hashed hosts, `@cert-authority`, multi-host blobs
+/// we don't recognise) are preserved verbatim so we never silently mutate
+/// state we don't fully understand.
+fn remove_entry(content: &str, host: &str, port: u16, fingerprint: &str) -> String {
+    let kept: Vec<&str> = content
+        .lines()
+        .filter(|line| match parse_line(line) {
+            Some(entry) => {
+                !(entry.host == host && entry.port == port && entry.fingerprint == fingerprint)
+            }
+            None => true,
+        })
+        .collect();
+    let mut out = kept.join("\n");
+    // Preserve trailing newline if the original had one (or if we still
+    // have any content) so the file stays POSIX-clean.
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+fn parse_line(line: &str) -> Option<KnownHostEntry> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let mut parts = trimmed.split_whitespace();
+    let host_field = parts.next()?;
+    let key_type = parts.next()?;
+    let key_b64 = parts.next()?;
+
+    // Skip hashed (|1|...) and marker (@cert-authority, @revoked) lines:
+    // we can't surface a host name to the user so they'd be useless in
+    // the dialog. They survive `remove_entry` because parse_line returns
+    // None and the filter keeps them.
+    if host_field.starts_with('|') || host_field.starts_with('@') {
+        return None;
+    }
+
+    let (host, port) = parse_host_field(host_field)?;
+    let key = parse_public_key_base64(key_b64).ok()?;
+    let fingerprint = format!("SHA256:{}", key.fingerprint(HashAlg::Sha256));
+    Some(KnownHostEntry {
+        host,
+        port,
+        key_type: key_type.to_string(),
+        fingerprint,
+    })
+}
+
+/// Parse the `host[,host…]` / `[host]:port` field at the start of a
+/// known_hosts line. Returns the *first* listed host (russh writes a
+/// single host per line, but we tolerate OpenSSH-style multi-host lines
+/// for hand-edited files) and the explicit port if present, defaulting
+/// to 22 otherwise.
+fn parse_host_field(field: &str) -> Option<(String, u16)> {
+    if let Some(stripped) = field.strip_prefix('[') {
+        let (host, rest) = stripped.split_once("]:")?;
+        let port: u16 = rest.parse().ok()?;
+        Some((host.to_string(), port))
+    } else if let Some(comma) = field.find(',') {
+        Some((field[..comma].to_string(), 22))
+    } else {
+        Some((field.to_string(), 22))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Two real ed25519 public keys from russh's test corpus. Their
+    // SHA-256 fingerprints are deterministic so we can assert on them.
+    const KEY_A: &str = "AAAAC3NzaC1lZDI1NTE5AAAAIJdD7y3aLq454yWBdwLWbieU1ebz9/cu7/QEXn9OIeZJ";
+    const KEY_B: &str = "AAAAC3NzaC1lZDI1NTE5AAAAILIG2T/B0l0gaqj3puu510tu9N1OkQ4znY3LYuEm5zCF";
+
+    fn fingerprint_of(b64: &str) -> String {
+        let key = parse_public_key_base64(b64).unwrap();
+        format!("SHA256:{}", key.fingerprint(HashAlg::Sha256))
+    }
+
+    #[test]
+    fn parses_default_port_entry() {
+        let line = format!("host.example ssh-ed25519 {KEY_A}");
+        let entry = parse_line(&line).expect("must parse");
+        assert_eq!(entry.host, "host.example");
+        assert_eq!(entry.port, 22);
+        assert_eq!(entry.key_type, "ssh-ed25519");
+        assert_eq!(entry.fingerprint, fingerprint_of(KEY_A));
+    }
+
+    #[test]
+    fn parses_explicit_port_entry() {
+        let line = format!("[bastion.internal]:2222 ssh-ed25519 {KEY_A}");
+        let entry = parse_line(&line).expect("must parse");
+        assert_eq!(entry.host, "bastion.internal");
+        assert_eq!(entry.port, 2222);
+    }
+
+    #[test]
+    fn skips_hashed_and_comment_lines() {
+        assert!(parse_line("").is_none());
+        assert!(parse_line("# my comment").is_none());
+        assert!(parse_line(&format!("|1|abc|def= ssh-ed25519 {KEY_A}")).is_none());
+        assert!(parse_line(&format!("@cert-authority ca ssh-ed25519 {KEY_A}")).is_none());
+    }
+
+    #[test]
+    fn skips_garbled_lines() {
+        assert!(parse_line("not enough fields").is_none());
+        assert!(parse_line("host ssh-ed25519 not-real-base64!!").is_none());
+        // Bracketed host without port is malformed.
+        assert!(parse_line(&format!("[host ssh-ed25519 {KEY_A}")).is_none());
+    }
+
+    #[test]
+    fn parses_multi_host_line_using_first_host() {
+        let line = format!("alias.example,host.example ssh-ed25519 {KEY_A}");
+        let entry = parse_line(&line).expect("must parse");
+        assert_eq!(entry.host, "alias.example");
+        assert_eq!(entry.port, 22);
+    }
+
+    #[test]
+    fn list_returns_only_recognised_entries() {
+        let content = format!(
+            "# managed by tablio\n\
+             host.example ssh-ed25519 {KEY_A}\n\
+             |1|hashed|line= ssh-ed25519 {KEY_A}\n\
+             [bastion]:2222 ssh-ed25519 {KEY_B}\n",
+        );
+        let entries = parse_known_hosts(&content);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].host, "host.example");
+        assert_eq!(entries[1].host, "bastion");
+        assert_eq!(entries[1].port, 2222);
+    }
+
+    #[test]
+    fn remove_entry_drops_only_matching_line() {
+        let fp_a = fingerprint_of(KEY_A);
+        let content = format!(
+            "host.example ssh-ed25519 {KEY_A}\n\
+             other.example ssh-ed25519 {KEY_B}\n",
+        );
+        let after = remove_entry(&content, "host.example", 22, &fp_a);
+        assert!(
+            !after.contains("host.example"),
+            "matching entry should be removed: {after}"
+        );
+        assert!(
+            after.contains("other.example"),
+            "non-matching entry must survive: {after}"
+        );
+        assert!(after.ends_with('\n'), "trailing newline preserved");
+    }
+
+    #[test]
+    fn remove_entry_preserves_unparseable_lines() {
+        let fp_a = fingerprint_of(KEY_A);
+        let content = format!(
+            "# tablio managed\n\
+             |1|hashed|line= ssh-ed25519 {KEY_A}\n\
+             host.example ssh-ed25519 {KEY_A}\n",
+        );
+        let after = remove_entry(&content, "host.example", 22, &fp_a);
+        assert!(after.contains("# tablio managed"));
+        assert!(after.contains("|1|hashed|line="));
+        assert!(!after.contains("host.example"));
+    }
+
+    #[test]
+    fn remove_entry_no_match_leaves_content_unchanged_modulo_newline() {
+        let fp_b = fingerprint_of(KEY_B);
+        let content = format!("host.example ssh-ed25519 {KEY_A}\n");
+        let after = remove_entry(&content, "host.example", 22, &fp_b);
+        // Same fingerprint mismatch -> entry must survive.
+        assert!(after.contains("host.example"));
+    }
+
+    #[test]
+    fn round_trip_list_then_forget() {
+        let fp_a = fingerprint_of(KEY_A);
+        let fp_b = fingerprint_of(KEY_B);
+        let content = format!(
+            "host.example ssh-ed25519 {KEY_A}\n\
+             [bastion]:2222 ssh-ed25519 {KEY_B}\n",
+        );
+        let entries = parse_known_hosts(&content);
+        assert_eq!(entries.len(), 2);
+        let host_to_forget = &entries[0];
+        let after = remove_entry(
+            &content,
+            &host_to_forget.host,
+            host_to_forget.port,
+            &host_to_forget.fingerprint,
+        );
+        let remaining = parse_known_hosts(&after);
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].host, "bastion");
+        assert_eq!(remaining[0].fingerprint, fp_b);
+        // And forgetting an already-removed entry is a no-op.
+        let after_again = remove_entry(&after, &host_to_forget.host, 22, &fp_a);
+        assert_eq!(after_again, after);
+    }
+
+    #[test]
+    fn entry_serialises_with_camelcase_key_type() {
+        let entry = KnownHostEntry {
+            host: "h".into(),
+            port: 22,
+            key_type: "ssh-ed25519".into(),
+            fingerprint: "SHA256:xyz".into(),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        // The TS contract uses `keyType`; serde rename guards against
+        // accidental drift.
+        assert!(
+            json.contains("\"keyType\":\"ssh-ed25519\""),
+            "expected keyType in JSON, got {json}"
+        );
+        let back: KnownHostEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, entry);
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod backup;
 pub mod connection;
 pub mod data;
 pub mod export;
+pub mod known_hosts;
 pub mod query;
 pub mod roles;
 pub mod saved_queries;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,4 +7,5 @@ pub mod query;
 pub mod roles;
 pub mod saved_queries;
 pub mod schema;
+pub mod ssh_config;
 pub mod system;

--- a/src-tauri/src/commands/ssh_config.rs
+++ b/src-tauri/src/commands/ssh_config.rs
@@ -1,0 +1,319 @@
+//! Lightweight read-only parser for `~/.ssh/config`.
+//!
+//! The goal is to let the connection dialog auto-fill the SSH section
+//! when a user types a host alias they already use from a terminal
+//! (e.g. `ssh prod-bastion`). We support the most common, unambiguous
+//! directives and ignore everything else:
+//!
+//! * `HostName <fqdn>`
+//! * `Port <num>`
+//! * `User <name>`
+//! * `IdentityFile <path>`
+//!
+//! Match wildcards (`*`, `?`) inside `Host` lines are honoured. `Match`
+//! blocks, `Include` directives, `ProxyJump`, and any other advanced
+//! features are deliberately out of scope — they require a
+//! shell-evaluation + transitive lookup engine that doesn't fit in a
+//! one-shot dialog assist. The frontend surfaces a clear "advanced
+//! directives ignored" hint when those are present.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Resolved subset of a `~/.ssh/config` entry. Every field is optional
+/// because real configs frequently set only a couple of these.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ResolvedSshHost {
+    /// `Host` value that matched (the literal, not the resolved hostname).
+    pub alias: String,
+    #[serde(rename = "hostName")]
+    pub host_name: Option<String>,
+    pub port: Option<u16>,
+    pub user: Option<String>,
+    /// Tilde-expanded absolute path when present.
+    #[serde(rename = "identityFile")]
+    pub identity_file: Option<String>,
+    /// True when the matching block (or any block we walked through to
+    /// fill in defaults) referenced an unsupported directive
+    /// (`ProxyJump`, `Match`, `Include`, ...). The UI uses this to warn
+    /// that the auto-fill may be incomplete.
+    #[serde(rename = "hasUnsupportedDirectives")]
+    pub has_unsupported_directives: bool,
+}
+
+fn config_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".ssh").join("config"))
+}
+
+fn expand_tilde(path: &str) -> String {
+    if let Some(stripped) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(stripped).to_string_lossy().into_owned();
+        }
+    } else if path == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home.to_string_lossy().into_owned();
+        }
+    }
+    path.to_string()
+}
+
+/// Glob-style match of `pat` against `name` for the OpenSSH-style `*`
+/// and `?` wildcards. `!pattern` negation is handled by the caller.
+fn glob_match(pat: &str, name: &str) -> bool {
+    fn rec(p: &[u8], n: &[u8]) -> bool {
+        match (p.first(), n.first()) {
+            (None, None) => true,
+            (Some(b'*'), _) => {
+                // `*` matches zero or more chars.
+                if rec(&p[1..], n) {
+                    return true;
+                }
+                if !n.is_empty() && rec(p, &n[1..]) {
+                    return true;
+                }
+                false
+            }
+            (Some(b'?'), Some(_)) => rec(&p[1..], &n[1..]),
+            (Some(a), Some(b)) if a.eq_ignore_ascii_case(b) => rec(&p[1..], &n[1..]),
+            _ => false,
+        }
+    }
+    rec(pat.as_bytes(), name.as_bytes())
+}
+
+/// `Host pat1 pat2 !pat3 ...` — match if any positive pattern matches
+/// AND no negated pattern matches.
+fn host_line_matches(patterns: &[&str], target: &str) -> bool {
+    let mut any_positive = false;
+    for p in patterns {
+        if let Some(neg) = p.strip_prefix('!') {
+            if glob_match(neg, target) {
+                return false;
+            }
+        } else if glob_match(p, target) {
+            any_positive = true;
+        }
+    }
+    any_positive
+}
+
+/// Parse the contents of an SSH config file and resolve `target`.
+///
+/// Returns `None` if the file has no `Host` block whose patterns match
+/// `target`. When multiple blocks match (e.g. a specific block plus a
+/// `Host *` block), values from the more specific block win — OpenSSH
+/// uses "first match wins per directive", which is what we implement by
+/// walking blocks top-down and only filling fields that are still empty.
+pub fn resolve_target(content: &str, target: &str) -> Option<ResolvedSshHost> {
+    let mut active_match = false;
+    let mut resolved = ResolvedSshHost::default();
+    let mut matched_any = false;
+
+    for raw in content.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Tokenise on whitespace; OpenSSH also accepts `Key = value` so
+        // strip a leading `=` from the second token.
+        let mut parts = line.splitn(2, |c: char| c.is_whitespace() || c == '=');
+        let key = match parts.next() {
+            Some(k) => k.to_ascii_lowercase(),
+            None => continue,
+        };
+        let value = parts
+            .next()
+            .unwrap_or("")
+            .trim()
+            .trim_start_matches('=')
+            .trim();
+
+        match key.as_str() {
+            "host" => {
+                let patterns: Vec<&str> = value.split_whitespace().collect();
+                active_match = host_line_matches(&patterns, target);
+                if active_match {
+                    matched_any = true;
+                    // Record the most-specific (i.e. first) matching alias.
+                    if resolved.alias.is_empty() {
+                        resolved.alias = patterns
+                            .iter()
+                            .find(|p| !p.starts_with('!') && !p.contains('*') && !p.contains('?'))
+                            .map(|s| s.to_string())
+                            .unwrap_or_else(|| target.to_string());
+                    }
+                }
+            }
+            "match" => {
+                // `Match` blocks need shell expansion; we can't honour
+                // them. Mark the entry so the UI shows a warning.
+                active_match = false;
+                resolved.has_unsupported_directives = true;
+            }
+            "include" | "proxyjump" | "proxycommand" => {
+                if active_match {
+                    resolved.has_unsupported_directives = true;
+                }
+            }
+            "hostname" if active_match && resolved.host_name.is_none() => {
+                resolved.host_name = Some(value.to_string());
+            }
+            "port" if active_match && resolved.port.is_none() => {
+                if let Ok(p) = value.parse::<u16>() {
+                    resolved.port = Some(p);
+                }
+            }
+            "user" if active_match && resolved.user.is_none() => {
+                resolved.user = Some(value.to_string());
+            }
+            "identityfile" if active_match && resolved.identity_file.is_none() => {
+                // Strip optional surrounding quotes — OpenSSH allows them.
+                let v = value.trim_matches(|c| c == '"' || c == '\'');
+                resolved.identity_file = Some(expand_tilde(v));
+            }
+            _ => {}
+        }
+    }
+
+    if matched_any {
+        Some(resolved)
+    } else {
+        None
+    }
+}
+
+/// Tauri command: look up `alias` in the user's `~/.ssh/config`.
+///
+/// Returns `Ok(None)` when the file doesn't exist or no Host block
+/// matches. Errors are reserved for hard IO failures (permission denied
+/// etc.) so the dialog can keep working when the user simply has no
+/// config.
+#[tauri::command]
+pub fn ssh_config_lookup(alias: String) -> Result<Option<ResolvedSshHost>, String> {
+    let alias = alias.trim();
+    if alias.is_empty() {
+        return Ok(None);
+    }
+    let path = match config_path() {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    Ok(resolve_target(&content, alias))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_basic() {
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("foo", "foo"));
+        assert!(!glob_match("foo", "bar"));
+        assert!(glob_match("prod-*", "prod-bastion"));
+        assert!(glob_match("*.example.com", "host.example.com"));
+        assert!(!glob_match("*.example.com", "example.com"));
+        assert!(glob_match("host?", "hosta"));
+        assert!(!glob_match("host?", "host"));
+        assert!(glob_match("Foo", "foo"), "case-insensitive");
+    }
+
+    #[test]
+    fn host_line_negation_filters_out_match() {
+        let pats = vec!["prod-*", "!prod-secret"];
+        assert!(host_line_matches(&pats, "prod-web"));
+        assert!(!host_line_matches(&pats, "prod-secret"));
+    }
+
+    #[test]
+    fn resolve_returns_none_when_no_match() {
+        let cfg = "Host other\n  HostName x.example.com\n";
+        assert!(resolve_target(cfg, "prod-bastion").is_none());
+    }
+
+    #[test]
+    fn resolve_specific_block_wins_over_wildcard() {
+        let cfg = "\
+Host prod-bastion
+  HostName 10.0.0.5
+  User admin
+  Port 2222
+  IdentityFile ~/.ssh/prod_ed25519
+
+Host *
+  User defaultuser
+  IdentityFile ~/.ssh/id_rsa
+";
+        let r = resolve_target(cfg, "prod-bastion").expect("must match");
+        assert_eq!(r.host_name.as_deref(), Some("10.0.0.5"));
+        assert_eq!(r.port, Some(2222));
+        assert_eq!(r.user.as_deref(), Some("admin"));
+        // First-match-wins per directive: the specific block's
+        // IdentityFile must be preferred even though `Host *` also has
+        // one.
+        let id = r.identity_file.as_deref().unwrap();
+        assert!(id.ends_with("prod_ed25519"), "got {id}");
+    }
+
+    #[test]
+    fn resolve_wildcard_block_supplies_defaults() {
+        // The specific block intentionally has only HostName so the
+        // wildcard block's User/IdentityFile fill the gaps.
+        let cfg = "\
+Host stage
+  HostName stage.example.com
+
+Host *
+  User deploy
+  IdentityFile ~/.ssh/id_ed25519
+";
+        let r = resolve_target(cfg, "stage").expect("must match");
+        assert_eq!(r.host_name.as_deref(), Some("stage.example.com"));
+        assert_eq!(r.user.as_deref(), Some("deploy"));
+        assert!(r
+            .identity_file
+            .as_deref()
+            .map(|p| p.ends_with("id_ed25519"))
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn resolve_flags_unsupported_directives() {
+        let cfg = "\
+Host bastion
+  HostName 10.0.0.1
+  ProxyJump jumpbox
+";
+        let r = resolve_target(cfg, "bastion").expect("must match");
+        assert_eq!(r.host_name.as_deref(), Some("10.0.0.1"));
+        assert!(
+            r.has_unsupported_directives,
+            "ProxyJump must be flagged as unsupported"
+        );
+    }
+
+    #[test]
+    fn resolve_handles_equals_separator() {
+        let cfg = "Host foo\n  HostName=10.0.0.42\n  Port=2200\n";
+        let r = resolve_target(cfg, "foo").expect("must match");
+        assert_eq!(r.host_name.as_deref(), Some("10.0.0.42"));
+        assert_eq!(r.port, Some(2200));
+    }
+
+    #[test]
+    fn negated_pattern_excludes_target() {
+        let cfg = "\
+Host prod-* !prod-secret
+  HostName 10.0.0.10
+  User admin
+";
+        assert!(resolve_target(cfg, "prod-web").is_some());
+        assert!(resolve_target(cfg, "prod-secret").is_none());
+    }
+}

--- a/src-tauri/src/commands/ssh_config.rs
+++ b/src-tauri/src/commands/ssh_config.rs
@@ -151,10 +151,8 @@ pub fn resolve_target(content: &str, target: &str) -> Option<ResolvedSshHost> {
                 active_match = false;
                 resolved.has_unsupported_directives = true;
             }
-            "include" | "proxyjump" | "proxycommand" => {
-                if active_match {
-                    resolved.has_unsupported_directives = true;
-                }
+            "include" | "proxyjump" | "proxycommand" if active_match => {
+                resolved.has_unsupported_directives = true;
             }
             "hostname" if active_match && resolved.host_name.is_none() => {
                 resolved.host_name = Some(value.to_string());

--- a/src-tauri/src/db/cockroachdb.rs
+++ b/src-tauri/src/db/cockroachdb.rs
@@ -545,6 +545,8 @@ mod tests {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         }
     }
 

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -8,6 +8,7 @@ pub mod pg_common;
 pub mod pool;
 pub mod postgres;
 pub mod sqlite;
+pub mod ssh_tunnel;
 pub mod tidb;
 
 use crate::models::*;

--- a/src-tauri/src/db/pool.rs
+++ b/src-tauri/src/db/pool.rs
@@ -10,14 +10,10 @@ use crate::db::mssql::MssqlDriver;
 use crate::db::mysql::MysqlDriver;
 use crate::db::postgres::PostgresDriver;
 use crate::db::sqlite::SqliteDriver;
+use crate::db::ssh_tunnel::{self, SshTunnel};
 use crate::db::tidb::TidbDriver;
 use crate::db::DatabaseDriver;
 use crate::models::*;
-
-struct SshTunnel {
-    child: tokio::process::Child,
-    local_port: u16,
-}
 
 pub struct PoolManager {
     connections: RwLock<HashMap<String, Arc<dyn DatabaseDriver>>>,
@@ -40,86 +36,17 @@ impl PoolManager {
         }
     }
 
-    async fn setup_ssh_tunnel(config: &ConnectionConfig) -> Result<SshTunnel> {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-        let local_port = listener.local_addr()?.port();
-        drop(listener);
-
-        let remote = format!("{}:{}", config.host, config.port);
-        let local = format!("127.0.0.1:{}", local_port);
-        let ssh_dest = if config.ssh_user.is_empty() {
-            config.ssh_host.clone()
-        } else {
-            format!("{}@{}", config.ssh_user, config.ssh_host)
-        };
-
-        let mut cmd = tokio::process::Command::new("ssh");
-        cmd.arg("-N")
-            .arg("-L")
-            .arg(format!("{}:{}", local, remote))
-            .arg(&ssh_dest)
-            .arg("-p")
-            .arg(config.ssh_port.to_string())
-            .arg("-o")
-            .arg("StrictHostKeyChecking=accept-new")
-            .arg("-o")
-            .arg("ExitOnForwardFailure=yes");
-
-        if !config.ssh_key_path.is_empty() {
-            cmd.arg("-i").arg(&config.ssh_key_path);
-        }
-
-        cmd.stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped());
-
-        let mut child = cmd.spawn().map_err(|e| {
-            anyhow!(
-                "Failed to start SSH tunnel: {}. Make sure 'ssh' is available.",
-                e
-            )
-        })?;
-
-        tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
-
-        for _ in 0..10 {
-            if tokio::net::TcpStream::connect(format!("127.0.0.1:{}", local_port))
-                .await
-                .is_ok()
-            {
-                return Ok(SshTunnel { child, local_port });
-            }
-            tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-        }
-
-        let stderr_output = if let Some(mut stderr) = child.stderr.take() {
-            use tokio::io::AsyncReadExt;
-            let mut buf = String::new();
-            let _ = stderr.read_to_string(&mut buf).await;
-            buf
-        } else {
-            String::new()
-        };
-        let _ = child.kill().await;
-        if stderr_output.is_empty() {
-            Err(anyhow!("SSH tunnel failed to become ready within timeout"))
-        } else {
-            Err(anyhow!("SSH tunnel failed: {}", stderr_output.trim()))
-        }
-    }
-
     pub async fn connect(&self, config: ConnectionConfig) -> Result<String> {
         let id = config.id.clone();
 
-        // Clean up any existing connection and tunnel for this id
-        if let Some(mut old_tunnel) = self.ssh_tunnels.write().await.remove(&id) {
-            let _ = old_tunnel.child.kill().await;
-        }
+        // Clean up any existing connection and tunnel for this id. Dropping
+        // the SshTunnel below shuts down its accept loop and SSH session.
+        let _old_tunnel = self.ssh_tunnels.write().await.remove(&id);
         self.connections.write().await.remove(&id);
 
         let effective_config = if config.ssh_enabled && !config.ssh_host.is_empty() {
-            let tunnel = Self::setup_ssh_tunnel(&config).await?;
-            let local_port = tunnel.local_port;
+            let tunnel = ssh_tunnel::open(&config).await?;
+            let local_port = tunnel.local_port();
             self.ssh_tunnels.write().await.insert(id.clone(), tunnel);
             ConnectionConfig {
                 host: "127.0.0.1".to_string(),
@@ -160,9 +87,9 @@ impl PoolManager {
         let driver = match driver_result {
             Ok(d) => d,
             Err(e) => {
-                if let Some(mut tunnel) = self.ssh_tunnels.write().await.remove(&id) {
-                    let _ = tunnel.child.kill().await;
-                }
+                // Drop the tunnel (if any) to release the russh session and
+                // forwarding task before returning the driver error.
+                let _ = self.ssh_tunnels.write().await.remove(&id);
                 return Err(e);
             }
         };
@@ -175,9 +102,8 @@ impl PoolManager {
     pub async fn disconnect(&self, id: &str) -> Result<()> {
         self.connections.write().await.remove(id);
         self.configs.write().await.remove(id);
-        if let Some(mut tunnel) = self.ssh_tunnels.write().await.remove(id) {
-            let _ = tunnel.child.kill().await;
-        }
+        // Drop the SshTunnel (if any) to shut down the russh session.
+        let _ = self.ssh_tunnels.write().await.remove(id);
         Ok(())
     }
 
@@ -200,11 +126,13 @@ impl PoolManager {
     }
 
     pub async fn test_connection(config: &ConnectionConfig) -> Result<bool> {
-        let mut tunnel_handle: Option<SshTunnel> = None;
+        // Tunnel is owned by this scope; its Drop shuts the russh session
+        // down once the test completes (or panics).
+        let mut _tunnel_guard: Option<SshTunnel> = None;
         let effective_config = if config.ssh_enabled && !config.ssh_host.is_empty() {
-            let tunnel = Self::setup_ssh_tunnel(config).await?;
-            let local_port = tunnel.local_port;
-            tunnel_handle = Some(tunnel);
+            let tunnel = ssh_tunnel::open(config).await?;
+            let local_port = tunnel.local_port();
+            _tunnel_guard = Some(tunnel);
             ConnectionConfig {
                 host: "127.0.0.1".to_string(),
                 port: local_port,
@@ -214,27 +142,17 @@ impl PoolManager {
             config.clone()
         };
 
-        let result = async {
-            let driver: Box<dyn DatabaseDriver> = match effective_config.db_type {
-                DbType::Postgres => Box::new(PostgresDriver::connect(&effective_config).await?),
-                DbType::Cockroachdb => {
-                    Box::new(CockroachdbDriver::connect(&effective_config).await?)
-                }
-                DbType::Mysql => Box::new(MysqlDriver::connect(&effective_config).await?),
-                DbType::Mariadb => Box::new(MariadbDriver::connect(&effective_config).await?),
-                DbType::Tidb => Box::new(TidbDriver::connect(&effective_config).await?),
-                DbType::Sqlite => Box::new(SqliteDriver::connect(&effective_config).await?),
-                DbType::Cassandra => Box::new(CassandraDriver::connect(&effective_config).await?),
-                DbType::Mssql => Box::new(MssqlDriver::connect(&effective_config).await?),
-            };
-            driver.test_connection().await
-        }
-        .await;
-
-        if let Some(mut t) = tunnel_handle {
-            let _ = t.child.kill().await;
-        }
-        result
+        let driver: Box<dyn DatabaseDriver> = match effective_config.db_type {
+            DbType::Postgres => Box::new(PostgresDriver::connect(&effective_config).await?),
+            DbType::Cockroachdb => Box::new(CockroachdbDriver::connect(&effective_config).await?),
+            DbType::Mysql => Box::new(MysqlDriver::connect(&effective_config).await?),
+            DbType::Mariadb => Box::new(MariadbDriver::connect(&effective_config).await?),
+            DbType::Tidb => Box::new(TidbDriver::connect(&effective_config).await?),
+            DbType::Sqlite => Box::new(SqliteDriver::connect(&effective_config).await?),
+            DbType::Cassandra => Box::new(CassandraDriver::connect(&effective_config).await?),
+            DbType::Mssql => Box::new(MssqlDriver::connect(&effective_config).await?),
+        };
+        driver.test_connection().await
     }
 
     pub async fn is_connected(&self, id: &str) -> bool {

--- a/src-tauri/src/db/postgres.rs
+++ b/src-tauri/src/db/postgres.rs
@@ -667,6 +667,8 @@ mod tests {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         }
     }
 

--- a/src-tauri/src/db/ssh_tunnel.rs
+++ b/src-tauri/src/db/ssh_tunnel.rs
@@ -247,8 +247,25 @@ pub async fn open(config: &ConnectionConfig) -> Result<SshTunnel> {
     let handler = KnownHostsHandler::new(known_hosts, config.ssh_host.clone(), config.ssh_port);
     let mismatch_slot = handler.mismatch.clone();
 
+    // Liveness policy:
+    //
+    // * `inactivity_timeout = None` — a quiet but live SQL session must not
+    //   be torn down just because no bytes flowed for a minute. The
+    //   previous `Some(60s)` killed idle pool connections silently.
+    // * `keepalive_interval = 30s` + `keepalive_max = 4` — send an SSH
+    //   keepalive every 30s and close the session if the server fails to
+    //   respond to four in a row (~2 minutes of dead network). This
+    //   mirrors OpenSSH's `ServerAliveInterval=30` / `ServerAliveCountMax=3`
+    //   convention and protects long-lived pools across NAT timeouts and
+    //   bastion-side idle disconnects.
+    //
+    // Auto-reconnect (re-establish the session and replay listeners after
+    // a forced disconnect) is tracked separately; today we tear the
+    // tunnel down and the user reconnects via the UI.
     let ssh_config = Arc::new(client::Config {
-        inactivity_timeout: Some(Duration::from_secs(60)),
+        inactivity_timeout: None,
+        keepalive_interval: Some(Duration::from_secs(30)),
+        keepalive_max: 4,
         ..Default::default()
     });
 
@@ -327,6 +344,7 @@ async fn authenticate(
                 .await
                 .context("SSH public key authentication failed")?
         }
+        SshAuthMethod::Agent => return authenticate_with_agent(session, &user).await,
     };
 
     match auth {
@@ -338,6 +356,99 @@ async fn authenticate(
             remaining_methods
         )),
     }
+}
+
+/// Authenticate via the local ssh-agent.
+///
+/// Tries every identity the agent has loaded, in order, until one succeeds.
+/// Returns a clear error if the agent is unreachable, has no identities
+/// loaded, or the bastion rejects every identity.
+async fn authenticate_with_agent(
+    session: &mut Handle<KnownHostsHandler>,
+    user: &str,
+) -> Result<()> {
+    let mut agent = connect_agent()
+        .await
+        .context("Could not connect to ssh-agent")?;
+
+    let identities = agent
+        .request_identities()
+        .await
+        .context("ssh-agent did not return its identity list")?;
+
+    if identities.is_empty() {
+        return Err(anyhow!(
+            "ssh-agent has no identities loaded. Run `ssh-add <key>` and try again."
+        ));
+    }
+
+    let mut last_failure: Option<String> = None;
+    for key in identities {
+        let res = session
+            .authenticate_publickey_with(user, key.clone(), Some(HashAlg::Sha256), &mut agent)
+            .await;
+        match res {
+            Ok(AuthResult::Success) => return Ok(()),
+            Ok(AuthResult::Failure {
+                remaining_methods, ..
+            }) => {
+                last_failure = Some(format!(
+                    "agent key {} rejected (server still allows: {:?})",
+                    key.fingerprint(HashAlg::Sha256),
+                    remaining_methods
+                ));
+                log::debug!(
+                    "ssh-agent key {} rejected by {}",
+                    key.fingerprint(HashAlg::Sha256),
+                    user
+                );
+            }
+            Err(e) => {
+                last_failure = Some(format!(
+                    "agent key {} signing/auth error: {}",
+                    key.fingerprint(HashAlg::Sha256),
+                    e
+                ));
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "SSH authentication via ssh-agent failed: every loaded identity was rejected. {}",
+        last_failure.unwrap_or_default()
+    ))
+}
+
+/// Connect to the local ssh-agent.
+///
+/// On Linux / macOS this resolves `SSH_AUTH_SOCK`. On Windows it falls
+/// back to Pageant. Returns a friendly error if no agent is reachable so
+/// the UI can suggest enabling an agent / loading a key.
+#[cfg(not(target_os = "windows"))]
+async fn connect_agent() -> Result<russh::keys::agent::client::AgentClient<tokio::net::UnixStream>>
+{
+    if std::env::var_os("SSH_AUTH_SOCK").is_none() {
+        return Err(anyhow!(
+            "SSH_AUTH_SOCK is not set; start ssh-agent (or pick a different authentication method)"
+        ));
+    }
+    russh::keys::agent::client::AgentClient::connect_env()
+        .await
+        .map_err(|e| anyhow!("Failed to talk to ssh-agent at SSH_AUTH_SOCK: {}", e))
+}
+
+#[cfg(target_os = "windows")]
+async fn connect_agent(
+) -> Result<russh::keys::agent::client::AgentClient<tokio::net::windows::named_pipe::NamedPipeClient>>
+{
+    russh::keys::agent::client::AgentClient::connect_pageant()
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "Failed to talk to Pageant: {}. Is Pageant running and a key loaded?",
+                e
+            )
+        })
 }
 
 async fn load_secret_key(path: &str, passphrase: &str) -> Result<russh::keys::PrivateKey> {
@@ -600,6 +711,38 @@ CUrE7QRAvdVpD5e3zKH/MZjilWrMOm6cyI1LKBCssLztPyvOALtroLAPlp7WYWfu\n\
             info.fingerprint
         );
         assert_eq!(info.known_hosts_path, kh.to_string_lossy());
+    }
+
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn agent_auth_reports_missing_auth_sock() {
+        // When `SSH_AUTH_SOCK` is unset on Linux/macOS we must surface a
+        // clear, actionable error rather than letting the russh
+        // connector fail with a cryptic `connection refused`.
+        // We can't mutate process env safely in a multi-threaded test
+        // runner, so call `connect_agent` directly with the env we want.
+        let prev = std::env::var("SSH_AUTH_SOCK").ok();
+        // SAFETY: the `unsafe` here is a quirk of the std API in newer
+        // Rust editions; in-test-only mutation is acceptable because the
+        // scope is tightly controlled and each test asserts and restores.
+        unsafe {
+            std::env::remove_var("SSH_AUTH_SOCK");
+        }
+        let err = connect_agent()
+            .await
+            .err()
+            .expect("missing SSH_AUTH_SOCK must surface an error");
+        assert!(
+            err.to_string().contains("SSH_AUTH_SOCK"),
+            "error should mention SSH_AUTH_SOCK; got {err}"
+        );
+        // Restore the env var so other tests in the same process see the
+        // same shell-inherited state they expect.
+        if let Some(v) = prev {
+            unsafe {
+                std::env::set_var("SSH_AUTH_SOCK", v);
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/db/ssh_tunnel.rs
+++ b/src-tauri/src/db/ssh_tunnel.rs
@@ -1,0 +1,455 @@
+//! In-process SSH tunnel powered by [`russh`].
+//!
+//! Replaces the historical implementation that shelled out to the system `ssh`
+//! binary. Goals:
+//!
+//! - **No external `ssh` requirement.** Pure-Rust client, runs on every Tauri
+//!   target out of the box.
+//! - **Real password auth.** The previous OpenSSH-subprocess approach silently
+//!   ignored `ssh_password`; this module passes it to russh's
+//!   `authenticate_password`.
+//! - **Encrypted-key passphrases.** Uses `russh::keys::decode_secret_key` so
+//!   protected OpenSSH keys can be opened with the user's passphrase.
+//! - **Trust-on-first-use host-key verification.** A separate
+//!   `~/.tablio/known_hosts` file is consulted (and grown) so we don't
+//!   stomp on the user's `~/.ssh/known_hosts`. A mismatched key is a hard
+//!   error that includes the new server fingerprint.
+//!
+//! The public surface is intentionally small: [`open`] returns a [`SshTunnel`]
+//! whose `Drop` impl shuts everything down. The driver layer should treat the
+//! tunnel as opaque and connect to `127.0.0.1:tunnel.local_port()`.
+
+use anyhow::{anyhow, Context, Result};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use russh::client::{self, AuthResult, Handle};
+use russh::keys::known_hosts::{check_known_hosts_path, learn_known_hosts_path};
+use russh::keys::{decode_secret_key, HashAlg, PrivateKeyWithHashAlg, PublicKey};
+
+use crate::models::{ConnectionConfig, SshAuthMethod};
+
+/// A live SSH tunnel.
+///
+/// Owns the local TCP listener task and the russh session. Dropping the
+/// tunnel aborts the accept loop and disconnects the SSH session.
+pub struct SshTunnel {
+    local_port: u16,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl SshTunnel {
+    pub fn local_port(&self) -> u16 {
+        self.local_port
+    }
+}
+
+impl Drop for SshTunnel {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(h) = self.task.take() {
+            h.abort();
+        }
+    }
+}
+
+/// Verifier that consults a Tablio-owned known_hosts file.
+///
+/// On first contact the server key is recorded; on later connections a
+/// changed key is rejected with a clear error and *not* silently accepted.
+struct KnownHostsHandler {
+    path: PathBuf,
+    host: String,
+    port: u16,
+}
+
+impl KnownHostsHandler {
+    fn fingerprint(key: &PublicKey) -> String {
+        // SHA-256 base64 fingerprint, formatted like OpenSSH ("SHA256:...").
+        // `PublicKeyBase64` exposes the wire-format bytes; we hash them ourselves
+        // to avoid pulling in another digest crate.
+        format!("SHA256:{}", key.fingerprint(HashAlg::Sha256))
+    }
+}
+
+impl client::Handler for KnownHostsHandler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &PublicKey,
+    ) -> Result<bool, Self::Error> {
+        match check_known_hosts_path(&self.host, self.port, server_public_key, &self.path) {
+            Ok(true) => Ok(true),
+            Ok(false) => {
+                if let Some(parent) = self.path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                if let Err(e) =
+                    learn_known_hosts_path(&self.host, self.port, server_public_key, &self.path)
+                {
+                    log::warn!("Failed to record SSH host key for {}: {}", self.host, e);
+                }
+                Ok(true)
+            }
+            Err(e) => {
+                log::error!(
+                    "SSH host key for {}:{} does not match the recorded one ({}). New fingerprint: {}",
+                    self.host,
+                    self.port,
+                    e,
+                    Self::fingerprint(server_public_key)
+                );
+                Ok(false)
+            }
+        }
+    }
+}
+
+fn known_hosts_path() -> Result<PathBuf> {
+    Ok(dirs::home_dir()
+        .ok_or_else(|| anyhow!("Cannot determine home directory for SSH known_hosts"))?
+        .join(".tablio")
+        .join("known_hosts"))
+}
+
+/// Open a tunnel that forwards `127.0.0.1:<random>` to
+/// `config.host:config.port` over the SSH session described by the `ssh_*`
+/// fields.
+///
+/// The caller should connect to `127.0.0.1:tunnel.local_port()` and treat the
+/// returned [`SshTunnel`] as the lifetime token for the forwarding loop.
+pub async fn open(config: &ConnectionConfig) -> Result<SshTunnel> {
+    if config.ssh_host.trim().is_empty() {
+        return Err(anyhow!("SSH host is empty"));
+    }
+    if config.ssh_user.trim().is_empty() {
+        return Err(anyhow!("SSH username is empty"));
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("Failed to bind local SSH forward listener")?;
+    let local_port = listener.local_addr()?.port();
+
+    let known_hosts = known_hosts_path()?;
+    let handler = KnownHostsHandler {
+        path: known_hosts,
+        host: config.ssh_host.clone(),
+        port: config.ssh_port,
+    };
+
+    let ssh_config = Arc::new(client::Config {
+        inactivity_timeout: Some(Duration::from_secs(60)),
+        ..Default::default()
+    });
+
+    let mut session = client::connect(
+        ssh_config,
+        (config.ssh_host.as_str(), config.ssh_port),
+        handler,
+    )
+    .await
+    .with_context(|| {
+        format!(
+            "SSH connect to {}:{} failed",
+            config.ssh_host, config.ssh_port
+        )
+    })?;
+
+    authenticate(&mut session, config).await?;
+
+    let remote_host = config.host.clone();
+    let remote_port = config.port;
+    let session = Arc::new(session);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let task = tokio::spawn(forward_loop(
+        listener,
+        session.clone(),
+        remote_host,
+        remote_port,
+        local_port,
+        shutdown_rx,
+    ));
+
+    Ok(SshTunnel {
+        local_port,
+        shutdown: Some(shutdown_tx),
+        task: Some(task),
+    })
+}
+
+async fn authenticate(
+    session: &mut Handle<KnownHostsHandler>,
+    config: &ConnectionConfig,
+) -> Result<()> {
+    let user = config.ssh_user.clone();
+
+    let auth = match config.ssh_auth_method {
+        SshAuthMethod::Password => {
+            if config.ssh_password.is_empty() {
+                return Err(anyhow!(
+                    "SSH password is empty (set Authentication = Identity file or supply a password)"
+                ));
+            }
+            session
+                .authenticate_password(user, config.ssh_password.clone())
+                .await
+                .context("SSH password authentication failed")?
+        }
+        SshAuthMethod::IdentityFile => {
+            if config.ssh_key_path.trim().is_empty() {
+                return Err(anyhow!("SSH identity file path is empty"));
+            }
+            let key = load_secret_key(&config.ssh_key_path, &config.ssh_password).await?;
+            let key_with_hash = PrivateKeyWithHashAlg::new(Arc::new(key), Some(HashAlg::Sha256));
+            session
+                .authenticate_publickey(user, key_with_hash)
+                .await
+                .context("SSH public key authentication failed")?
+        }
+    };
+
+    match auth {
+        AuthResult::Success => Ok(()),
+        AuthResult::Failure {
+            remaining_methods, ..
+        } => Err(anyhow!(
+            "SSH authentication rejected by server. Methods still available: {:?}",
+            remaining_methods
+        )),
+    }
+}
+
+async fn load_secret_key(path: &str, passphrase: &str) -> Result<russh::keys::PrivateKey> {
+    let path = Path::new(path).to_path_buf();
+    let pass = if passphrase.is_empty() {
+        None
+    } else {
+        Some(passphrase.to_string())
+    };
+    // Run blocking file IO + key decryption off the runtime worker.
+    tokio::task::spawn_blocking(move || {
+        let bytes = std::fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read SSH identity file {}", path.display()))?;
+        decode_secret_key(&bytes, pass.as_deref()).map_err(|e| {
+            anyhow!(
+                "Failed to decode SSH identity file {}: {}{}",
+                path.display(),
+                e,
+                if pass.is_none() {
+                    " (key may be encrypted; supply the passphrase)"
+                } else {
+                    ""
+                }
+            )
+        })
+    })
+    .await
+    .map_err(|e| anyhow!("Joining key-loading task failed: {}", e))?
+}
+
+async fn forward_loop(
+    listener: TcpListener,
+    session: Arc<Handle<KnownHostsHandler>>,
+    remote_host: String,
+    remote_port: u16,
+    local_port: u16,
+    mut shutdown: oneshot::Receiver<()>,
+) {
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => {
+                log::debug!("SSH tunnel on 127.0.0.1:{} shutting down", local_port);
+                let _ = session.disconnect(russh::Disconnect::ByApplication, "tablio shutdown", "").await;
+                break;
+            }
+            accept = listener.accept() => {
+                let (mut socket, addr) = match accept {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log::warn!("SSH tunnel listener.accept() failed: {}", e);
+                        continue;
+                    }
+                };
+                let session = session.clone();
+                let remote_host = remote_host.clone();
+                tokio::spawn(async move {
+                    let channel = match session
+                        .channel_open_direct_tcpip(
+                            remote_host.clone(),
+                            remote_port as u32,
+                            addr.ip().to_string(),
+                            addr.port() as u32,
+                        )
+                        .await
+                    {
+                        Ok(c) => c,
+                        Err(e) => {
+                            log::warn!(
+                                "Failed to open direct-tcpip channel to {}:{}: {}",
+                                remote_host,
+                                remote_port,
+                                e
+                            );
+                            let _ = socket.shutdown().await;
+                            return;
+                        }
+                    };
+                    let mut stream = channel.into_stream();
+                    if let Err(e) = tokio::io::copy_bidirectional(&mut socket, &mut stream).await {
+                        // Closed connections are normal; log at debug.
+                        log::debug!("SSH tunnel relay closed for {}:{}: {}", remote_host, remote_port, e);
+                    }
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use russh::client::Handler;
+    use std::io::Write;
+
+    fn pg_config_with(auth: SshAuthMethod) -> ConnectionConfig {
+        ConnectionConfig {
+            id: "id".into(),
+            name: "n".into(),
+            db_type: crate::models::DbType::Postgres,
+            host: "remote-db".into(),
+            port: 5432,
+            user: "u".into(),
+            password: "p".into(),
+            database: "db".into(),
+            color: "#fff".into(),
+            ssl: false,
+            trust_server_cert: false,
+            group: None,
+            ssh_enabled: true,
+            ssh_host: "bastion".into(),
+            ssh_port: 22,
+            ssh_user: "ssh-user".into(),
+            ssh_password: String::new(),
+            ssh_key_path: String::new(),
+            ssh_auth_method: auth,
+            ssh_prompt_passphrase: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn open_rejects_empty_ssh_host() {
+        let mut cfg = pg_config_with(SshAuthMethod::Password);
+        cfg.ssh_host = "   ".into();
+        // SshTunnel intentionally doesn't impl Debug (it owns runtime resources),
+        // so we map the error before unwrapping.
+        let err = open(&cfg)
+            .await
+            .err()
+            .expect("expected error for empty ssh_host");
+        assert!(err.to_string().contains("SSH host is empty"), "got {err}");
+    }
+
+    #[tokio::test]
+    async fn open_rejects_empty_ssh_user() {
+        let mut cfg = pg_config_with(SshAuthMethod::Password);
+        cfg.ssh_user = String::new();
+        let err = open(&cfg)
+            .await
+            .err()
+            .expect("expected error for empty ssh_user");
+        assert!(
+            err.to_string().contains("SSH username is empty"),
+            "got {err}"
+        );
+    }
+
+    #[test]
+    fn known_hosts_path_includes_tablio_subdir() {
+        let p = known_hosts_path().expect("home dir resolvable in test env");
+        assert!(p.ends_with(".tablio/known_hosts"));
+    }
+
+    #[tokio::test]
+    async fn load_secret_key_reports_missing_passphrase() {
+        // Generate an encrypted ed25519 key on the fly so we don't ship test fixtures.
+        // We just need the decoder to *fail* without a passphrase.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("id_ed25519");
+        // Minimal encrypted key blob from russh's own test corpus.
+        let pkcs8_encrypted = "-----BEGIN ENCRYPTED PRIVATE KEY-----\n\
+MIGjMF8GCSqGSIb3DQEFDTBSMDEGCSqGSIb3DQEFDDAkBBAWQiUHKoocuxfoZ/hF\n\
+YTjkAgIIADAMBggqhkiG9w0CCQUAMB0GCWCGSAFlAwQBKgQQ83d1d5/S2wz475uC\n\
+CUrE7QRAvdVpD5e3zKH/MZjilWrMOm6cyI1LKBCssLztPyvOALtroLAPlp7WYWfu\n\
+9Sncmm7u14n2lia7r1r5I3VBsVuH0g==\n\
+-----END ENCRYPTED PRIVATE KEY-----\n";
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(pkcs8_encrypted.as_bytes())
+            .unwrap();
+        let path_str = path.to_string_lossy().to_string();
+
+        // Wrong / empty passphrase must surface a useful error.
+        let err = load_secret_key(&path_str, "").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Failed to decode SSH identity file"),
+            "expected decode error, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn known_hosts_handler_learns_first_contact() {
+        let dir = tempfile::tempdir().unwrap();
+        let kh = dir.path().join("known_hosts");
+        let mut handler = KnownHostsHandler {
+            path: kh.clone(),
+            host: "host.example".into(),
+            port: 22,
+        };
+        // Build a key by parsing an OpenSSH-formatted one.
+        let key = russh::keys::parse_public_key_base64(
+            "AAAAC3NzaC1lZDI1NTE5AAAAIJdD7y3aLq454yWBdwLWbieU1ebz9/cu7/QEXn9OIeZJ",
+        )
+        .unwrap();
+        let accepted = handler.check_server_key(&key).await.unwrap();
+        assert!(accepted, "first contact must be accepted (TOFU)");
+        assert!(kh.exists(), "known_hosts file must be created");
+        // Second call should match the now-recorded key.
+        let accepted_again = handler.check_server_key(&key).await.unwrap();
+        assert!(accepted_again, "matching key on reconnect must be accepted");
+    }
+
+    #[tokio::test]
+    async fn known_hosts_handler_rejects_changed_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let kh = dir.path().join("known_hosts");
+        let mut handler = KnownHostsHandler {
+            path: kh,
+            host: "host.example".into(),
+            port: 22,
+        };
+        let key1 = russh::keys::parse_public_key_base64(
+            "AAAAC3NzaC1lZDI1NTE5AAAAIJdD7y3aLq454yWBdwLWbieU1ebz9/cu7/QEXn9OIeZJ",
+        )
+        .unwrap();
+        let key2 = russh::keys::parse_public_key_base64(
+            "AAAAC3NzaC1lZDI1NTE5AAAAILIG2T/B0l0gaqj3puu510tu9N1OkQ4znY3LYuEm5zCF",
+        )
+        .unwrap();
+        assert!(handler.check_server_key(&key1).await.unwrap());
+        // Now the same host hands us a different key — must be rejected.
+        let rejected = handler.check_server_key(&key2).await.unwrap();
+        assert!(!rejected, "changed host key must be rejected");
+    }
+}

--- a/src-tauri/src/db/ssh_tunnel.rs
+++ b/src-tauri/src/db/ssh_tunnel.rs
@@ -20,8 +20,9 @@
 //! tunnel as opaque and connect to `127.0.0.1:tunnel.local_port()`.
 
 use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
@@ -61,6 +62,38 @@ impl Drop for SshTunnel {
     }
 }
 
+/// Structured payload surfaced when a server's host key no longer matches
+/// the one previously recorded in our known_hosts file.
+///
+/// The frontend looks for the `ssh_host_key_mismatch:` prefix in the
+/// stringified Tauri error and parses the JSON body to drive the
+/// "Forget & Retry" prompt. Keep this struct strictly serde-compatible —
+/// renaming a field is a breaking UI change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SshHostKeyMismatch {
+    pub host: String,
+    pub port: u16,
+    /// SHA-256 fingerprint of the *new* key (what the server just presented).
+    pub fingerprint: String,
+    #[serde(rename = "knownHostsPath")]
+    pub known_hosts_path: String,
+}
+
+/// Magic prefix the frontend uses to detect a mismatch error coming back
+/// from any Tauri command that may open an SSH session.
+pub const HOST_KEY_MISMATCH_PREFIX: &str = "ssh_host_key_mismatch:";
+
+impl std::fmt::Display for SshHostKeyMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // serde_json on a small struct of String/u16 cannot fail in practice;
+        // fall back to a plain message just so we never panic in Display.
+        let json = serde_json::to_string(self).unwrap_or_default();
+        write!(f, "{HOST_KEY_MISMATCH_PREFIX}{json}")
+    }
+}
+
+impl std::error::Error for SshHostKeyMismatch {}
+
 /// Verifier that consults a Tablio-owned known_hosts file.
 ///
 /// On first contact the server key is recorded; on later connections a
@@ -69,9 +102,23 @@ struct KnownHostsHandler {
     path: PathBuf,
     host: String,
     port: u16,
+    /// Set by `check_server_key` when the presented key doesn't match the
+    /// recorded one. `open()` swaps it out after `client::connect` fails so
+    /// callers see a structured `SshHostKeyMismatch` instead of a generic
+    /// "ssh: invalid key" error.
+    mismatch: Arc<Mutex<Option<SshHostKeyMismatch>>>,
 }
 
 impl KnownHostsHandler {
+    fn new(path: PathBuf, host: String, port: u16) -> Self {
+        Self {
+            path,
+            host,
+            port,
+            mismatch: Arc::new(Mutex::new(None)),
+        }
+    }
+
     fn fingerprint(key: &PublicKey) -> String {
         // SHA-256 base64 fingerprint, formatted like OpenSSH ("SHA256:...").
         // `PublicKeyBase64` exposes the wire-format bytes; we hash them ourselves
@@ -101,13 +148,25 @@ impl client::Handler for KnownHostsHandler {
                 Ok(true)
             }
             Err(e) => {
+                let fp = Self::fingerprint(server_public_key);
                 log::error!(
                     "SSH host key for {}:{} does not match the recorded one ({}). New fingerprint: {}",
                     self.host,
                     self.port,
                     e,
-                    Self::fingerprint(server_public_key)
+                    fp
                 );
+                if let Ok(mut slot) = self.mismatch.lock() {
+                    *slot = Some(SshHostKeyMismatch {
+                        host: self.host.clone(),
+                        port: self.port,
+                        fingerprint: fp,
+                        known_hosts_path: self.path.to_string_lossy().into_owned(),
+                    });
+                }
+                // Returning `Ok(false)` makes russh tear the handshake down;
+                // `open()` notices the mismatch slot was filled and converts
+                // the resulting connect error into [`SshHostKeyMismatch`].
                 Ok(false)
             }
         }
@@ -119,6 +178,50 @@ fn known_hosts_path() -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("Cannot determine home directory for SSH known_hosts"))?
         .join(".tablio")
         .join("known_hosts"))
+}
+
+/// Public wrapper around the (intentionally private) path resolver so that
+/// command handlers (e.g. `commands::known_hosts`) and the planned
+/// `KnownHostsDialog` UI hit the same file russh writes to.
+pub fn known_hosts_path_pub() -> Result<PathBuf> {
+    known_hosts_path()
+}
+
+/// Effective network target after optionally interposing an SSH tunnel.
+///
+/// When `_tunnel` is `Some`, callers should connect to `host:port` (always
+/// `127.0.0.1:<local>`) and keep the [`EffectiveTarget`] alive for the
+/// lifetime of the consumer (subprocess, sqlx pool, etc.). The tunnel is
+/// torn down when this struct is dropped.
+pub struct EffectiveTarget {
+    pub host: String,
+    pub port: u16,
+    /// Held purely to keep the SSH session alive; never read directly.
+    pub _tunnel: Option<SshTunnel>,
+}
+
+/// Decide whether to open an SSH tunnel for `config` and return the
+/// host/port the caller should actually talk to.
+///
+/// Mirrors the logic in [`crate::db::pool::PoolManager::connect`] so
+/// short-lived consumers (e.g. backup/restore subprocesses) can route
+/// through the same bastion the live driver uses without holding a slot
+/// in the pool's tunnel table.
+pub async fn open_for(config: &ConnectionConfig) -> Result<EffectiveTarget> {
+    if config.ssh_enabled && !config.ssh_host.trim().is_empty() {
+        let tunnel = open(config).await?;
+        Ok(EffectiveTarget {
+            host: "127.0.0.1".to_string(),
+            port: tunnel.local_port(),
+            _tunnel: Some(tunnel),
+        })
+    } else {
+        Ok(EffectiveTarget {
+            host: config.host.clone(),
+            port: config.port,
+            _tunnel: None,
+        })
+    }
 }
 
 /// Open a tunnel that forwards `127.0.0.1:<random>` to
@@ -141,29 +244,36 @@ pub async fn open(config: &ConnectionConfig) -> Result<SshTunnel> {
     let local_port = listener.local_addr()?.port();
 
     let known_hosts = known_hosts_path()?;
-    let handler = KnownHostsHandler {
-        path: known_hosts,
-        host: config.ssh_host.clone(),
-        port: config.ssh_port,
-    };
+    let handler = KnownHostsHandler::new(known_hosts, config.ssh_host.clone(), config.ssh_port);
+    let mismatch_slot = handler.mismatch.clone();
 
     let ssh_config = Arc::new(client::Config {
         inactivity_timeout: Some(Duration::from_secs(60)),
         ..Default::default()
     });
 
-    let mut session = client::connect(
+    let mut session = match client::connect(
         ssh_config,
         (config.ssh_host.as_str(), config.ssh_port),
         handler,
     )
     .await
-    .with_context(|| {
-        format!(
-            "SSH connect to {}:{} failed",
-            config.ssh_host, config.ssh_port
-        )
-    })?;
+    {
+        Ok(s) => s,
+        Err(e) => {
+            // If the handshake aborted because we rejected the key, prefer
+            // the structured mismatch error over russh's generic message —
+            // the frontend keys off this to offer a one-click "Forget &
+            // retry" flow.
+            if let Some(info) = mismatch_slot.lock().ok().and_then(|mut s| s.take()) {
+                return Err(anyhow::Error::from(info));
+            }
+            return Err(anyhow::Error::new(e).context(format!(
+                "SSH connect to {}:{} failed",
+                config.ssh_host, config.ssh_port
+            )));
+        }
+    };
 
     authenticate(&mut session, config).await?;
 
@@ -348,6 +458,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn open_for_passes_through_when_ssh_disabled() {
+        let mut cfg = pg_config_with(SshAuthMethod::Password);
+        cfg.ssh_enabled = false;
+        cfg.host = "remote-db".into();
+        cfg.port = 5432;
+        let target = open_for(&cfg)
+            .await
+            .expect("open_for must not fail when SSH is disabled");
+        assert_eq!(target.host, "remote-db");
+        assert_eq!(target.port, 5432);
+        assert!(target._tunnel.is_none(), "no tunnel should be allocated");
+    }
+
+    #[tokio::test]
+    async fn open_for_passes_through_when_ssh_host_blank() {
+        let mut cfg = pg_config_with(SshAuthMethod::Password);
+        cfg.ssh_enabled = true;
+        cfg.ssh_host = "   ".into();
+        cfg.host = "remote-db".into();
+        cfg.port = 5432;
+        let target = open_for(&cfg)
+            .await
+            .expect("blank ssh_host must skip tunneling, not error");
+        assert_eq!(target.host, "remote-db");
+        assert_eq!(target.port, 5432);
+        assert!(target._tunnel.is_none());
+    }
+
+    #[tokio::test]
     async fn open_rejects_empty_ssh_host() {
         let mut cfg = pg_config_with(SshAuthMethod::Password);
         cfg.ssh_host = "   ".into();
@@ -412,11 +551,7 @@ CUrE7QRAvdVpD5e3zKH/MZjilWrMOm6cyI1LKBCssLztPyvOALtroLAPlp7WYWfu\n\
     async fn known_hosts_handler_learns_first_contact() {
         let dir = tempfile::tempdir().unwrap();
         let kh = dir.path().join("known_hosts");
-        let mut handler = KnownHostsHandler {
-            path: kh.clone(),
-            host: "host.example".into(),
-            port: 22,
-        };
+        let mut handler = KnownHostsHandler::new(kh.clone(), "host.example".into(), 22);
         // Build a key by parsing an OpenSSH-formatted one.
         let key = russh::keys::parse_public_key_base64(
             "AAAAC3NzaC1lZDI1NTE5AAAAIJdD7y3aLq454yWBdwLWbieU1ebz9/cu7/QEXn9OIeZJ",
@@ -434,11 +569,8 @@ CUrE7QRAvdVpD5e3zKH/MZjilWrMOm6cyI1LKBCssLztPyvOALtroLAPlp7WYWfu\n\
     async fn known_hosts_handler_rejects_changed_key() {
         let dir = tempfile::tempdir().unwrap();
         let kh = dir.path().join("known_hosts");
-        let mut handler = KnownHostsHandler {
-            path: kh,
-            host: "host.example".into(),
-            port: 22,
-        };
+        let mut handler = KnownHostsHandler::new(kh.clone(), "host.example".into(), 22);
+        let mismatch_slot = handler.mismatch.clone();
         let key1 = russh::keys::parse_public_key_base64(
             "AAAAC3NzaC1lZDI1NTE5AAAAIJdD7y3aLq454yWBdwLWbieU1ebz9/cu7/QEXn9OIeZJ",
         )
@@ -448,8 +580,53 @@ CUrE7QRAvdVpD5e3zKH/MZjilWrMOm6cyI1LKBCssLztPyvOALtroLAPlp7WYWfu\n\
         )
         .unwrap();
         assert!(handler.check_server_key(&key1).await.unwrap());
+        assert!(
+            mismatch_slot.lock().unwrap().is_none(),
+            "no mismatch should be recorded on first contact"
+        );
         // Now the same host hands us a different key — must be rejected.
         let rejected = handler.check_server_key(&key2).await.unwrap();
         assert!(!rejected, "changed host key must be rejected");
+        let info = mismatch_slot
+            .lock()
+            .unwrap()
+            .take()
+            .expect("mismatch slot must be populated");
+        assert_eq!(info.host, "host.example");
+        assert_eq!(info.port, 22);
+        assert!(
+            info.fingerprint.starts_with("SHA256:"),
+            "fingerprint should be SHA256-formatted, got {}",
+            info.fingerprint
+        );
+        assert_eq!(info.known_hosts_path, kh.to_string_lossy());
+    }
+
+    #[test]
+    fn host_key_mismatch_serialises_with_prefix() {
+        let info = SshHostKeyMismatch {
+            host: "h".into(),
+            port: 22,
+            fingerprint: "SHA256:xyz".into(),
+            known_hosts_path: "/tmp/known_hosts".into(),
+        };
+        let s = info.to_string();
+        assert!(
+            s.starts_with(HOST_KEY_MISMATCH_PREFIX),
+            "missing prefix: {s}"
+        );
+        let json = &s[HOST_KEY_MISMATCH_PREFIX.len()..];
+        let parsed: SshHostKeyMismatch =
+            serde_json::from_str(json).expect("payload after prefix must be valid JSON");
+        assert_eq!(parsed.host, "h");
+        assert_eq!(parsed.port, 22);
+        assert_eq!(parsed.fingerprint, "SHA256:xyz");
+        assert_eq!(parsed.known_hosts_path, "/tmp/known_hosts");
+        // The serde key for the path must remain camelCase to match the
+        // Tauri/TS contract — guard against accidental rename.
+        assert!(
+            json.contains("\"knownHostsPath\""),
+            "expected camelCase key, got {json}"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ use commands::query::*;
 use commands::roles::*;
 use commands::saved_queries::*;
 use commands::schema::*;
+use commands::ssh_config::*;
 use commands::system::*;
 use db::pool::PoolManager;
 use std::sync::Arc;
@@ -74,6 +75,7 @@ pub fn run() {
             dump_and_restore,
             list_known_hosts,
             forget_known_host,
+            ssh_config_lookup,
             get_app_resource_usage,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use commands::backup::*;
 use commands::connection::*;
 use commands::data::*;
 use commands::export::*;
+use commands::known_hosts::*;
 use commands::query::*;
 use commands::roles::*;
 use commands::saved_queries::*;
@@ -71,6 +72,8 @@ pub fn run() {
             backup_database,
             restore_database,
             dump_and_restore,
+            list_known_hosts,
+            forget_known_host,
             get_app_resource_usage,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/models/types.rs
+++ b/src-tauri/src/models/types.rs
@@ -59,6 +59,12 @@ pub enum SshAuthMethod {
     Password,
     #[serde(rename = "identityfile", alias = "identity_file")]
     IdentityFile,
+    /// Use the local ssh-agent (Linux / macOS read `SSH_AUTH_SOCK`,
+    /// Windows tries Pageant). The agent is asked for the list of loaded
+    /// identities and each one is offered to the bastion in turn. No
+    /// passphrase is ever read by Tablio in this mode.
+    #[serde(rename = "agent")]
+    Agent,
 }
 
 fn default_ssh_port() -> u16 {
@@ -693,6 +699,10 @@ mod tests {
             serde_json::to_string(&SshAuthMethod::IdentityFile).unwrap(),
             r#""identityfile""#
         );
+        assert_eq!(
+            serde_json::to_string(&SshAuthMethod::Agent).unwrap(),
+            r#""agent""#
+        );
     }
 
     #[test]
@@ -705,6 +715,12 @@ mod tests {
     fn ssh_auth_method_accepts_legacy_identity_file_alias() {
         let m: SshAuthMethod = serde_json::from_str(r#""identity_file""#).unwrap();
         assert_eq!(m, SshAuthMethod::IdentityFile);
+    }
+
+    #[test]
+    fn ssh_auth_method_deserializes_agent() {
+        let m: SshAuthMethod = serde_json::from_str(r#""agent""#).unwrap();
+        assert_eq!(m, SshAuthMethod::Agent);
     }
 
     #[test]

--- a/src-tauri/src/models/types.rs
+++ b/src-tauri/src/models/types.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DbType {
+    #[default]
     Postgres,
     Mysql,
     Sqlite,
@@ -42,10 +43,53 @@ pub struct ConnectionConfig {
     pub ssh_password: String,
     #[serde(default)]
     pub ssh_key_path: String,
+    #[serde(default)]
+    pub ssh_auth_method: SshAuthMethod,
+    /// When true and `ssh_auth_method == IdentityFile`, the UI will ask for
+    /// the key passphrase at connect time rather than persisting it; the
+    /// stored `ssh_password` is empty and a transient one is injected.
+    #[serde(default)]
+    pub ssh_prompt_passphrase: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SshAuthMethod {
+    #[default]
+    Password,
+    #[serde(rename = "identityfile", alias = "identity_file")]
+    IdentityFile,
 }
 
 fn default_ssh_port() -> u16 {
     22
+}
+
+impl Default for ConnectionConfig {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: String::new(),
+            db_type: DbType::default(),
+            host: String::new(),
+            port: 0,
+            user: String::new(),
+            password: String::new(),
+            database: String::new(),
+            color: String::new(),
+            ssl: false,
+            trust_server_cert: false,
+            group: None,
+            ssh_enabled: false,
+            ssh_host: String::new(),
+            ssh_port: default_ssh_port(),
+            ssh_user: String::new(),
+            ssh_password: String::new(),
+            ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
+        }
+    }
 }
 
 impl ConnectionConfig {
@@ -637,6 +681,60 @@ mod tests {
         assert!(!config.ssh_enabled);
         assert_eq!(config.ssh_host, "");
         assert!(config.group.is_none());
+    }
+
+    #[test]
+    fn ssh_auth_method_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&SshAuthMethod::Password).unwrap(),
+            r#""password""#
+        );
+        assert_eq!(
+            serde_json::to_string(&SshAuthMethod::IdentityFile).unwrap(),
+            r#""identityfile""#
+        );
+    }
+
+    #[test]
+    fn ssh_auth_method_default_is_password() {
+        let m: SshAuthMethod = Default::default();
+        assert_eq!(m, SshAuthMethod::Password);
+    }
+
+    #[test]
+    fn ssh_auth_method_accepts_legacy_identity_file_alias() {
+        let m: SshAuthMethod = serde_json::from_str(r#""identity_file""#).unwrap();
+        assert_eq!(m, SshAuthMethod::IdentityFile);
+    }
+
+    #[test]
+    fn connection_config_ssh_defaults_to_password_auth() {
+        let json = r##"{
+            "id": "1", "name": "test", "db_type": "postgres",
+            "host": "localhost", "port": 5432, "user": "u",
+            "password": "p", "database": "db", "color": "#fff",
+            "ssl": false
+        }"##;
+        let config: ConnectionConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.ssh_auth_method, SshAuthMethod::Password);
+        assert!(!config.ssh_prompt_passphrase);
+    }
+
+    #[test]
+    fn connection_config_ssh_identity_file() {
+        let json = r##"{
+            "id": "1", "name": "test", "db_type": "postgres",
+            "host": "localhost", "port": 5432, "user": "u",
+            "password": "p", "database": "db", "color": "#fff",
+            "ssl": false, "ssh_enabled": true, "ssh_host": "bastion",
+            "ssh_user": "admin", "ssh_auth_method": "identityfile",
+            "ssh_key_path": "/home/u/.ssh/id_ed25519",
+            "ssh_prompt_passphrase": true
+        }"##;
+        let config: ConnectionConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.ssh_auth_method, SshAuthMethod::IdentityFile);
+        assert_eq!(config.ssh_key_path, "/home/u/.ssh/id_ed25519");
+        assert!(config.ssh_prompt_passphrase);
     }
 
     #[test]

--- a/src-tauri/tests/cassandra_integration.rs
+++ b/src-tauri/tests/cassandra_integration.rs
@@ -33,6 +33,8 @@ async fn create_driver() -> CassandraDriver {
         ssh_user: String::new(),
         ssh_password: String::new(),
         ssh_key_path: String::new(),
+        ssh_auth_method: SshAuthMethod::default(),
+        ssh_prompt_passphrase: false,
     };
     CassandraDriver::connect(&config).await.unwrap()
 }

--- a/src-tauri/tests/cockroachdb_integration.rs
+++ b/src-tauri/tests/cockroachdb_integration.rs
@@ -39,6 +39,8 @@ macro_rules! crdb_driver {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         (
             CockroachdbDriver::connect(&config).await.unwrap(),
@@ -85,6 +87,8 @@ macro_rules! crdb_driver_no_db {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         CockroachdbDriver::connect(&config).await.unwrap()
     }};

--- a/src-tauri/tests/mariadb_integration.rs
+++ b/src-tauri/tests/mariadb_integration.rs
@@ -36,6 +36,8 @@ macro_rules! mariadb_driver {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         (
             MariadbDriver::connect(&config).await.unwrap(),
@@ -77,6 +79,8 @@ macro_rules! mariadb_driver_no_db {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         MariadbDriver::connect(&config).await.unwrap()
     }};

--- a/src-tauri/tests/mssql_integration.rs
+++ b/src-tauri/tests/mssql_integration.rs
@@ -40,6 +40,8 @@ macro_rules! mssql_driver {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         (
             MssqlDriver::connect(&config).await.unwrap(),
@@ -84,6 +86,8 @@ macro_rules! mssql_driver_no_db {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         MssqlDriver::connect(&config).await.unwrap()
     }};

--- a/src-tauri/tests/mysql_integration.rs
+++ b/src-tauri/tests/mysql_integration.rs
@@ -36,6 +36,8 @@ macro_rules! mysql_driver {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         (
             MysqlDriver::connect(&config).await.unwrap(),
@@ -77,6 +79,8 @@ macro_rules! mysql_driver_no_db {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         MysqlDriver::connect(&config).await.unwrap()
     }};

--- a/src-tauri/tests/postgres_integration.rs
+++ b/src-tauri/tests/postgres_integration.rs
@@ -39,6 +39,8 @@ macro_rules! pg_driver {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         PostgresDriver::connect(&config).await.unwrap()
     }};
@@ -91,6 +93,8 @@ macro_rules! pg_driver_no_db {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         PostgresDriver::connect(&config).await.unwrap()
     }};

--- a/src-tauri/tests/sqlite_integration.rs
+++ b/src-tauri/tests/sqlite_integration.rs
@@ -24,6 +24,8 @@ async fn create_driver() -> (SqliteDriver, String) {
         ssh_user: String::new(),
         ssh_password: String::new(),
         ssh_key_path: String::new(),
+        ssh_auth_method: SshAuthMethod::default(),
+        ssh_prompt_passphrase: false,
     };
     let driver = SqliteDriver::connect(&config).await.unwrap();
     (driver, path)

--- a/src-tauri/tests/ssh_tunnel_integration.rs
+++ b/src-tauri/tests/ssh_tunnel_integration.rs
@@ -271,6 +271,68 @@ async fn pg_dump_through_tunnel() {
     );
 }
 
+/// Build an ssh-agent-flavoured config from the same env. The caller
+/// must additionally have `SSH_AUTH_SOCK` set with the test identity
+/// loaded — gated behind `TEST_SSH_AGENT_AVAILABLE=1` so a misconfigured
+/// CI never silently passes the test as "skipped".
+fn ssh_agent_config() -> Option<ConnectionConfig> {
+    if env("TEST_SSH_AGENT_AVAILABLE").as_deref() != Some("1") {
+        return None;
+    }
+    if std::env::var_os("SSH_AUTH_SOCK").is_none() {
+        eprintln!("Skipping ssh-agent test: TEST_SSH_AGENT_AVAILABLE=1 but SSH_AUTH_SOCK is unset");
+        return None;
+    }
+    let mut cfg = ssh_test_config()?;
+    cfg.id = "ssh-int-test-agent".into();
+    cfg.name = "ssh-int-test-agent".into();
+    cfg.ssh_auth_method = SshAuthMethod::Agent;
+    cfg.ssh_password = String::new();
+    cfg.ssh_key_path = String::new();
+    Some(cfg)
+}
+
+#[tokio::test]
+async fn ssh_tunnel_open_with_agent() {
+    let Some(config) = ssh_agent_config() else {
+        eprintln!("Skipping ssh_tunnel_open_with_agent: TEST_SSH_AGENT_AVAILABLE!=1");
+        return;
+    };
+    let tunnel = ssh_tunnel::open(&config)
+        .await
+        .expect("ssh_tunnel::open with Agent auth must succeed");
+    let port = tunnel.local_port();
+    assert_ne!(port, 0, "tunnel must allocate a real local port");
+    let _stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("local tunnel endpoint must accept connections");
+}
+
+#[tokio::test]
+async fn pool_manager_connects_through_agent_tunnel() {
+    let Some(config) = ssh_agent_config() else {
+        eprintln!(
+            "Skipping pool_manager_connects_through_agent_tunnel: TEST_SSH_AGENT_AVAILABLE!=1"
+        );
+        return;
+    };
+    let pool = PoolManager::new();
+    pool.connect(config.clone())
+        .await
+        .expect("connect through agent-auth SSH tunnel should succeed");
+    let driver = pool
+        .get_driver(&config.id)
+        .await
+        .expect("driver should be present after connect");
+    assert!(driver
+        .test_connection()
+        .await
+        .expect("test_connection should not error"));
+    pool.disconnect(&config.id)
+        .await
+        .expect("disconnect should succeed");
+}
+
 #[tokio::test]
 async fn ssh_tunnel_open_rejects_bad_password() {
     let Some(mut config) = ssh_test_config() else {

--- a/src-tauri/tests/ssh_tunnel_integration.rs
+++ b/src-tauri/tests/ssh_tunnel_integration.rs
@@ -1,0 +1,128 @@
+//! Integration test for the russh-based SSH tunnel.
+//!
+//! Gated behind environment variables so it stays a no-op when an SSH
+//! bastion + DB pair isn't available. CI provisions both via Docker.
+//!
+//! Required env vars (when running):
+//!   - TEST_SSH_HOST          host of the SSH bastion (e.g. "localhost")
+//!   - TEST_SSH_PORT          ssh port on the bastion (e.g. "2222")
+//!   - TEST_SSH_USER          ssh login username
+//!   - TEST_SSH_PASSWORD      ssh login password
+//!   - TEST_SSH_TARGET_HOST   db host as seen *from* the bastion (e.g.
+//!                            "host.docker.internal" or "localhost")
+//!   - TEST_SSH_TARGET_PORT   db port as seen from the bastion (e.g. "5432")
+//!   - TEST_POSTGRES_USER / _PASSWORD / _DB     Postgres credentials
+
+use tablio_lib::db::pool::PoolManager;
+use tablio_lib::db::ssh_tunnel;
+// `DatabaseDriver` is brought in transparently through the trait method
+// invocation on the Arc returned by `pool.get_driver`, so we don't need to
+// import it explicitly.
+use tablio_lib::models::*;
+
+fn env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+fn ssh_test_config() -> Option<ConnectionConfig> {
+    let ssh_host = env("TEST_SSH_HOST")?;
+    let ssh_port: u16 = env("TEST_SSH_PORT")?.parse().ok()?;
+    let ssh_user = env("TEST_SSH_USER")?;
+    let ssh_password = env("TEST_SSH_PASSWORD")?;
+    let target_host = env("TEST_SSH_TARGET_HOST")?;
+    let target_port: u16 = env("TEST_SSH_TARGET_PORT")?.parse().ok()?;
+    let pg_user = env("TEST_POSTGRES_USER").unwrap_or_else(|| "test".into());
+    let pg_password = env("TEST_POSTGRES_PASSWORD").unwrap_or_else(|| "test".into());
+    let pg_db = env("TEST_POSTGRES_DB").unwrap_or_else(|| "testdb".into());
+
+    Some(ConnectionConfig {
+        id: "ssh-int-test".into(),
+        name: "ssh-int-test".into(),
+        db_type: DbType::Postgres,
+        host: target_host,
+        port: target_port,
+        user: pg_user,
+        password: pg_password,
+        database: pg_db,
+        color: "#000".into(),
+        ssl: false,
+        trust_server_cert: true,
+        group: None,
+        ssh_enabled: true,
+        ssh_host,
+        ssh_port,
+        ssh_user,
+        ssh_password,
+        ssh_key_path: String::new(),
+        ssh_auth_method: SshAuthMethod::Password,
+        ssh_prompt_passphrase: false,
+    })
+}
+
+#[tokio::test]
+async fn pool_manager_connects_through_ssh_tunnel() {
+    let Some(config) = ssh_test_config() else {
+        eprintln!("Skipping ssh_tunnel_integration: TEST_SSH_* env vars not set");
+        return;
+    };
+    let pool = PoolManager::new();
+    pool.connect(config.clone())
+        .await
+        .expect("connect through SSH tunnel should succeed");
+    let driver = pool
+        .get_driver(&config.id)
+        .await
+        .expect("driver should be present after connect");
+    assert!(driver
+        .test_connection()
+        .await
+        .expect("test_connection should not error"));
+    pool.disconnect(&config.id)
+        .await
+        .expect("disconnect should succeed (and tear the tunnel down)");
+    assert!(!pool.is_connected(&config.id).await);
+}
+
+#[tokio::test]
+async fn ssh_tunnel_open_drops_listener_when_dropped() {
+    let Some(config) = ssh_test_config() else {
+        eprintln!("Skipping ssh_tunnel_integration: TEST_SSH_* env vars not set");
+        return;
+    };
+    let local_port = {
+        let tunnel = ssh_tunnel::open(&config)
+            .await
+            .expect("ssh_tunnel::open should succeed with valid creds");
+        let port = tunnel.local_port();
+        // Tunnel is dropped at end of this scope; the next bind to that
+        // port should succeed almost immediately. We don't poll for that
+        // here (kernel TIME_WAIT can still hold the port), but we do
+        // assert that a connection through the live tunnel works.
+        let _stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("local tunnel endpoint must accept connections");
+        port
+    };
+    // Sanity: port was non-zero (i.e. ephemeral allocation succeeded).
+    assert_ne!(local_port, 0);
+}
+
+#[tokio::test]
+async fn ssh_tunnel_open_rejects_bad_password() {
+    let Some(mut config) = ssh_test_config() else {
+        eprintln!("Skipping ssh_tunnel_integration: TEST_SSH_* env vars not set");
+        return;
+    };
+    config.ssh_password = "definitely-not-the-right-password".into();
+    let err = ssh_tunnel::open(&config)
+        .await
+        .err()
+        .expect("ssh_tunnel::open should reject a wrong password");
+    let msg = err.to_string();
+    assert!(
+        msg.to_lowercase().contains("auth")
+            || msg.to_lowercase().contains("password")
+            || msg.to_lowercase().contains("rejected"),
+        "expected an auth error, got: {msg}"
+    );
+}

--- a/src-tauri/tests/ssh_tunnel_integration.rs
+++ b/src-tauri/tests/ssh_tunnel_integration.rs
@@ -8,10 +8,14 @@
 //!   - TEST_SSH_PORT          ssh port on the bastion (e.g. "2222")
 //!   - TEST_SSH_USER          ssh login username
 //!   - TEST_SSH_PASSWORD      ssh login password
-//!   - TEST_SSH_TARGET_HOST   db host as seen *from* the bastion (e.g.
-//!                            "host.docker.internal" or "localhost")
+//!   - TEST_SSH_TARGET_HOST   db host as seen *from* the bastion
+//!     (e.g. "host.docker.internal" or "localhost")
 //!   - TEST_SSH_TARGET_PORT   db port as seen from the bastion (e.g. "5432")
 //!   - TEST_POSTGRES_USER / _PASSWORD / _DB     Postgres credentials
+//!
+//! Optional (enables identity-file auth tests):
+//!   - TEST_SSH_KEY_PATH      path to an unencrypted OpenSSH/PEM private
+//!     key whose public half is in the bastion's authorized_keys
 
 use tablio_lib::db::pool::PoolManager;
 use tablio_lib::db::ssh_tunnel;
@@ -105,6 +109,166 @@ async fn ssh_tunnel_open_drops_listener_when_dropped() {
     };
     // Sanity: port was non-zero (i.e. ephemeral allocation succeeded).
     assert_ne!(local_port, 0);
+}
+
+/// Build the same config as `ssh_test_config` but flip auth to
+/// `identityfile` and point at the key referenced by `TEST_SSH_KEY_PATH`.
+/// Returns `None` when either the base config or the key path env var is
+/// missing — every identity-file test must skip cleanly in those envs.
+fn ssh_identity_file_config() -> Option<ConnectionConfig> {
+    let mut cfg = ssh_test_config()?;
+    let key_path = env("TEST_SSH_KEY_PATH")?;
+    if !std::path::Path::new(&key_path).exists() {
+        eprintln!(
+            "Skipping identity-file test: TEST_SSH_KEY_PATH={} does not exist",
+            key_path
+        );
+        return None;
+    }
+    cfg.id = "ssh-int-test-id-file".into();
+    cfg.name = "ssh-int-test-id-file".into();
+    cfg.ssh_auth_method = SshAuthMethod::IdentityFile;
+    cfg.ssh_key_path = key_path;
+    // Empty passphrase — the CI key is unencrypted by design so we can
+    // exercise the IdentityFile branch end-to-end without prompting.
+    cfg.ssh_password = String::new();
+    Some(cfg)
+}
+
+#[tokio::test]
+async fn ssh_tunnel_open_with_identity_file() {
+    let Some(config) = ssh_identity_file_config() else {
+        eprintln!("Skipping ssh_tunnel_open_with_identity_file: env vars not set");
+        return;
+    };
+    let tunnel = ssh_tunnel::open(&config)
+        .await
+        .expect("ssh_tunnel::open with IdentityFile auth must succeed");
+    let port = tunnel.local_port();
+    assert_ne!(port, 0, "tunnel must allocate a real local port");
+    let _stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+        .await
+        .expect("local tunnel endpoint must accept connections");
+}
+
+#[tokio::test]
+async fn pool_manager_connects_through_identity_file_tunnel() {
+    let Some(config) = ssh_identity_file_config() else {
+        eprintln!("Skipping pool_manager_connects_through_identity_file_tunnel: env vars not set");
+        return;
+    };
+    let pool = PoolManager::new();
+    pool.connect(config.clone())
+        .await
+        .expect("connect through identity-file SSH tunnel should succeed");
+    let driver = pool
+        .get_driver(&config.id)
+        .await
+        .expect("driver should be present after connect");
+    assert!(driver
+        .test_connection()
+        .await
+        .expect("test_connection should not error"));
+    pool.disconnect(&config.id)
+        .await
+        .expect("disconnect should succeed");
+    assert!(!pool.is_connected(&config.id).await);
+}
+
+#[tokio::test]
+async fn ssh_tunnel_open_rejects_missing_identity_file() {
+    let Some(mut config) = ssh_identity_file_config() else {
+        eprintln!("Skipping ssh_tunnel_open_rejects_missing_identity_file: env vars not set");
+        return;
+    };
+    // Point at a path that's guaranteed not to exist; the IdentityFile
+    // branch should surface a clear error before any SSH handshake.
+    config.ssh_key_path = "/tmp/tablio-ssh-int-no-such-key".into();
+    let err = ssh_tunnel::open(&config)
+        .await
+        .err()
+        .expect("missing identity file must produce an error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Failed to read SSH identity file") || msg.contains("identity"),
+        "expected identity-file error, got: {msg}"
+    );
+}
+
+/// Verify that `pg_dump` running locally can reach the bastion-hosted
+/// Postgres instance through the same russh tunnel used by the live driver.
+///
+/// This protects the contract between [`ssh_tunnel::open_for`] and the
+/// dump/restore subprocesses in `commands/backup.rs`: the only way these
+/// utilities can talk to a private DB is by being handed `127.0.0.1:<local>`
+/// while a tunnel guard is alive in the calling task.
+#[tokio::test]
+async fn pg_dump_through_tunnel() {
+    let Some(config) = ssh_test_config() else {
+        eprintln!("Skipping pg_dump_through_tunnel: TEST_SSH_* env vars not set");
+        return;
+    };
+    if which::which("pg_dump").is_err() {
+        eprintln!("Skipping pg_dump_through_tunnel: pg_dump binary not found in PATH");
+        return;
+    }
+
+    let target = ssh_tunnel::open_for(&config)
+        .await
+        .expect("open_for should succeed with valid SSH creds");
+    assert_eq!(
+        target.host, "127.0.0.1",
+        "open_for must redirect through the local tunnel endpoint"
+    );
+    assert_ne!(target.port, 0, "tunnel must allocate a real local port");
+    assert_ne!(
+        target.port, config.port,
+        "tunnel local port must differ from the remote DB port"
+    );
+
+    let tmp = tempfile::Builder::new()
+        .prefix("tablio-pgdump-tunnel-")
+        .suffix(".sql")
+        .tempfile()
+        .expect("tempfile creation");
+    let tmp_path = tmp.path().to_owned();
+
+    let mut cmd = tokio::process::Command::new("pg_dump");
+    cmd.arg("-h")
+        .arg(&target.host)
+        .arg("-p")
+        .arg(target.port.to_string())
+        .arg("-U")
+        .arg(&config.user)
+        .arg("-d")
+        .arg(&config.database)
+        .arg("--schema-only")
+        .arg("-f")
+        .arg(&tmp_path);
+    cmd.env("PGPASSWORD", &config.password);
+
+    let output = cmd.output().await.expect("pg_dump must spawn successfully");
+
+    drop(target);
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "pg_dump exited non-zero (status={:?}): stderr={}",
+        output.status.code(),
+        stderr
+    );
+
+    let dumped = std::fs::read_to_string(&tmp_path).expect("dump file should be readable");
+    assert!(
+        !dumped.is_empty(),
+        "pg_dump produced an empty file (stderr={stderr})"
+    );
+    assert!(
+        dumped.contains("PostgreSQL database dump"),
+        "dump file missing standard pg_dump header (got: {} bytes)",
+        dumped.len()
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/tests/tidb_integration.rs
+++ b/src-tauri/tests/tidb_integration.rs
@@ -36,6 +36,8 @@ macro_rules! tidb_driver {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         (
             TidbDriver::connect(&config).await.unwrap(),
@@ -77,6 +79,8 @@ macro_rules! tidb_driver_no_db {
             ssh_user: String::new(),
             ssh_password: String::new(),
             ssh_key_path: String::new(),
+            ssh_auth_method: SshAuthMethod::default(),
+            ssh_prompt_passphrase: false,
         };
         TidbDriver::connect(&config).await.unwrap()
     }};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { BackupRestoreDialog } from "./components/BackupRestore/BackupRestoreDia
 import { DumpRestoreDialog } from "./components/DumpRestore/DumpRestoreDialog";
 import { KeyboardShortcuts } from "./components/KeyboardShortcuts/KeyboardShortcuts";
 import { ToastContainer } from "./components/Toast/Toast";
+import { PassphrasePrompt } from "./components/PassphrasePrompt";
 import { useConnectionStore } from "./stores/connectionStore";
 import { useTabStore } from "./stores/tabStore";
 import { loader } from "@monaco-editor/react";
@@ -429,6 +430,7 @@ export default function App() {
         <KeyboardShortcuts onClose={() => setShowShortcuts(false)} />
       )}
       <ToastContainer />
+      <PassphrasePrompt />
     </div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,12 @@ import { DumpRestoreDialog } from "./components/DumpRestore/DumpRestoreDialog";
 import { KeyboardShortcuts } from "./components/KeyboardShortcuts/KeyboardShortcuts";
 import { ToastContainer } from "./components/Toast/Toast";
 import { PassphrasePrompt } from "./components/PassphrasePrompt";
+import { HostKeyMismatchPrompt } from "./components/HostKeyMismatchPrompt";
+import { KnownHostsDialog } from "./components/KnownHostsDialog";
 import { useConnectionStore } from "./stores/connectionStore";
 import { useTabStore } from "./stores/tabStore";
 import { loader } from "@monaco-editor/react";
-import { Database, Plus, Keyboard, Palette, Check, Cpu, MemoryStick } from "lucide-react";
+import { Database, Plus, Keyboard, Palette, Check, Cpu, MemoryStick, ShieldCheck } from "lucide-react";
 import { themes, getThemeById, applyTheme } from "./lib/themes";
 import { syncMonacoTheme } from "./lib/monacoTheme";
 import { api } from "./lib/tauri";
@@ -102,6 +104,7 @@ export default function App() {
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showZoom, setShowZoom] = useState(false);
   const [showThemePicker, setShowThemePicker] = useState(false);
+  const [showKnownHosts, setShowKnownHosts] = useState(false);
   const zoomTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const themePickerRef = useRef<HTMLDivElement>(null);
   const [themeId, setThemeId] = useState<string>(() => {
@@ -385,6 +388,19 @@ export default function App() {
                       </button>
                     ))}
                   </div>
+                  <div className="theme-picker-group">
+                    <div className="theme-picker-group-label">Settings</div>
+                    <button
+                      className="theme-picker-item"
+                      onClick={() => {
+                        setShowThemePicker(false);
+                        setShowKnownHosts(true);
+                      }}
+                    >
+                      <ShieldCheck size={13} />
+                      <span className="theme-picker-name">SSH known hosts</span>
+                    </button>
+                  </div>
                 </div>
               )}
             </div>
@@ -442,6 +458,11 @@ export default function App() {
       )}
       <ToastContainer />
       <PassphrasePrompt />
+      <HostKeyMismatchPrompt />
+      <KnownHostsDialog
+        open={showKnownHosts}
+        onClose={() => setShowKnownHosts(false)}
+      />
     </div>
     </div>
   );

--- a/src/components/BackupRestore/BackupRestoreDialog.tsx
+++ b/src/components/BackupRestore/BackupRestoreDialog.tsx
@@ -1,6 +1,9 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { api, BackupRequest, RestoreRequest } from "../../lib/tauri";
-import { useConnectionStore } from "../../stores/connectionStore";
+import {
+  useConnectionStore,
+  withHostKeyMismatchRetry,
+} from "../../stores/connectionStore";
 import {
   X,
   Loader2,
@@ -134,6 +137,12 @@ export function BackupRestoreDialog({
   onClose,
 }: Props) {
   const connections = useConnectionStore((s) => s.connections);
+  const connectionLabel = useMemo(
+    () =>
+      connections.find((c) => c.id === connectionId)?.name ||
+      "this connection",
+    [connections, connectionId],
+  );
   const [tab, setTab] = useState<Tab>("backup");
 
   const [outputPath, setOutputPath] = useState("");
@@ -233,7 +242,10 @@ export function BackupRestoreDialog({
         schema_only: contentMode === "schema",
         data_only: contentMode === "data",
       };
-      const message = await api.backupDatabase(request);
+      const message = await withHostKeyMismatchRetry(
+        connectionLabel,
+        () => api.backupDatabase(request),
+      );
       setResult(message);
     } catch (e) {
       setError(String(e));
@@ -257,7 +269,10 @@ export function BackupRestoreDialog({
         input_path: inputPath.trim(),
         format: restoreFormat,
       };
-      const message = await api.restoreDatabase(request);
+      const message = await withHostKeyMismatchRetry(
+        connectionLabel,
+        () => api.restoreDatabase(request),
+      );
       setResult(message);
     } catch (e) {
       setError(String(e));

--- a/src/components/ConnectionDialog.css
+++ b/src/components/ConnectionDialog.css
@@ -20,6 +20,15 @@
   min-width: 400px;
 }
 
+.connection-dialog {
+  width: min(840px, calc(100vw - 32px));
+  min-width: min(760px, calc(100vw - 32px));
+  max-height: min(86vh, 760px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
 .dialog-header {
   display: flex;
   align-items: center;
@@ -44,6 +53,202 @@
   gap: 16px;
 }
 
+.connection-dialog-body {
+  flex: 1;
+  min-height: 480px;
+  display: grid;
+  grid-template-columns: 206px minmax(0, 1fr);
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+  background: var(--bg-primary);
+}
+
+.connection-dialog-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 10px;
+  border-right: 1px solid var(--border);
+  background: var(--bg-secondary);
+  overflow-y: auto;
+}
+
+.connection-nav-item {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  min-height: 54px;
+  padding: 9px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+
+.connection-nav-item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.connection-nav-item--active {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 28%, transparent);
+  color: var(--text-primary);
+}
+
+.connection-nav-item--error {
+  border-color: color-mix(in srgb, var(--error) 36%, var(--border));
+}
+
+.connection-nav-item__icon {
+  display: inline-flex;
+  color: var(--text-muted);
+}
+
+.connection-nav-item--active .connection-nav-item__icon {
+  color: var(--accent);
+}
+
+.connection-nav-item__text {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.connection-nav-item__label {
+  color: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.connection-nav-item__description {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connection-nav-item__error {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--error);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.connection-dialog-content {
+  min-width: 0;
+  overflow-y: auto;
+  padding: 22px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.connection-section-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.connection-section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.connection-section-heading h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.connection-section-heading p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.connection-section-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-field-description {
+  margin-top: -2px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.auth-method-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.auth-method-card--active {
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-secondary));
+}
+
+.auth-method-card svg {
+  color: var(--accent);
+  margin-top: 1px;
+  flex-shrink: 0;
+}
+
+.auth-method-card strong {
+  display: block;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 3px;
+}
+
+.auth-method-card span {
+  display: block;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.connection-section-note {
+  padding: 13px 14px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
 .dialog-footer {
   display: flex;
   align-items: center;
@@ -56,6 +261,11 @@
   position: sticky;
   bottom: 0;
   z-index: 1;
+}
+
+.connection-dialog .dialog-header,
+.connection-dialog .dialog-footer {
+  flex-shrink: 0;
 }
 
 .dialog-footer-right {
@@ -510,8 +720,8 @@
   flex-direction: column;
   align-items: stretch;
   gap: 12px;
-  padding-top: 8px;
-  border-top: 1px solid var(--border);
+  padding-top: 0;
+  border-top: none;
 }
 
 .ssh-tunnel-fields {
@@ -624,4 +834,54 @@
 .group-suggestion-item:hover svg {
   color: var(--accent);
   opacity: 1;
+}
+
+@media (max-width: 760px) {
+  .connection-dialog {
+    width: calc(100vw - 20px);
+    min-width: 0;
+    max-height: 90vh;
+  }
+
+  .connection-dialog-body {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .connection-dialog-nav {
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding: 10px;
+  }
+
+  .connection-nav-item {
+    flex: 0 0 160px;
+    min-height: 48px;
+  }
+
+  .connection-dialog-content {
+    padding: 16px;
+  }
+
+  .form-row {
+    flex-direction: column;
+  }
+
+  .form-group--db-type {
+    flex-basis: auto;
+  }
+
+  .security-options {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .ssh-tunnel-fields {
+    padding-left: 0;
+  }
 }

--- a/src/components/ConnectionDialog.css
+++ b/src/components/ConnectionDialog.css
@@ -504,6 +504,73 @@
   margin-left: 6px;
 }
 
+/* SSH Tunnel section in the Register Server dialog. Sits below the SSL
+   block and matches the surrounding form-row / security-toggle styles. */
+.ssh-tunnel-section {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.ssh-tunnel-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-left: 36px;
+  /* Align with the toggle's text column above. */
+}
+
+.ssh-auth-toggle {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  width: fit-content;
+}
+
+.ssh-auth-toggle__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.ssh-auth-toggle__btn:hover {
+  color: var(--text-primary);
+}
+
+.ssh-auth-toggle__btn--active {
+  color: var(--accent);
+  background: var(--accent-muted);
+}
+
+.ssh-file-picker {
+  display: flex;
+  gap: 6px;
+}
+
+.ssh-file-picker > input {
+  flex: 1;
+  min-width: 0;
+}
+
+.ssh-file-picker__browse {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .group-input-wrapper {
   position: relative;
 }

--- a/src/components/ConnectionDialog.css
+++ b/src/components/ConnectionDialog.css
@@ -732,6 +732,58 @@
   /* Align with the toggle's text column above. */
 }
 
+.ssh-tunnel-warning {
+  display: grid;
+  grid-template-columns: 14px 1fr;
+  gap: 8px;
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.45;
+  background: rgba(250, 196, 23, 0.08);
+  border: 1px solid rgba(250, 196, 23, 0.45);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+}
+
+.ssh-tunnel-warning > svg {
+  color: rgb(250, 196, 23);
+  margin-top: 2px;
+}
+
+.ssh-tunnel-warning strong {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.ssh-tunnel-warning span {
+  color: var(--text-secondary);
+}
+
+.ssh-tunnel-warning code {
+  padding: 0 4px;
+  font-size: 11px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+}
+
+.ssh-tunnel-warning em {
+  font-style: normal;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ssh-tunnel-warning--info {
+  background: rgba(89, 178, 250, 0.08);
+  border-color: rgba(89, 178, 250, 0.45);
+}
+
+.ssh-tunnel-warning--info > svg {
+  color: rgb(89, 178, 250);
+}
+
 .ssh-auth-toggle {
   display: inline-flex;
   gap: 4px;

--- a/src/components/ConnectionDialog.test.ts
+++ b/src/components/ConnectionDialog.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeConnectionForm,
+  validateConnectionForm,
+} from "./ConnectionDialog";
+import type { ConnectionConfig } from "../lib/tauri";
+
+const baseConfig: ConnectionConfig = {
+  id: "id-1",
+  name: "My DB",
+  db_type: "postgres",
+  host: "db.example.com",
+  port: 5432,
+  user: "alice",
+  password: "secret",
+  database: "appdb",
+  color: "#89b4fa",
+  ssl: false,
+  trust_server_cert: false,
+  group: null,
+  ssh_enabled: false,
+  ssh_host: "",
+  ssh_port: 22,
+  ssh_user: "",
+  ssh_password: "",
+  ssh_key_path: "",
+  ssh_auth_method: "password",
+  ssh_prompt_passphrase: false,
+};
+
+describe("normalizeConnectionForm — SSH fields", () => {
+  it("clears every SSH field when ssh_enabled is false", () => {
+    const dirty: ConnectionConfig = {
+      ...baseConfig,
+      ssh_enabled: false,
+      ssh_host: "  bastion ",
+      ssh_user: " alice ",
+      ssh_password: "leftover",
+      ssh_key_path: "/tmp/leftover",
+      ssh_auth_method: "identityfile",
+      ssh_prompt_passphrase: true,
+    };
+    const out = normalizeConnectionForm(dirty);
+    expect(out.ssh_enabled).toBe(false);
+    expect(out.ssh_host).toBe("");
+    expect(out.ssh_user).toBe("");
+    expect(out.ssh_password).toBe("");
+    expect(out.ssh_key_path).toBe("");
+    expect(out.ssh_auth_method).toBe("password");
+    expect(out.ssh_prompt_passphrase).toBe(false);
+  });
+
+  it("trims ssh_host and ssh_user when SSH is enabled", () => {
+    const out = normalizeConnectionForm({
+      ...baseConfig,
+      ssh_enabled: true,
+      ssh_host: "  bastion.example.com  ",
+      ssh_user: " alice ",
+      ssh_password: "p",
+      ssh_auth_method: "password",
+    });
+    expect(out.ssh_host).toBe("bastion.example.com");
+    expect(out.ssh_user).toBe("alice");
+  });
+
+  it("clears ssh_key_path when auth = password", () => {
+    const out = normalizeConnectionForm({
+      ...baseConfig,
+      ssh_enabled: true,
+      ssh_host: "h",
+      ssh_user: "u",
+      ssh_password: "p",
+      ssh_key_path: "/tmp/key",
+      ssh_auth_method: "password",
+    });
+    expect(out.ssh_key_path).toBe("");
+  });
+
+  it("trims ssh_key_path when auth = identityfile", () => {
+    const out = normalizeConnectionForm({
+      ...baseConfig,
+      ssh_enabled: true,
+      ssh_host: "h",
+      ssh_user: "u",
+      ssh_key_path: "  /home/alice/.ssh/id_ed25519  ",
+      ssh_auth_method: "identityfile",
+    });
+    expect(out.ssh_key_path).toBe("/home/alice/.ssh/id_ed25519");
+  });
+
+  it("blanks the stored passphrase when prompt-for-passphrase is on", () => {
+    const out = normalizeConnectionForm({
+      ...baseConfig,
+      ssh_enabled: true,
+      ssh_host: "h",
+      ssh_user: "u",
+      ssh_password: "should-not-be-saved",
+      ssh_key_path: "/k",
+      ssh_auth_method: "identityfile",
+      ssh_prompt_passphrase: true,
+    });
+    expect(out.ssh_password).toBe("");
+    expect(out.ssh_prompt_passphrase).toBe(true);
+  });
+
+  it("ignores prompt-for-passphrase when auth = password", () => {
+    const out = normalizeConnectionForm({
+      ...baseConfig,
+      ssh_enabled: true,
+      ssh_host: "h",
+      ssh_user: "u",
+      ssh_password: "secret-bastion-password",
+      ssh_auth_method: "password",
+      ssh_prompt_passphrase: true,
+    });
+    expect(out.ssh_prompt_passphrase).toBe(false);
+    expect(out.ssh_password).toBe("secret-bastion-password");
+  });
+
+  it("falls back to ssh_port = 22 when missing", () => {
+    const out = normalizeConnectionForm({
+      ...baseConfig,
+      ssh_enabled: true,
+      ssh_host: "h",
+      ssh_user: "u",
+      ssh_password: "p",
+      ssh_port: undefined as unknown as number,
+    });
+    expect(out.ssh_port).toBe(22);
+  });
+});
+
+describe("validateConnectionForm — SSH rules", () => {
+  it("requires ssh_host, ssh_user and ssh_password when SSH + password auth", () => {
+    const errors = validateConnectionForm(
+      {
+        ...baseConfig,
+        ssh_enabled: true,
+        ssh_host: "",
+        ssh_user: "",
+        ssh_password: "",
+        ssh_auth_method: "password",
+      },
+      [],
+    );
+    expect(errors.ssh_host).toBeTruthy();
+    expect(errors.ssh_user).toBeTruthy();
+    expect(errors.ssh_password).toBeTruthy();
+    // No identity-file path is required in password mode.
+    expect(errors.ssh_key_path).toBeUndefined();
+  });
+
+  it("requires ssh_key_path when SSH + identity-file auth", () => {
+    const errors = validateConnectionForm(
+      {
+        ...baseConfig,
+        ssh_enabled: true,
+        ssh_host: "h",
+        ssh_user: "u",
+        ssh_password: "",
+        ssh_key_path: "",
+        ssh_auth_method: "identityfile",
+      },
+      [],
+    );
+    expect(errors.ssh_key_path).toBeTruthy();
+    // ssh_password is the (optional) passphrase in this mode; not required.
+    expect(errors.ssh_password).toBeUndefined();
+  });
+
+  it("rejects out-of-range SSH ports", () => {
+    const errors = validateConnectionForm(
+      {
+        ...baseConfig,
+        ssh_enabled: true,
+        ssh_host: "h",
+        ssh_user: "u",
+        ssh_password: "p",
+        ssh_port: 70000,
+      },
+      [],
+    );
+    expect(errors.ssh_port).toBeTruthy();
+  });
+
+  it("does not enforce SSH validation when SSH is disabled", () => {
+    const errors = validateConnectionForm(
+      {
+        ...baseConfig,
+        ssh_enabled: false,
+        ssh_host: "",
+        ssh_user: "",
+        ssh_password: "",
+      },
+      [],
+    );
+    expect(errors.ssh_host).toBeUndefined();
+    expect(errors.ssh_user).toBeUndefined();
+    expect(errors.ssh_password).toBeUndefined();
+  });
+
+  it("ignores SSH for SQLite connections", () => {
+    const errors = validateConnectionForm(
+      {
+        ...baseConfig,
+        db_type: "sqlite",
+        host: "",
+        user: "",
+        database: "/tmp/db.sqlite",
+        ssh_enabled: true,
+        ssh_host: "",
+        ssh_user: "",
+      },
+      [],
+    );
+    expect(errors.ssh_host).toBeUndefined();
+    expect(errors.ssh_user).toBeUndefined();
+  });
+
+  it("still validates DB host/user alongside SSH validation for postgres", () => {
+    const errors = validateConnectionForm(
+      {
+        ...baseConfig,
+        host: "",
+        user: "",
+        ssh_enabled: true,
+        ssh_host: "",
+        ssh_user: "",
+        ssh_password: "",
+      },
+      [],
+    );
+    expect(errors.host).toBeTruthy();
+    expect(errors.user).toBeTruthy();
+    expect(errors.ssh_host).toBeTruthy();
+    expect(errors.ssh_user).toBeTruthy();
+  });
+});

--- a/src/components/ConnectionDialog.tsx
+++ b/src/components/ConnectionDialog.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { useConnectionStore } from "../stores/connectionStore";
+import {
+  resolveSshPassphrase,
+  useConnectionStore,
+  withHostKeyMismatchRetry,
+} from "../stores/connectionStore";
 import { api, ConnectionConfig, SshAuthMethod } from "../lib/tauri";
 import {
   AlertCircle,
@@ -590,6 +594,24 @@ function SshTunnelSection({
     }
   };
 
+  // --- Cross-section advisories ---
+  // We surface these in the SSH section because they only matter when
+  // SSH is *enabled*, but they're triggered by other fields (SSL on
+  // General-style settings; the chosen DB driver). Displayed inline so
+  // the user sees them at the moment they enable the tunnel rather
+  // than discovering them at connect time.
+  const tlsVerifyConflict =
+    enabled && !!form.ssl && !form.trust_server_cert && form.db_type !== "cassandra";
+  const cassandraPeerDiscovery = enabled && form.db_type === "cassandra";
+  // Warns only when the field actually contains something — empty
+  // passphrases are unencrypted keys, not a security risk.
+  const persistedPassphrase =
+    enabled &&
+    isIdentity &&
+    !promptPassphrase &&
+    !!form.ssh_password &&
+    form.ssh_password.length > 0;
+
   return (
     <div className="security-options ssh-tunnel-section" aria-label="SSH tunnel">
       <label className={`security-toggle${enabled ? " security-toggle--active" : ""}`}>
@@ -609,6 +631,35 @@ function SshTunnelSection({
 
       {enabled && (
         <div className="ssh-tunnel-fields">
+          {tlsVerifyConflict && (
+            <div className="ssh-tunnel-warning" role="alert">
+              <AlertCircle size={14} />
+              <div>
+                <strong>SSL hostname verification will fail.</strong>
+                <span>
+                  After tunneling, the driver connects to{" "}
+                  <code>127.0.0.1</code> — the server certificate's hostname
+                  won't match. Either turn on{" "}
+                  <em>Trust server certificate</em> in the Security section, or
+                  disable SSL.
+                </span>
+              </div>
+            </div>
+          )}
+          {cassandraPeerDiscovery && (
+            <div className="ssh-tunnel-warning" role="alert">
+              <AlertCircle size={14} />
+              <div>
+                <strong>Cassandra cluster discovery bypasses the tunnel.</strong>
+                <span>
+                  The driver contacts the seed node through the tunnel, then
+                  opens direct TCP connections to every peer it learns about.
+                  This works for single-node clusters; multi-node clusters
+                  need each peer reachable directly or its own forward.
+                </span>
+              </div>
+            </div>
+          )}
           <div className="form-row">
             <div
               className={`form-group flex-1${getFieldError("ssh_host") ? " form-group--error" : ""}`}
@@ -735,6 +786,23 @@ function SshTunnelSection({
                 {getFieldError("ssh_password") && (
                   <div className="field-error">{getFieldError("ssh_password")}</div>
                 )}
+              </div>
+            </div>
+          )}
+
+          {persistedPassphrase && (
+            <div
+              className="ssh-tunnel-warning ssh-tunnel-warning--info"
+              role="status"
+            >
+              <AlertCircle size={14} />
+              <div>
+                <strong>Passphrase will be saved to disk.</strong>
+                <span>
+                  Tablio stores connection details in plain text. Enable
+                  <em> Prompt for passphrase?</em> below to be asked at
+                  connect time instead.
+                </span>
               </div>
             </div>
           )}
@@ -904,7 +972,15 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
     setTestError("");
     setTesting(true);
     try {
-      await api.testConnection(normalized);
+      // Walk the same SSH UX as a live connect: prompt for the
+      // identity-file passphrase if the user opted not to persist it,
+      // and offer a Forget & Retry modal when the bastion's host key
+      // has changed. Without this the user would just see a raw
+      // `ssh_host_key_mismatch:{...}` error string.
+      const effective = await resolveSshPassphrase(normalized);
+      await withHostKeyMismatchRetry(normalized.name || "this connection", () =>
+        api.testConnection(effective),
+      );
       setTestResult("success");
     } catch (e) {
       setTestResult("error");

--- a/src/components/ConnectionDialog.tsx
+++ b/src/components/ConnectionDialog.tsx
@@ -11,7 +11,6 @@ import {
   Key,
   Loader2,
   Lock,
-  Server,
   Shield,
   SlidersHorizontal,
   UserRound,
@@ -29,15 +28,23 @@ const COLORS = [
 ];
 
 const DB_TYPES = [
-  { value: "postgres" as const, label: "PostgreSQL", short: "PG", defaultPort: 5432, accent: "#89b4fa" },
-  { value: "mysql" as const, label: "MySQL", short: "MY", defaultPort: 3306, accent: "#f9e2af" },
-  { value: "sqlite" as const, label: "SQLite", short: "SQ", defaultPort: 0, accent: "#94e2d5" },
-  { value: "mariadb" as const, label: "MariaDB", short: "MA", defaultPort: 3306, accent: "#fab387" },
-  { value: "cockroachdb" as const, label: "CockroachDB", short: "CR", defaultPort: 26257, accent: "#cba6f7" },
-  { value: "tidb" as const, label: "TiDB", short: "TI", defaultPort: 4000, accent: "#f38ba8" },
-  { value: "cassandra" as const, label: "Cassandra / ScyllaDB", short: "CS", defaultPort: 9042, accent: "#a6e3a1" },
-  { value: "mssql" as const, label: "Microsoft SQL Server", short: "MS", defaultPort: 1433, accent: "#7aa2f7" },
+  { value: "postgres" as const, label: "PostgreSQL", short: "PG", defaultPort: 5432, defaultUser: "postgres", accent: "#89b4fa" },
+  { value: "mysql" as const, label: "MySQL", short: "MY", defaultPort: 3306, defaultUser: "root", accent: "#f9e2af" },
+  { value: "sqlite" as const, label: "SQLite", short: "SQ", defaultPort: 0, defaultUser: "", accent: "#94e2d5" },
+  { value: "mariadb" as const, label: "MariaDB", short: "MA", defaultPort: 3306, defaultUser: "root", accent: "#fab387" },
+  { value: "cockroachdb" as const, label: "CockroachDB", short: "CR", defaultPort: 26257, defaultUser: "root", accent: "#cba6f7" },
+  { value: "tidb" as const, label: "TiDB", short: "TI", defaultPort: 4000, defaultUser: "root", accent: "#f38ba8" },
+  { value: "cassandra" as const, label: "Cassandra / ScyllaDB", short: "CS", defaultPort: 9042, defaultUser: "cassandra", accent: "#a6e3a1" },
+  { value: "mssql" as const, label: "Microsoft SQL Server", short: "MS", defaultPort: 1433, defaultUser: "sa", accent: "#7aa2f7" },
 ];
+
+/** Set of every per-driver default username, used to detect whether the
+ *  current `user` value is "still a default" so we can safely swap it
+ *  when the user changes DB type. A username they typed by hand is
+ *  preserved across DB-type changes. */
+const DEFAULT_USERNAMES = new Set(
+  DB_TYPES.map((d) => d.defaultUser).filter((u) => u.length > 0),
+);
 
 type ValidationField =
   | "name"
@@ -54,7 +61,6 @@ type ValidationErrors = Partial<Record<ValidationField, string>>;
 
 type DialogSectionId =
   | "general"
-  | "connection"
   | "authentication"
   | "security"
   | "ssh"
@@ -68,8 +74,10 @@ interface DialogSection {
 }
 
 const SECTION_FIELDS: Record<DialogSectionId, ValidationField[]> = {
-  general: ["name"],
-  connection: ["host", "port", "database"],
+  // General owns the basic identity *and* connection target — these
+  // typically fit on one screen and splitting them across two nav items
+  // wasted vertical space without adding clarity.
+  general: ["name", "host", "port", "database"],
   authentication: ["user"],
   security: [],
   ssh: ["ssh_host", "ssh_port", "ssh_user", "ssh_password", "ssh_key_path"],
@@ -84,14 +92,10 @@ function getConnectionDialogSections(
     {
       id: "general",
       label: "General",
-      description: "Name, type, folder and colour",
+      description: isSqlite
+        ? "Name, type, folder and database file"
+        : "Name, type and connection target",
       icon: <Database size={16} />,
-    },
-    {
-      id: "connection",
-      label: "Connection",
-      description: isSqlite ? "Local database file" : "Host, port and database",
-      icon: <Server size={16} />,
     },
   ];
 
@@ -600,7 +604,6 @@ function SshTunnelSection({
         </span>
         <span className="security-toggle__text">
           <span className="security-toggle__label">Use SSH tunneling</span>
-          <span className="security-toggle__meta">connect through an SSH bastion</span>
         </span>
       </label>
 
@@ -753,9 +756,6 @@ function SshTunnelSection({
               </span>
               <span className="security-toggle__text">
                 <span className="security-toggle__label">Prompt for passphrase?</span>
-                <span className="security-toggle__meta">
-                  ask each time instead of saving the passphrase to disk
-                </span>
               </span>
             </label>
           )}
@@ -799,7 +799,7 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
       db_type: "postgres",
       host: "localhost",
       port: 5432,
-      user: "",
+      user: DB_TYPES.find((d) => d.value === "postgres")!.defaultUser,
       password: "",
       database: "",
       color: COLORS[0],
@@ -874,12 +874,21 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
 
   const handleDbTypeChange = (dbType: ConnectionConfig["db_type"]) => {
     const info = DB_TYPES.find((d) => d.value === dbType)!;
-    setForm((f) => ({
-      ...f,
-      db_type: dbType,
-      port: info.defaultPort,
-      host: dbType === "sqlite" ? "" : f.host || "localhost",
-    }));
+    setForm((f) => {
+      // Only swap the username when it's still a default value (or
+      // empty); a value the user typed by hand survives a DB-type
+      // change so they don't lose their work flipping back and forth.
+      const trimmedUser = f.user.trim();
+      const isStillDefault =
+        trimmedUser === "" || DEFAULT_USERNAMES.has(trimmedUser);
+      return {
+        ...f,
+        db_type: dbType,
+        port: info.defaultPort,
+        host: dbType === "sqlite" ? "" : f.host || "localhost",
+        user: isStillDefault ? info.defaultUser : f.user,
+      };
+    });
     setTestResult(null);
     setTestError("");
   };
@@ -986,71 +995,69 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
                       />
                     </FormField>
                   </div>
-                </>
-              )}
 
-              {activeSection === "connection" && (
-                isSqlite ? (
-                  <FormField
-                    label="Database File Path"
-                    error={getFieldError("database")}
-                    description="SQLite connections use a local database file instead of a network host."
-                  >
-                    <input
-                      value={form.database}
-                      onChange={(e) => updateField("database", e.target.value)}
-                      onBlur={() => touchField("database")}
-                      placeholder="/path/to/database.db"
-                      aria-invalid={!!getFieldError("database")}
-                    />
-                  </FormField>
-                ) : (
-                  <>
-                    <div className="form-row">
-                      <FormField
-                        label="Host"
-                        error={getFieldError("host")}
-                        className="flex-1"
-                      >
-                        <input
-                          value={form.host}
-                          onChange={(e) => updateField("host", e.target.value)}
-                          onBlur={() => touchField("host")}
-                          placeholder="localhost"
-                          aria-invalid={!!getFieldError("host")}
-                        />
-                      </FormField>
-                      <FormField
-                        label="Port"
-                        error={getFieldError("port")}
-                        style={{ width: 112 }}
-                      >
-                        <input
-                          type="number"
-                          value={form.port}
-                          onChange={(e) => updateField("port", parseInt(e.target.value, 10) || 0)}
-                          onBlur={() => touchField("port")}
-                          min={1}
-                          max={65535}
-                          aria-invalid={!!getFieldError("port")}
-                        />
-                      </FormField>
-                    </div>
-
+                  {isSqlite ? (
                     <FormField
-                      label={form.db_type === "cassandra" ? "Keyspace (optional)" : "Database (optional)"}
+                      label="Database File Path"
                       error={getFieldError("database")}
+                      description="SQLite connections use a local database file instead of a network host."
                     >
                       <input
                         value={form.database}
                         onChange={(e) => updateField("database", e.target.value)}
                         onBlur={() => touchField("database")}
-                        placeholder={form.db_type === "cassandra" ? "my_keyspace" : "mydb"}
+                        placeholder="/path/to/database.db"
                         aria-invalid={!!getFieldError("database")}
                       />
                     </FormField>
-                  </>
-                )
+                  ) : (
+                    <>
+                      <div className="form-row">
+                        <FormField
+                          label="Host"
+                          error={getFieldError("host")}
+                          className="flex-1"
+                        >
+                          <input
+                            value={form.host}
+                            onChange={(e) => updateField("host", e.target.value)}
+                            onBlur={() => touchField("host")}
+                            placeholder="localhost"
+                            aria-invalid={!!getFieldError("host")}
+                          />
+                        </FormField>
+                        <FormField
+                          label="Port"
+                          error={getFieldError("port")}
+                          style={{ width: 112 }}
+                        >
+                          <input
+                            type="number"
+                            value={form.port}
+                            onChange={(e) => updateField("port", parseInt(e.target.value, 10) || 0)}
+                            onBlur={() => touchField("port")}
+                            min={1}
+                            max={65535}
+                            aria-invalid={!!getFieldError("port")}
+                          />
+                        </FormField>
+                      </div>
+
+                      <FormField
+                        label={form.db_type === "cassandra" ? "Keyspace (optional)" : "Database (optional)"}
+                        error={getFieldError("database")}
+                      >
+                        <input
+                          value={form.database}
+                          onChange={(e) => updateField("database", e.target.value)}
+                          onBlur={() => touchField("database")}
+                          placeholder={form.db_type === "cassandra" ? "my_keyspace" : "mydb"}
+                          aria-invalid={!!getFieldError("database")}
+                        />
+                      </FormField>
+                    </>
+                  )}
+                </>
               )}
 
               {activeSection === "authentication" && !isSqlite && (
@@ -1128,7 +1135,6 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
                       </span>
                       <span className="security-toggle__text">
                         <span className="security-toggle__label">Trust server certificate</span>
-                        <span className="security-toggle__meta">(self-signed)</span>
                       </span>
                     </label>
                   </div>

--- a/src/components/ConnectionDialog.tsx
+++ b/src/components/ConnectionDialog.tsx
@@ -1,8 +1,23 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useConnectionStore } from "../stores/connectionStore";
 import { api, ConnectionConfig, SshAuthMethod } from "../lib/tauri";
-import { X, Loader2, CheckCircle, XCircle, ChevronDown, Folder, Key, Lock } from "lucide-react";
+import {
+  AlertCircle,
+  CheckCircle,
+  ChevronDown,
+  Database,
+  Folder,
+  Key,
+  Loader2,
+  Lock,
+  Server,
+  Shield,
+  SlidersHorizontal,
+  UserRound,
+  X,
+  XCircle,
+} from "lucide-react";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import "./ConnectionDialog.css";
 
@@ -36,6 +51,212 @@ type ValidationField =
   | "ssh_password"
   | "ssh_key_path";
 type ValidationErrors = Partial<Record<ValidationField, string>>;
+
+type DialogSectionId =
+  | "general"
+  | "connection"
+  | "authentication"
+  | "security"
+  | "ssh"
+  | "advanced";
+
+interface DialogSection {
+  id: DialogSectionId;
+  label: string;
+  description: string;
+  icon: ReactNode;
+}
+
+const SECTION_FIELDS: Record<DialogSectionId, ValidationField[]> = {
+  general: ["name"],
+  connection: ["host", "port", "database"],
+  authentication: ["user"],
+  security: [],
+  ssh: ["ssh_host", "ssh_port", "ssh_user", "ssh_password", "ssh_key_path"],
+  advanced: [],
+};
+
+function getConnectionDialogSections(
+  isSqlite: boolean,
+  supportsTlsOptions: boolean,
+): DialogSection[] {
+  const sections: DialogSection[] = [
+    {
+      id: "general",
+      label: "General",
+      description: "Name, type, folder and colour",
+      icon: <Database size={16} />,
+    },
+    {
+      id: "connection",
+      label: "Connection",
+      description: isSqlite ? "Local database file" : "Host, port and database",
+      icon: <Server size={16} />,
+    },
+  ];
+
+  if (!isSqlite) {
+    sections.push(
+      {
+        id: "authentication",
+        label: "Authentication",
+        description: "User credentials and future auth methods",
+        icon: <UserRound size={16} />,
+      },
+      {
+        id: "security",
+        label: "Security",
+        description: supportsTlsOptions ? "TLS and certificates" : "Driver-managed transport",
+        icon: <Shield size={16} />,
+      },
+      {
+        id: "ssh",
+        label: "SSH Tunnel",
+        description: "Bastion host and SSH auth",
+        icon: <Key size={16} />,
+      },
+    );
+  }
+
+  sections.push({
+    id: "advanced",
+    label: "Advanced",
+    description: "Parameters and driver options",
+    icon: <SlidersHorizontal size={16} />,
+  });
+
+  return sections;
+}
+
+function getSectionErrorCount(
+  sectionId: DialogSectionId,
+  errors: ValidationErrors,
+): number {
+  return SECTION_FIELDS[sectionId].filter((field) => !!errors[field]).length;
+}
+
+function getFirstInvalidSection(
+  errors: ValidationErrors,
+  sections: DialogSection[],
+): DialogSectionId | null {
+  return sections.find((section) => getSectionErrorCount(section.id, errors) > 0)?.id ?? null;
+}
+
+function FormField({
+  label,
+  error,
+  children,
+  className = "",
+  style,
+  description,
+}: {
+  label: string;
+  error?: string;
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  description?: string;
+}) {
+  return (
+    <div
+      className={`form-group${className ? ` ${className}` : ""}${error ? " form-group--error" : ""}`}
+      style={style}
+    >
+      <label>{label}</label>
+      {description && <div className="form-field-description">{description}</div>}
+      {children}
+      {error && <div className="field-error">{error}</div>}
+    </div>
+  );
+}
+
+function SectionCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="connection-section-card" aria-label={title}>
+      <div className="connection-section-heading">
+        <h3>{title}</h3>
+        <p>{description}</p>
+      </div>
+      <div className="connection-section-fields">{children}</div>
+    </section>
+  );
+}
+
+function ConnectionDialogNav({
+  sections,
+  activeSection,
+  errors,
+  showErrors,
+  onSelect,
+}: {
+  sections: DialogSection[];
+  activeSection: DialogSectionId;
+  errors: ValidationErrors;
+  showErrors: boolean;
+  onSelect: (sectionId: DialogSectionId) => void;
+}) {
+  return (
+    <nav className="connection-dialog-nav" aria-label="Connection settings sections">
+      {sections.map((section) => {
+        const errorCount = showErrors ? getSectionErrorCount(section.id, errors) : 0;
+        return (
+          <button
+            key={section.id}
+            type="button"
+            className={`connection-nav-item${
+              activeSection === section.id ? " connection-nav-item--active" : ""
+            }${errorCount > 0 ? " connection-nav-item--error" : ""}`}
+            onClick={() => onSelect(section.id)}
+            data-section={section.id}
+          >
+            <span className="connection-nav-item__icon">{section.icon}</span>
+            <span className="connection-nav-item__text">
+              <span className="connection-nav-item__label">{section.label}</span>
+              <span className="connection-nav-item__description">{section.description}</span>
+            </span>
+            {errorCount > 0 && (
+              <span className="connection-nav-item__error" title={`${errorCount} validation error${errorCount === 1 ? "" : "s"}`}>
+                <AlertCircle size={13} />
+                {errorCount}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+function ColorPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="color-picker">
+      {COLORS.map((c) => (
+        <button
+          key={c}
+          type="button"
+          className={`color-dot ${value === c ? "active" : ""}`}
+          style={{ background: c }}
+          onClick={() => onChange(c)}
+          aria-label={`Use colour ${c}`}
+        />
+      ))}
+    </div>
+  );
+}
 
 export function normalizeConnectionForm(form: ConnectionConfig): ConnectionConfig {
   const sshEnabled = !!form.ssh_enabled;
@@ -600,13 +821,27 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
   const [saving, setSaving] = useState(false);
   const [showValidation, setShowValidation] = useState(false);
   const [touched, setTouched] = useState<Partial<Record<ValidationField, boolean>>>({});
+  const [activeSection, setActiveSection] = useState<DialogSectionId>("general");
   const testingRef = useRef(false);
 
   const isSqlite = form.db_type === "sqlite";
+  const supportsTlsOptions = !isSqlite && form.db_type !== "cassandra";
+  const dialogSections = useMemo(
+    () => getConnectionDialogSections(isSqlite, supportsTlsOptions),
+    [isSqlite, supportsTlsOptions],
+  );
   const validationErrors = useMemo(
     () => validateConnectionForm(form, connections),
     [form, connections],
   );
+  const activeSectionMeta =
+    dialogSections.find((section) => section.id === activeSection) ?? dialogSections[0];
+
+  useEffect(() => {
+    if (!dialogSections.some((section) => section.id === activeSection)) {
+      setActiveSection(dialogSections[0].id);
+    }
+  }, [activeSection, dialogSections]);
 
   const touchField = (field: ValidationField) => {
     setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
@@ -627,6 +862,8 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
     setShowValidation(true);
     const nextErrors = validateConnectionForm(normalized, connections);
     if (Object.keys(nextErrors).length > 0) {
+      const firstInvalidSection = getFirstInvalidSection(nextErrors, dialogSections);
+      if (firstInvalidSection) setActiveSection(firstInvalidSection);
       setTestResult(null);
       setTestError("Please fix the highlighted fields.");
       return null;
@@ -648,7 +885,6 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
   };
 
   const [testing, setTesting] = useState(false);
-  const supportsTlsOptions = !isSqlite && form.db_type !== "cassandra";
 
   const handleTest = async () => {
     if (testingRef.current) return;
@@ -690,7 +926,7 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
 
   return (
     <div className="dialog-overlay">
-      <div className="dialog">
+      <div className="dialog connection-dialog">
         <div className="dialog-header">
           <h2>{isEdit ? "Edit Connection" : "New Connection"}</h2>
           <button className="btn-icon" onClick={onClose}>
@@ -698,199 +934,231 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
           </button>
         </div>
 
-        <div className="dialog-body">
-          <div className="form-row">
-            <DbTypeDropdown
-              value={form.db_type}
-              onChange={handleDbTypeChange}
-              className="form-group--db-type"
-            />
-            <div className={`form-group flex-1${getFieldError("name") ? " form-group--error" : ""}`}>
-              <label>Connection Name</label>
-              <input
-                value={form.name}
-                onChange={(e) => updateField("name", e.target.value)}
-                onBlur={() => touchField("name")}
-                placeholder="My Database"
-                aria-invalid={!!getFieldError("name")}
-              />
-              {getFieldError("name") && <div className="field-error">{getFieldError("name")}</div>}
-            </div>
-          </div>
-
-          {isSqlite ? (
-            <div className="form-row">
-              <div className={`form-group flex-1${getFieldError("database") ? " form-group--error" : ""}`}>
-                <label>Database File Path</label>
-                <input
-                  value={form.database}
-                  onChange={(e) => updateField("database", e.target.value)}
-                  onBlur={() => touchField("database")}
-                  placeholder="/path/to/database.db"
-                  aria-invalid={!!getFieldError("database")}
-                />
-                {getFieldError("database") && (
-                  <div className="field-error">{getFieldError("database")}</div>
-                )}
-              </div>
-              <div className="form-group form-group--color">
-                <label>Color</label>
-                <div className="color-picker">
-                  {COLORS.map((c) => (
-                    <button
-                      key={c}
-                      className={`color-dot ${form.color === c ? "active" : ""}`}
-                      style={{ background: c }}
-                      onClick={() => setForm((f) => ({ ...f, color: c }))}
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
-          ) : (
-            <>
-              <div className="form-row">
-                <div className={`form-group flex-1${getFieldError("host") ? " form-group--error" : ""}`}>
-                  <label>Host</label>
-                  <input
-                    value={form.host}
-                    onChange={(e) => updateField("host", e.target.value)}
-                    onBlur={() => touchField("host")}
-                    placeholder="localhost"
-                    aria-invalid={!!getFieldError("host")}
-                  />
-                  {getFieldError("host") && <div className="field-error">{getFieldError("host")}</div>}
-                </div>
-                <div className={`form-group${getFieldError("port") ? " form-group--error" : ""}`} style={{ width: 100 }}>
-                  <label>Port</label>
-                  <input
-                    type="number"
-                    value={form.port}
-                    onChange={(e) => updateField("port", parseInt(e.target.value, 10) || 0)}
-                    onBlur={() => touchField("port")}
-                    min={1}
-                    max={65535}
-                    aria-invalid={!!getFieldError("port")}
-                  />
-                  {getFieldError("port") && <div className="field-error">{getFieldError("port")}</div>}
-                </div>
-              </div>
-
-              <div className="form-row">
-                <div className={`form-group flex-1${getFieldError("user") ? " form-group--error" : ""}`}>
-                  <label>Username</label>
-                  <input
-                    value={form.user}
-                    onChange={(e) => updateField("user", e.target.value)}
-                    onBlur={() => touchField("user")}
-                    placeholder="postgres"
-                    aria-invalid={!!getFieldError("user")}
-                  />
-                  {getFieldError("user") && <div className="field-error">{getFieldError("user")}</div>}
-                </div>
-                <div className="form-group flex-1">
-                  <label>Password</label>
-                  <input
-                    type="password"
-                    value={form.password}
-                    onChange={(e) => updateField("password", e.target.value)}
-                  />
-                </div>
-              </div>
-
-              <div className="form-row">
-                <div className={`form-group flex-1${getFieldError("database") ? " form-group--error" : ""}`}>
-                  <label>{form.db_type === "cassandra" ? "Keyspace (optional)" : "Database (optional)"}</label>
-                  <input
-                    value={form.database}
-                    onChange={(e) => updateField("database", e.target.value)}
-                    onBlur={() => touchField("database")}
-                    placeholder={form.db_type === "cassandra" ? "my_keyspace" : "mydb"}
-                    aria-invalid={!!getFieldError("database")}
-                  />
-                  {getFieldError("database") && (
-                    <div className="field-error">{getFieldError("database")}</div>
-                  )}
-                </div>
-                <div className="form-group form-group--color">
-                  <label>Color</label>
-                  <div className="color-picker">
-                    {COLORS.map((c) => (
-                      <button
-                        key={c}
-                        className={`color-dot ${form.color === c ? "active" : ""}`}
-                        style={{ background: c }}
-                        onClick={() => setForm((f) => ({ ...f, color: c }))}
-                      />
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </>
-          )}
-
-          {supportsTlsOptions && (
-            <div className="security-options" aria-label="Transport security">
-              <label className={`security-toggle${form.ssl ? " security-toggle--active" : ""}`}>
-                <span className="security-toggle__control">
-                  <input
-                    className="security-toggle__input"
-                    type="checkbox"
-                    checked={form.ssl}
-                    onChange={(e) => {
-                      updateField("ssl", e.target.checked);
-                      if (!e.target.checked) updateField("trust_server_cert", false);
-                    }}
-                  />
-                  <span className="security-toggle__slider" aria-hidden="true" />
-                </span>
-                <span className="security-toggle__text">
-                  <span className="security-toggle__label">SSL / TLS</span>
-                </span>
-              </label>
-
-              <label
-                className={`security-toggle security-toggle--nested${
-                  form.trust_server_cert ? " security-toggle--active" : ""
-                }${
-                  !form.ssl ? " security-toggle--disabled" : ""
-                }`}
-              >
-                <span className="security-toggle__control">
-                  <input
-                    className="security-toggle__input"
-                    type="checkbox"
-                    checked={form.trust_server_cert ?? false}
-                    disabled={!form.ssl}
-                    onChange={(e) => updateField("trust_server_cert", e.target.checked)}
-                  />
-                  <span className="security-toggle__slider" aria-hidden="true" />
-                </span>
-                <span className="security-toggle__text">
-                  <span className="security-toggle__label">Trust server certificate</span>
-                  <span className="security-toggle__meta">(self-signed)</span>
-                </span>
-              </label>
-            </div>
-          )}
-
-          {!isSqlite && (
-            <SshTunnelSection
-              form={form}
-              updateField={updateField}
-              touchField={touchField}
-              getFieldError={getFieldError}
-            />
-          )}
-
-          <GroupInput
-            value={form.group || ""}
-            onChange={(v) => updateField("group", v || null)}
-            connections={connections}
+        <div className="dialog-body connection-dialog-body">
+          <ConnectionDialogNav
+            sections={dialogSections}
+            activeSection={activeSection}
+            errors={validationErrors}
+            showErrors={showValidation}
+            onSelect={setActiveSection}
           />
 
-          {testError && <div className="connection-form-error">{testError}</div>}
+          <div className="connection-dialog-content">
+            <SectionCard
+              title={activeSectionMeta.label}
+              description={activeSectionMeta.description}
+            >
+              {activeSection === "general" && (
+                <>
+                  <div className="form-row">
+                    <DbTypeDropdown
+                      value={form.db_type}
+                      onChange={handleDbTypeChange}
+                      className="form-group--db-type"
+                    />
+                    <FormField
+                      label="Connection Name"
+                      error={getFieldError("name")}
+                      className="flex-1"
+                    >
+                      <input
+                        value={form.name}
+                        onChange={(e) => updateField("name", e.target.value)}
+                        onBlur={() => touchField("name")}
+                        placeholder="My Database"
+                        aria-invalid={!!getFieldError("name")}
+                      />
+                    </FormField>
+                  </div>
 
+                  <div className="form-row">
+                    <div className="flex-1">
+                      <GroupInput
+                        value={form.group || ""}
+                        onChange={(v) => updateField("group", v || null)}
+                        connections={connections}
+                      />
+                    </div>
+                    <FormField label="Color" className="form-group--color">
+                      <ColorPicker
+                        value={form.color}
+                        onChange={(color) => setForm((f) => ({ ...f, color }))}
+                      />
+                    </FormField>
+                  </div>
+                </>
+              )}
+
+              {activeSection === "connection" && (
+                isSqlite ? (
+                  <FormField
+                    label="Database File Path"
+                    error={getFieldError("database")}
+                    description="SQLite connections use a local database file instead of a network host."
+                  >
+                    <input
+                      value={form.database}
+                      onChange={(e) => updateField("database", e.target.value)}
+                      onBlur={() => touchField("database")}
+                      placeholder="/path/to/database.db"
+                      aria-invalid={!!getFieldError("database")}
+                    />
+                  </FormField>
+                ) : (
+                  <>
+                    <div className="form-row">
+                      <FormField
+                        label="Host"
+                        error={getFieldError("host")}
+                        className="flex-1"
+                      >
+                        <input
+                          value={form.host}
+                          onChange={(e) => updateField("host", e.target.value)}
+                          onBlur={() => touchField("host")}
+                          placeholder="localhost"
+                          aria-invalid={!!getFieldError("host")}
+                        />
+                      </FormField>
+                      <FormField
+                        label="Port"
+                        error={getFieldError("port")}
+                        style={{ width: 112 }}
+                      >
+                        <input
+                          type="number"
+                          value={form.port}
+                          onChange={(e) => updateField("port", parseInt(e.target.value, 10) || 0)}
+                          onBlur={() => touchField("port")}
+                          min={1}
+                          max={65535}
+                          aria-invalid={!!getFieldError("port")}
+                        />
+                      </FormField>
+                    </div>
+
+                    <FormField
+                      label={form.db_type === "cassandra" ? "Keyspace (optional)" : "Database (optional)"}
+                      error={getFieldError("database")}
+                    >
+                      <input
+                        value={form.database}
+                        onChange={(e) => updateField("database", e.target.value)}
+                        onBlur={() => touchField("database")}
+                        placeholder={form.db_type === "cassandra" ? "my_keyspace" : "mydb"}
+                        aria-invalid={!!getFieldError("database")}
+                      />
+                    </FormField>
+                  </>
+                )
+              )}
+
+              {activeSection === "authentication" && !isSqlite && (
+                <>
+                  <div className="auth-method-card auth-method-card--active">
+                    <Lock size={16} />
+                    <div>
+                      <strong>Password</strong>
+                      <span>Built-in username/password authentication. More methods can be added here.</span>
+                    </div>
+                  </div>
+
+                  <div className="form-row">
+                    <FormField
+                      label="Username"
+                      error={getFieldError("user")}
+                      className="flex-1"
+                    >
+                      <input
+                        value={form.user}
+                        onChange={(e) => updateField("user", e.target.value)}
+                        onBlur={() => touchField("user")}
+                        placeholder="postgres"
+                        aria-invalid={!!getFieldError("user")}
+                      />
+                    </FormField>
+                    <FormField label="Password" className="flex-1">
+                      <input
+                        type="password"
+                        value={form.password}
+                        onChange={(e) => updateField("password", e.target.value)}
+                      />
+                    </FormField>
+                  </div>
+                </>
+              )}
+
+              {activeSection === "security" && !isSqlite && (
+                supportsTlsOptions ? (
+                  <div className="security-options" aria-label="Transport security">
+                    <label className={`security-toggle${form.ssl ? " security-toggle--active" : ""}`}>
+                      <span className="security-toggle__control">
+                        <input
+                          className="security-toggle__input"
+                          type="checkbox"
+                          checked={form.ssl}
+                          onChange={(e) => {
+                            updateField("ssl", e.target.checked);
+                            if (!e.target.checked) updateField("trust_server_cert", false);
+                          }}
+                        />
+                        <span className="security-toggle__slider" aria-hidden="true" />
+                      </span>
+                      <span className="security-toggle__text">
+                        <span className="security-toggle__label">SSL / TLS</span>
+                      </span>
+                    </label>
+
+                    <label
+                      className={`security-toggle security-toggle--nested${
+                        form.trust_server_cert ? " security-toggle--active" : ""
+                      }${
+                        !form.ssl ? " security-toggle--disabled" : ""
+                      }`}
+                    >
+                      <span className="security-toggle__control">
+                        <input
+                          className="security-toggle__input"
+                          type="checkbox"
+                          checked={form.trust_server_cert ?? false}
+                          disabled={!form.ssl}
+                          onChange={(e) => updateField("trust_server_cert", e.target.checked)}
+                        />
+                        <span className="security-toggle__slider" aria-hidden="true" />
+                      </span>
+                      <span className="security-toggle__text">
+                        <span className="security-toggle__label">Trust server certificate</span>
+                        <span className="security-toggle__meta">(self-signed)</span>
+                      </span>
+                    </label>
+                  </div>
+                ) : (
+                  <div className="connection-section-note">
+                    TLS options are not exposed for Cassandra / ScyllaDB yet. This section is reserved
+                    for future driver-specific transport settings.
+                  </div>
+                )
+              )}
+
+              {activeSection === "ssh" && !isSqlite && (
+                <SshTunnelSection
+                  form={form}
+                  updateField={updateField}
+                  touchField={touchField}
+                  getFieldError={getFieldError}
+                />
+              )}
+
+              {activeSection === "advanced" && (
+                <div className="connection-section-note">
+                  Connection parameters and driver-specific options will live here. Keeping this section
+                  separate makes it easier to add future settings without crowding the basic connection flow.
+                </div>
+              )}
+            </SectionCard>
+
+            {testError && <div className="connection-form-error">{testError}</div>}
+          </div>
         </div>
 
         <div className="dialog-footer">

--- a/src/components/ConnectionDialog.tsx
+++ b/src/components/ConnectionDialog.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useConnectionStore } from "../stores/connectionStore";
-import { api, ConnectionConfig } from "../lib/tauri";
-import { X, Loader2, CheckCircle, XCircle, ChevronDown, Folder } from "lucide-react";
+import { api, ConnectionConfig, SshAuthMethod } from "../lib/tauri";
+import { X, Loader2, CheckCircle, XCircle, ChevronDown, Folder, Key, Lock } from "lucide-react";
+import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import "./ConnectionDialog.css";
 
 const MAX_FOLDER_NAME_LENGTH = 50;
@@ -23,10 +24,25 @@ const DB_TYPES = [
   { value: "mssql" as const, label: "Microsoft SQL Server", short: "MS", defaultPort: 1433, accent: "#7aa2f7" },
 ];
 
-type ValidationField = "name" | "host" | "port" | "user" | "database";
+type ValidationField =
+  | "name"
+  | "host"
+  | "port"
+  | "user"
+  | "database"
+  | "ssh_host"
+  | "ssh_port"
+  | "ssh_user"
+  | "ssh_password"
+  | "ssh_key_path";
 type ValidationErrors = Partial<Record<ValidationField, string>>;
 
-function normalizeConnectionForm(form: ConnectionConfig): ConnectionConfig {
+export function normalizeConnectionForm(form: ConnectionConfig): ConnectionConfig {
+  const sshEnabled = !!form.ssh_enabled;
+  const sshAuth = form.ssh_auth_method ?? "password";
+  const promptPassphrase =
+    sshEnabled && sshAuth === "identityfile" && !!form.ssh_prompt_passphrase;
+
   return {
     ...form,
     name: form.name.trim(),
@@ -34,10 +50,20 @@ function normalizeConnectionForm(form: ConnectionConfig): ConnectionConfig {
     user: form.db_type === "sqlite" ? form.user : form.user.trim(),
     database: form.database.trim(),
     group: form.group?.trim() ? form.group.trim().slice(0, MAX_FOLDER_NAME_LENGTH) : null,
+    ssh_enabled: sshEnabled,
+    ssh_host: sshEnabled ? (form.ssh_host ?? "").trim() : "",
+    ssh_port: sshEnabled ? form.ssh_port ?? 22 : 22,
+    ssh_user: sshEnabled ? (form.ssh_user ?? "").trim() : "",
+    ssh_auth_method: sshEnabled ? sshAuth : "password",
+    // Identity-file path only meaningful with identityfile auth.
+    ssh_key_path: sshEnabled && sshAuth === "identityfile" ? (form.ssh_key_path ?? "").trim() : "",
+    // Don't persist a passphrase the user opted out of saving.
+    ssh_password: sshEnabled && !promptPassphrase ? form.ssh_password ?? "" : "",
+    ssh_prompt_passphrase: promptPassphrase,
   };
 }
 
-function validateConnectionForm(
+export function validateConnectionForm(
   form: ConnectionConfig,
   existingConnections: ConnectionConfig[],
 ): ValidationErrors {
@@ -54,6 +80,36 @@ function validateConnectionForm(
     );
     if (duplicateName) {
       errors.name = "A connection with this name already exists.";
+    }
+  }
+
+  // SSH validation runs for every db type that uses TCP. SQLite is local
+  // to the user's machine so SSH never applies; we just ignore the toggle
+  // there. The shared SSH block must come before the early returns below
+  // so it still runs for cassandra and the default branch.
+  if (normalized.db_type !== "sqlite" && normalized.ssh_enabled) {
+    if (!normalized.ssh_host) {
+      errors.ssh_host = "SSH host is required.";
+    }
+    if (
+      !Number.isInteger(normalized.ssh_port ?? NaN) ||
+      (normalized.ssh_port ?? 0) < 1 ||
+      (normalized.ssh_port ?? 0) > 65535
+    ) {
+      errors.ssh_port = "SSH port must be between 1 and 65535.";
+    }
+    if (!normalized.ssh_user) {
+      errors.ssh_user = "SSH username is required.";
+    }
+    if (normalized.ssh_auth_method === "identityfile") {
+      if (!normalized.ssh_key_path) {
+        errors.ssh_key_path = "Identity file path is required.";
+      }
+    } else if (!normalized.ssh_password) {
+      // Only require a password when the user opted to store it.
+      // (For identity-file auth, ssh_password is the *passphrase* and may
+      // be intentionally empty for unencrypted keys.)
+      errors.ssh_password = "SSH password is required.";
     }
   }
 
@@ -278,6 +334,216 @@ function GroupInput({
   );
 }
 
+interface SshTunnelSectionProps {
+  form: ConnectionConfig;
+  updateField: <K extends keyof ConnectionConfig>(field: K, value: ConnectionConfig[K]) => void;
+  touchField: (field: ValidationField) => void;
+  getFieldError: (field: ValidationField) => string | undefined;
+}
+
+function SshTunnelSection({
+  form,
+  updateField,
+  touchField,
+  getFieldError,
+}: SshTunnelSectionProps) {
+  const enabled = !!form.ssh_enabled;
+  const authMethod: SshAuthMethod = form.ssh_auth_method ?? "password";
+  const promptPassphrase = !!form.ssh_prompt_passphrase;
+  const isIdentity = authMethod === "identityfile";
+
+  const browseForKey = async () => {
+    try {
+      const path = await openFileDialog({
+        multiple: false,
+        directory: false,
+        title: "Select SSH identity file",
+      });
+      if (typeof path === "string" && path) updateField("ssh_key_path", path);
+    } catch {
+      // User cancelled — no-op.
+    }
+  };
+
+  return (
+    <div className="security-options ssh-tunnel-section" aria-label="SSH tunnel">
+      <label className={`security-toggle${enabled ? " security-toggle--active" : ""}`}>
+        <span className="security-toggle__control">
+          <input
+            className="security-toggle__input"
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => updateField("ssh_enabled", e.target.checked)}
+          />
+          <span className="security-toggle__slider" aria-hidden="true" />
+        </span>
+        <span className="security-toggle__text">
+          <span className="security-toggle__label">Use SSH tunneling</span>
+          <span className="security-toggle__meta">connect through an SSH bastion</span>
+        </span>
+      </label>
+
+      {enabled && (
+        <div className="ssh-tunnel-fields">
+          <div className="form-row">
+            <div
+              className={`form-group flex-1${getFieldError("ssh_host") ? " form-group--error" : ""}`}
+            >
+              <label>Tunnel host</label>
+              <input
+                value={form.ssh_host ?? ""}
+                onChange={(e) => updateField("ssh_host", e.target.value)}
+                onBlur={() => touchField("ssh_host")}
+                placeholder="bastion.example.com"
+                aria-invalid={!!getFieldError("ssh_host")}
+              />
+              {getFieldError("ssh_host") && (
+                <div className="field-error">{getFieldError("ssh_host")}</div>
+              )}
+            </div>
+            <div
+              className={`form-group${getFieldError("ssh_port") ? " form-group--error" : ""}`}
+              style={{ width: 100 }}
+            >
+              <label>Tunnel port</label>
+              <input
+                type="number"
+                value={form.ssh_port ?? 22}
+                onChange={(e) => updateField("ssh_port", parseInt(e.target.value, 10) || 0)}
+                onBlur={() => touchField("ssh_port")}
+                min={1}
+                max={65535}
+                aria-invalid={!!getFieldError("ssh_port")}
+              />
+              {getFieldError("ssh_port") && (
+                <div className="field-error">{getFieldError("ssh_port")}</div>
+              )}
+            </div>
+          </div>
+
+          <div className="form-row">
+            <div
+              className={`form-group flex-1${getFieldError("ssh_user") ? " form-group--error" : ""}`}
+            >
+              <label>SSH username</label>
+              <input
+                value={form.ssh_user ?? ""}
+                onChange={(e) => updateField("ssh_user", e.target.value)}
+                onBlur={() => touchField("ssh_user")}
+                placeholder="ubuntu"
+                aria-invalid={!!getFieldError("ssh_user")}
+              />
+              {getFieldError("ssh_user") && (
+                <div className="field-error">{getFieldError("ssh_user")}</div>
+              )}
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label>Authentication</label>
+            <div className="ssh-auth-toggle" role="radiogroup" aria-label="SSH authentication">
+              <button
+                type="button"
+                role="radio"
+                aria-checked={!isIdentity}
+                className={`ssh-auth-toggle__btn${!isIdentity ? " ssh-auth-toggle__btn--active" : ""}`}
+                onClick={() => updateField("ssh_auth_method", "password")}
+              >
+                <Lock size={14} />
+                Password
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={isIdentity}
+                className={`ssh-auth-toggle__btn${isIdentity ? " ssh-auth-toggle__btn--active" : ""}`}
+                onClick={() => updateField("ssh_auth_method", "identityfile")}
+              >
+                <Key size={14} />
+                Identity file
+              </button>
+            </div>
+          </div>
+
+          {isIdentity && (
+            <div className="form-row">
+              <div
+                className={`form-group flex-1${getFieldError("ssh_key_path") ? " form-group--error" : ""}`}
+              >
+                <label>Identity file</label>
+                <div className="ssh-file-picker">
+                  <input
+                    value={form.ssh_key_path ?? ""}
+                    onChange={(e) => updateField("ssh_key_path", e.target.value)}
+                    onBlur={() => touchField("ssh_key_path")}
+                    placeholder="~/.ssh/id_ed25519"
+                    aria-invalid={!!getFieldError("ssh_key_path")}
+                  />
+                  <button
+                    type="button"
+                    className="btn-secondary ssh-file-picker__browse"
+                    onClick={browseForKey}
+                  >
+                    Browse…
+                  </button>
+                </div>
+                {getFieldError("ssh_key_path") && (
+                  <div className="field-error">{getFieldError("ssh_key_path")}</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {!(isIdentity && promptPassphrase) && (
+            <div className="form-row">
+              <div
+                className={`form-group flex-1${getFieldError("ssh_password") ? " form-group--error" : ""}`}
+              >
+                <label>{isIdentity ? "Key passphrase" : "Password"}</label>
+                <input
+                  type="password"
+                  value={form.ssh_password ?? ""}
+                  onChange={(e) => updateField("ssh_password", e.target.value)}
+                  onBlur={() => touchField("ssh_password")}
+                  placeholder={isIdentity ? "(leave blank if key is unencrypted)" : ""}
+                  aria-invalid={!!getFieldError("ssh_password")}
+                />
+                {getFieldError("ssh_password") && (
+                  <div className="field-error">{getFieldError("ssh_password")}</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {isIdentity && (
+            <label
+              className={`security-toggle security-toggle--nested${
+                promptPassphrase ? " security-toggle--active" : ""
+              }`}
+            >
+              <span className="security-toggle__control">
+                <input
+                  className="security-toggle__input"
+                  type="checkbox"
+                  checked={promptPassphrase}
+                  onChange={(e) => updateField("ssh_prompt_passphrase", e.target.checked)}
+                />
+                <span className="security-toggle__slider" aria-hidden="true" />
+              </span>
+              <span className="security-toggle__text">
+                <span className="security-toggle__label">Prompt for passphrase?</span>
+                <span className="security-toggle__meta">
+                  ask each time instead of saving the passphrase to disk
+                </span>
+              </span>
+            </label>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 interface Props {
   onClose: () => void;
   editConfig?: ConnectionConfig;
@@ -318,6 +584,14 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
       color: COLORS[0],
       ssl: false,
       trust_server_cert: false,
+      ssh_enabled: false,
+      ssh_host: "",
+      ssh_port: 22,
+      ssh_user: "",
+      ssh_password: "",
+      ssh_key_path: "",
+      ssh_auth_method: "password",
+      ssh_prompt_passphrase: false,
     };
   });
 
@@ -598,6 +872,15 @@ export function ConnectionDialog({ onClose, editConfig, duplicate }: Props) {
                 </span>
               </label>
             </div>
+          )}
+
+          {!isSqlite && (
+            <SshTunnelSection
+              form={form}
+              updateField={updateField}
+              touchField={touchField}
+              getFieldError={getFieldError}
+            />
           )}
 
           <GroupInput

--- a/src/components/ConnectionDialog.tsx
+++ b/src/components/ConnectionDialog.tsx
@@ -286,8 +286,10 @@ export function normalizeConnectionForm(form: ConnectionConfig): ConnectionConfi
     ssh_auth_method: sshEnabled ? sshAuth : "password",
     // Identity-file path only meaningful with identityfile auth.
     ssh_key_path: sshEnabled && sshAuth === "identityfile" ? (form.ssh_key_path ?? "").trim() : "",
-    // Don't persist a passphrase the user opted out of saving.
-    ssh_password: sshEnabled && !promptPassphrase ? form.ssh_password ?? "" : "",
+    // ssh-agent never reads a password / passphrase; clear any stored value
+    // so it isn't accidentally persisted across an auth-method switch.
+    ssh_password:
+      sshEnabled && sshAuth !== "agent" && !promptPassphrase ? form.ssh_password ?? "" : "",
     ssh_prompt_passphrase: promptPassphrase,
   };
 }
@@ -334,10 +336,13 @@ export function validateConnectionForm(
       if (!normalized.ssh_key_path) {
         errors.ssh_key_path = "Identity file path is required.";
       }
+    } else if (normalized.ssh_auth_method === "agent") {
+      // ssh-agent supplies the credential at connect time; nothing to
+      // validate here. The backend surfaces a clear error if SSH_AUTH_SOCK
+      // is unset or the agent has no identities loaded.
     } else if (!normalized.ssh_password) {
-      // Only require a password when the user opted to store it.
-      // (For identity-file auth, ssh_password is the *passphrase* and may
-      // be intentionally empty for unencrypted keys.)
+      // Password auth: require a password (only when the user opted to
+      // store it).
       errors.ssh_password = "SSH password is required.";
     }
   }
@@ -580,6 +585,11 @@ function SshTunnelSection({
   const authMethod: SshAuthMethod = form.ssh_auth_method ?? "password";
   const promptPassphrase = !!form.ssh_prompt_passphrase;
   const isIdentity = authMethod === "identityfile";
+  const isAgent = authMethod === "agent";
+  // The password / passphrase field is only relevant for password auth and
+  // for identity-file auth where the user opted to persist the passphrase.
+  // ssh-agent never reads either, so the field is hidden entirely.
+  const showPasswordField = !isAgent && !(isIdentity && promptPassphrase);
 
   const browseForKey = async () => {
     try {
@@ -591,6 +601,83 @@ function SshTunnelSection({
       if (typeof path === "string" && path) updateField("ssh_key_path", path);
     } catch {
       // User cancelled — no-op.
+    }
+  };
+
+  // ssh-config import: read ~/.ssh/config and fill the SSH section from
+  // the matching Host block. Empty fields are filled; non-empty fields
+  // are left alone so the user's typed values aren't clobbered. We also
+  // surface a status message so the user can tell whether anything was
+  // applied.
+  const [sshConfigStatus, setSshConfigStatus] = useState<{
+    kind: "info" | "success" | "warning" | "error";
+    message: string;
+  } | null>(null);
+  const applySshConfig = async () => {
+    const alias = (form.ssh_host ?? "").trim();
+    if (!alias) {
+      setSshConfigStatus({
+        kind: "info",
+        message: "Type the alias from your ~/.ssh/config first, then press Apply.",
+      });
+      return;
+    }
+    try {
+      const resolved = await api.sshConfigLookup(alias);
+      if (!resolved) {
+        setSshConfigStatus({
+          kind: "info",
+          message: `No matching Host block for "${alias}" in ~/.ssh/config.`,
+        });
+        return;
+      }
+      const filled: string[] = [];
+      if (resolved.hostName && !form.ssh_host?.trim().includes(".")) {
+        // Replace the alias with the resolved hostname so subsequent
+        // connect attempts hit the real bastion. Tracked so the status
+        // message can mention what changed.
+        updateField("ssh_host", resolved.hostName);
+        filled.push("host");
+      }
+      if (
+        resolved.port &&
+        (form.ssh_port == null || form.ssh_port === 22 || form.ssh_port === 0)
+      ) {
+        updateField("ssh_port", resolved.port);
+        filled.push("port");
+      }
+      if (resolved.user && !(form.ssh_user ?? "").trim()) {
+        updateField("ssh_user", resolved.user);
+        filled.push("user");
+      }
+      if (resolved.identityFile && !(form.ssh_key_path ?? "").trim()) {
+        updateField("ssh_key_path", resolved.identityFile);
+        if (form.ssh_auth_method !== "identityfile") {
+          updateField("ssh_auth_method", "identityfile");
+        }
+        filled.push("identity file");
+      }
+      if (filled.length === 0) {
+        setSshConfigStatus({
+          kind: "info",
+          message: `Matched ${resolved.alias}, but every relevant field already has a value.`,
+        });
+      } else if (resolved.hasUnsupportedDirectives) {
+        setSshConfigStatus({
+          kind: "warning",
+          message: `Applied ${filled.join(", ")}. Note: this Host block uses ProxyJump / Match / Include — Tablio does not follow those, so the auto-fill may be incomplete.`,
+        });
+      } else {
+        setSshConfigStatus({
+          kind: "success",
+          message: `Applied ${filled.join(", ")} from ${resolved.alias}.`,
+        });
+      }
+    } catch (err) {
+      setSshConfigStatus({
+        kind: "error",
+        message: `Could not read ~/.ssh/config: ${err instanceof Error ? err.message : String(err)}`,
+      });
     }
   };
 
@@ -665,15 +752,34 @@ function SshTunnelSection({
               className={`form-group flex-1${getFieldError("ssh_host") ? " form-group--error" : ""}`}
             >
               <label>Tunnel host</label>
-              <input
-                value={form.ssh_host ?? ""}
-                onChange={(e) => updateField("ssh_host", e.target.value)}
-                onBlur={() => touchField("ssh_host")}
-                placeholder="bastion.example.com"
-                aria-invalid={!!getFieldError("ssh_host")}
-              />
+              <div className="ssh-file-picker">
+                <input
+                  value={form.ssh_host ?? ""}
+                  onChange={(e) => updateField("ssh_host", e.target.value)}
+                  onBlur={() => touchField("ssh_host")}
+                  placeholder="bastion.example.com (or an alias from ~/.ssh/config)"
+                  aria-invalid={!!getFieldError("ssh_host")}
+                />
+                <button
+                  type="button"
+                  className="btn-secondary ssh-file-picker__browse"
+                  onClick={applySshConfig}
+                  title="Look up the current host in ~/.ssh/config and fill empty fields"
+                >
+                  Apply ~/.ssh/config
+                </button>
+              </div>
               {getFieldError("ssh_host") && (
                 <div className="field-error">{getFieldError("ssh_host")}</div>
+              )}
+              {sshConfigStatus && (
+                <div
+                  className={`form-field-description ssh-config-status ssh-config-status--${sshConfigStatus.kind}`}
+                  role={sshConfigStatus.kind === "error" ? "alert" : undefined}
+                  style={{ marginTop: 6 }}
+                >
+                  {sshConfigStatus.message}
+                </div>
               )}
             </div>
             <div
@@ -720,8 +826,8 @@ function SshTunnelSection({
               <button
                 type="button"
                 role="radio"
-                aria-checked={!isIdentity}
-                className={`ssh-auth-toggle__btn${!isIdentity ? " ssh-auth-toggle__btn--active" : ""}`}
+                aria-checked={authMethod === "password"}
+                className={`ssh-auth-toggle__btn${authMethod === "password" ? " ssh-auth-toggle__btn--active" : ""}`}
                 onClick={() => updateField("ssh_auth_method", "password")}
               >
                 <Lock size={14} />
@@ -737,7 +843,24 @@ function SshTunnelSection({
                 <Key size={14} />
                 Identity file
               </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={isAgent}
+                className={`ssh-auth-toggle__btn${isAgent ? " ssh-auth-toggle__btn--active" : ""}`}
+                onClick={() => updateField("ssh_auth_method", "agent")}
+                title="Use the local ssh-agent (SSH_AUTH_SOCK on Linux/macOS, Pageant on Windows)"
+              >
+                <Key size={14} />
+                ssh-agent
+              </button>
             </div>
+            {isAgent && (
+              <div className="form-field-description" style={{ marginTop: 6 }}>
+                Tablio will offer every identity loaded in your local ssh-agent
+                until one is accepted. No passphrase is read or stored.
+              </div>
+            )}
           </div>
 
           {isIdentity && (
@@ -769,7 +892,7 @@ function SshTunnelSection({
             </div>
           )}
 
-          {!(isIdentity && promptPassphrase) && (
+          {showPasswordField && (
             <div className="form-row">
               <div
                 className={`form-group flex-1${getFieldError("ssh_password") ? " form-group--error" : ""}`}

--- a/src/components/DumpRestore/DumpRestoreDialog.tsx
+++ b/src/components/DumpRestore/DumpRestoreDialog.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { api, DumpRestoreRequest } from "../../lib/tauri";
-import { useConnectionStore } from "../../stores/connectionStore";
+import {
+  useConnectionStore,
+  withHostKeyMismatchRetry,
+} from "../../stores/connectionStore";
 import { X, Loader2, AlertTriangle, CheckCircle, XCircle, Shield, Search, ChevronDown, ChevronUp } from "lucide-react";
 import "./DumpRestoreDialog.css";
 
@@ -144,7 +147,16 @@ export function DumpRestoreDialog({ sourceConnectionId, sourceDatabase, onClose 
         target_connection_id: selectedTargetInfo.connectionId,
         target_database: selectedTargetInfo.database,
       };
-      const msg = await api.dumpAndRestore(request);
+      // Surface the same Forget & Retry modal that `connectTo` /
+      // "Test Connection" use when either bastion's host key has
+      // changed. Use the source connection's name as the prompt label
+      // because the dump runs first; if the *target* tunnel mismatches
+      // the modal will refer to "source" but the embedded host:port
+      // makes the actual culprit unambiguous.
+      const label = sourceConn?.name || "this connection";
+      const msg = await withHostKeyMismatchRetry(label, () =>
+        api.dumpAndRestore(request),
+      );
       setResult(msg);
       setStep("done");
     } catch (e) {

--- a/src/components/HostKeyMismatchPrompt.css
+++ b/src/components/HostKeyMismatchPrompt.css
@@ -1,0 +1,114 @@
+.host-mismatch-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.host-mismatch-prompt {
+  width: min(480px, calc(100vw - 48px));
+  background: var(--bg-secondary);
+  border: 1px solid var(--danger, #dc2626);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-dialog);
+  overflow: hidden;
+}
+
+.host-mismatch-prompt__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--danger, #dc2626);
+}
+
+.host-mismatch-prompt__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.host-mismatch-prompt__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.host-mismatch-prompt__close:hover {
+  background: rgba(220, 38, 38, 0.18);
+}
+
+.host-mismatch-prompt__body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.host-mismatch-prompt__lead {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.host-mismatch-prompt__meta {
+  margin: 0;
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 4px 12px;
+  font-size: 12px;
+}
+
+.host-mismatch-prompt__meta dt {
+  color: var(--text-muted);
+}
+
+.host-mismatch-prompt__meta dd {
+  margin: 0;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.host-mismatch-prompt__fp,
+.host-mismatch-prompt__path {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 11px;
+}
+
+.host-mismatch-prompt__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-tertiary);
+}
+
+.host-mismatch-prompt .btn-danger {
+  background: var(--danger, #dc2626);
+  border-color: var(--danger, #dc2626);
+  color: #fff;
+  padding: 6px 12px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.host-mismatch-prompt .btn-danger:hover {
+  filter: brightness(1.05);
+}

--- a/src/components/HostKeyMismatchPrompt.test.tsx
+++ b/src/components/HostKeyMismatchPrompt.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { HostKeyMismatchPrompt } from "./HostKeyMismatchPrompt";
+import {
+  useConnectionStore,
+  type PendingHostKeyMismatchPrompt,
+} from "../stores/connectionStore";
+
+function setPending(
+  partial: Partial<PendingHostKeyMismatchPrompt> = {},
+): { resolve: ReturnType<typeof vi.fn>; pending: PendingHostKeyMismatchPrompt } {
+  const resolve = vi.fn();
+  const pending: PendingHostKeyMismatchPrompt = {
+    connectionName: "Prod replica",
+    info: {
+      host: "bastion.example",
+      port: 2222,
+      fingerprint: "SHA256:abc123",
+      knownHostsPath: "/home/u/.tablio/known_hosts",
+    },
+    resolve,
+    ...partial,
+  };
+  useConnectionStore.setState({ pendingHostKeyMismatch: pending });
+  return { resolve, pending };
+}
+
+describe("HostKeyMismatchPrompt", () => {
+  beforeEach(() => {
+    useConnectionStore.setState({ pendingHostKeyMismatch: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useConnectionStore.setState({ pendingHostKeyMismatch: null });
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing while no prompt is pending", () => {
+    const { container } = render(<HostKeyMismatchPrompt />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("surfaces host:port, fingerprint, key path, and the connection name", () => {
+    setPending({});
+    render(<HostKeyMismatchPrompt />);
+    // Host and port are rendered together inside the lead paragraph.
+    expect(
+      screen.getByText(
+        (_, node) => node?.textContent === "bastion.example:2222",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("SHA256:abc123")).toBeInTheDocument();
+    expect(screen.getByText("/home/u/.tablio/known_hosts")).toBeInTheDocument();
+    expect(screen.getByText("Prod replica")).toBeInTheDocument();
+  });
+
+  it("falls back to (unnamed) when the connection has no name", () => {
+    setPending({ connectionName: "" });
+    render(<HostKeyMismatchPrompt />);
+    expect(screen.getByText("(unnamed)")).toBeInTheDocument();
+  });
+
+  it("Forget & retry resolves with true exactly once", () => {
+    const { resolve } = setPending({});
+    render(<HostKeyMismatchPrompt />);
+    fireEvent.click(screen.getByRole("button", { name: /Forget & retry/i }));
+    expect(resolve).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it("Cancel resolves with false", () => {
+    const { resolve } = setPending({});
+    render(<HostKeyMismatchPrompt />);
+    const footerCancel = screen
+      .getAllByRole("button", { name: /Cancel/i })
+      .find((b) => b.classList.contains("btn-secondary"));
+    expect(footerCancel).toBeDefined();
+    fireEvent.click(footerCancel!);
+    expect(resolve).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it("X close icon resolves with false", () => {
+    const { resolve } = setPending({});
+    render(<HostKeyMismatchPrompt />);
+    const xClose = screen
+      .getAllByRole("button", { name: /Cancel/i })
+      .find((b) => b.classList.contains("host-mismatch-prompt__close"));
+    expect(xClose).toBeDefined();
+    fireEvent.click(xClose!);
+    expect(resolve).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it("Escape key resolves with false (default-deny)", () => {
+    const { resolve } = setPending({});
+    render(<HostKeyMismatchPrompt />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(resolve).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  it("ignores other keys", () => {
+    const { resolve } = setPending({});
+    render(<HostKeyMismatchPrompt />);
+    fireEvent.keyDown(window, { key: "Enter" });
+    fireEvent.keyDown(window, { key: " " });
+    expect(resolve).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/HostKeyMismatchPrompt.tsx
+++ b/src/components/HostKeyMismatchPrompt.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { ShieldAlert, X } from "lucide-react";
+import { useConnectionStore } from "../stores/connectionStore";
+import "./HostKeyMismatchPrompt.css";
+
+/**
+ * Modal that appears when the SSH bastion presents a host key that
+ * doesn't match the one previously recorded in `~/.tablio/known_hosts`.
+ *
+ * "Forget & retry" forgets the recorded key for that host and asks the
+ * connection store to retry the connect (which then re-records the new
+ * key under TOFU). Cancel propagates the original mismatch error to the
+ * caller.
+ *
+ * Mount this once near the application root, alongside `PassphrasePrompt`.
+ */
+export function HostKeyMismatchPrompt() {
+  const pending = useConnectionStore((s) => s.pendingHostKeyMismatch);
+
+  useEffect(() => {
+    if (!pending) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") pending.resolve(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [pending]);
+
+  if (!pending) return null;
+
+  const { info, connectionName } = pending;
+
+  return createPortal(
+    <div
+      className="host-mismatch-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="SSH host key changed"
+    >
+      <div className="host-mismatch-prompt">
+        <header className="host-mismatch-prompt__header">
+          <div className="host-mismatch-prompt__title">
+            <ShieldAlert size={16} />
+            <span>SSH host key changed</span>
+          </div>
+          <button
+            type="button"
+            className="host-mismatch-prompt__close"
+            aria-label="Cancel"
+            onClick={() => pending.resolve(false)}
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        <div className="host-mismatch-prompt__body">
+          <p className="host-mismatch-prompt__lead">
+            The SSH server <strong>{info.host}:{info.port}</strong> presented a
+            different host key than the one Tablio recorded last time. This can
+            happen after a legitimate key rotation, but it's also what an
+            active man-in-the-middle attack looks like — only continue if you
+            recognise the new fingerprint.
+          </p>
+          <dl className="host-mismatch-prompt__meta">
+            <dt>Connection</dt>
+            <dd>{connectionName || "(unnamed)"}</dd>
+            <dt>New fingerprint</dt>
+            <dd className="host-mismatch-prompt__fp">{info.fingerprint}</dd>
+            <dt>Recorded in</dt>
+            <dd className="host-mismatch-prompt__path">{info.knownHostsPath}</dd>
+          </dl>
+        </div>
+
+        <footer className="host-mismatch-prompt__footer">
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => pending.resolve(false)}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn-danger"
+            onClick={() => pending.resolve(true)}
+          >
+            Forget &amp; retry
+          </button>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/KnownHostsDialog.css
+++ b/src/components/KnownHostsDialog.css
@@ -1,0 +1,188 @@
+.known-hosts-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.known-hosts-dialog {
+  width: min(720px, calc(100vw - 48px));
+  max-height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-dialog);
+  overflow: hidden;
+}
+
+.known-hosts-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-tertiary);
+}
+
+.known-hosts-dialog__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.known-hosts-dialog__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.known-hosts-dialog__close:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.known-hosts-dialog__toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.known-hosts-dialog__filter {
+  flex: 1;
+  padding: 6px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.known-hosts-dialog__filter:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.known-hosts-dialog__refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.known-hosts-dialog__error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 16px 0;
+  padding: 8px 10px;
+  border: 1px solid var(--danger, #dc2626);
+  background: rgba(220, 38, 38, 0.08);
+  color: var(--danger, #dc2626);
+  border-radius: var(--radius-md);
+  font-size: 12px;
+}
+
+.known-hosts-dialog__body {
+  flex: 1;
+  overflow: auto;
+  padding: 0;
+}
+
+.known-hosts-dialog__empty {
+  padding: 32px 16px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.known-hosts-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.known-hosts-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  text-align: left;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--bg-tertiary);
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.known-hosts-table tbody td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-subtle, var(--border));
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.known-hosts-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.known-hosts-table__host {
+  font-weight: 500;
+  word-break: break-all;
+}
+
+.known-hosts-table__fp {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  color: var(--text-secondary);
+  word-break: break-all;
+  max-width: 280px;
+}
+
+.known-hosts-table__actions {
+  text-align: right;
+  width: 1%;
+  white-space: nowrap;
+}
+
+.known-hosts-table__forget {
+  color: var(--danger, #dc2626);
+}
+
+.known-hosts-table__forget:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.known-hosts-dialog__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-tertiary);
+}
+
+.known-hosts-dialog__hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+  max-width: 480px;
+}

--- a/src/components/KnownHostsDialog.test.tsx
+++ b/src/components/KnownHostsDialog.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { KnownHostsDialog } from "./KnownHostsDialog";
+import { api, type KnownHostEntry } from "../lib/tauri";
+
+const sampleEntries: KnownHostEntry[] = [
+  {
+    host: "bastion.example.com",
+    port: 22,
+    keyType: "ssh-ed25519",
+    fingerprint: "SHA256:aaa",
+  },
+  {
+    host: "10.0.0.5",
+    port: 2222,
+    keyType: "ssh-rsa",
+    fingerprint: "SHA256:bbb",
+  },
+];
+
+describe("KnownHostsDialog", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "listKnownHosts").mockResolvedValue([...sampleEntries]);
+    vi.spyOn(api, "forgetKnownHost").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <KnownHostsDialog open={false} onClose={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(api.listKnownHosts).not.toHaveBeenCalled();
+  });
+
+  it("loads and lists entries when opened", async () => {
+    render(<KnownHostsDialog open={true} onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText("bastion.example.com")).toBeInTheDocument();
+    });
+    expect(screen.getByText("10.0.0.5")).toBeInTheDocument();
+    expect(screen.getByText("ssh-ed25519")).toBeInTheDocument();
+    expect(screen.getByText("ssh-rsa")).toBeInTheDocument();
+    expect(screen.getByText("2222")).toBeInTheDocument();
+  });
+
+  it("filters entries case-insensitively across host, key type, and fingerprint", async () => {
+    render(<KnownHostsDialog open={true} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("bastion.example.com"));
+
+    const filter = screen.getByLabelText(/Filter known hosts/i);
+    fireEvent.change(filter, { target: { value: "RSA" } });
+
+    expect(screen.queryByText("bastion.example.com")).not.toBeInTheDocument();
+    expect(screen.getByText("10.0.0.5")).toBeInTheDocument();
+
+    fireEvent.change(filter, { target: { value: "sha256:aaa" } });
+    expect(screen.queryByText("10.0.0.5")).not.toBeInTheDocument();
+    expect(screen.getByText("bastion.example.com")).toBeInTheDocument();
+
+    fireEvent.change(filter, { target: { value: "nope" } });
+    expect(screen.getByText(/No entries match your filter/i)).toBeInTheDocument();
+  });
+
+  it("forgets the matching entry and removes it from the list", async () => {
+    render(<KnownHostsDialog open={true} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("bastion.example.com"));
+
+    const forgetButton = screen.getByRole("button", {
+      name: /Forget bastion\.example\.com/i,
+    });
+    fireEvent.click(forgetButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText("bastion.example.com")).not.toBeInTheDocument();
+    });
+    expect(api.forgetKnownHost).toHaveBeenCalledWith(
+      "bastion.example.com",
+      22,
+      "SHA256:aaa",
+    );
+    expect(screen.getByText("10.0.0.5")).toBeInTheDocument();
+  });
+
+  it("surfaces backend errors instead of crashing", async () => {
+    (api.listKnownHosts as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("disk full"),
+    );
+    render(<KnownHostsDialog open={true} onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("disk full");
+    });
+  });
+
+  it("shows the empty state when there are no recorded hosts", async () => {
+    (api.listKnownHosts as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    render(<KnownHostsDialog open={true} onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No SSH hosts have been recorded yet/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("calls onClose when Escape is pressed and when the Close button is clicked", async () => {
+    const onClose = vi.fn();
+    render(<KnownHostsDialog open={true} onClose={onClose} />);
+    await waitFor(() => screen.getByText("bastion.example.com"));
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const closeButtons = screen.getAllByRole("button", { name: /Close/i });
+    const footerClose = closeButtons.find((b) =>
+      b.classList.contains("btn-primary"),
+    );
+    expect(footerClose).toBeDefined();
+    fireEvent.click(footerClose!);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes the list on demand", async () => {
+    render(<KnownHostsDialog open={true} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("bastion.example.com"));
+    expect(api.listKnownHosts).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh/i }));
+    await waitFor(() => {
+      expect(api.listKnownHosts).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/components/KnownHostsDialog.tsx
+++ b/src/components/KnownHostsDialog.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { Trash2, ShieldCheck, X, AlertCircle, RefreshCw } from "lucide-react";
+import { api, type KnownHostEntry } from "../lib/tauri";
+import "./KnownHostsDialog.css";
+
+interface KnownHostsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Modal that lists every entry in `~/.tablio/known_hosts` and lets the
+ * user forget individual hosts. Reads happen on every open so the list
+ * stays in sync with whatever the SSH layer wrote since the last view.
+ *
+ * The dialog deliberately leaves entries it can't parse (hashed hosts,
+ * `@cert-authority`, etc.) untouched on disk — see `commands::known_hosts`.
+ */
+export function KnownHostsDialog({ open, onClose }: KnownHostsDialogProps) {
+  const [entries, setEntries] = useState<KnownHostEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingForget, setPendingForget] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await api.listKnownHosts();
+      setEntries(list);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setFilter("");
+    void refresh();
+  }, [open, refresh]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const forget = useCallback(
+    async (entry: KnownHostEntry) => {
+      const key = entryKey(entry);
+      setPendingForget(key);
+      setError(null);
+      try {
+        await api.forgetKnownHost(entry.host, entry.port, entry.fingerprint);
+        setEntries((prev) =>
+          prev.filter((e) => entryKey(e) !== key),
+        );
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setPendingForget(null);
+      }
+    },
+    [],
+  );
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return entries;
+    return entries.filter(
+      (e) =>
+        e.host.toLowerCase().includes(q) ||
+        e.fingerprint.toLowerCase().includes(q) ||
+        e.keyType.toLowerCase().includes(q),
+    );
+  }, [entries, filter]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="known-hosts-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="SSH known hosts"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="known-hosts-dialog">
+        <header className="known-hosts-dialog__header">
+          <div className="known-hosts-dialog__title">
+            <ShieldCheck size={16} />
+            <span>SSH known hosts</span>
+          </div>
+          <button
+            type="button"
+            className="known-hosts-dialog__close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        <div className="known-hosts-dialog__toolbar">
+          <input
+            type="search"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter by host, key type, or fingerprint…"
+            className="known-hosts-dialog__filter"
+            aria-label="Filter known hosts"
+          />
+          <button
+            type="button"
+            className="btn-secondary known-hosts-dialog__refresh"
+            onClick={() => void refresh()}
+            disabled={loading}
+            aria-label="Refresh"
+          >
+            <RefreshCw size={14} />
+            <span>Refresh</span>
+          </button>
+        </div>
+
+        {error && (
+          <div className="known-hosts-dialog__error" role="alert">
+            <AlertCircle size={14} />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="known-hosts-dialog__body">
+          {loading && entries.length === 0 ? (
+            <div className="known-hosts-dialog__empty">Loading…</div>
+          ) : filtered.length === 0 ? (
+            <div className="known-hosts-dialog__empty">
+              {entries.length === 0
+                ? "No SSH hosts have been recorded yet. They appear here the first time you connect through an SSH tunnel."
+                : "No entries match your filter."}
+            </div>
+          ) : (
+            <table className="known-hosts-table">
+              <thead>
+                <tr>
+                  <th>Host</th>
+                  <th>Port</th>
+                  <th>Key type</th>
+                  <th>Fingerprint</th>
+                  <th aria-label="Actions" />
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((entry) => {
+                  const key = entryKey(entry);
+                  const busy = pendingForget === key;
+                  return (
+                    <tr key={key} data-host={entry.host}>
+                      <td className="known-hosts-table__host">{entry.host}</td>
+                      <td>{entry.port}</td>
+                      <td>{entry.keyType}</td>
+                      <td className="known-hosts-table__fp">
+                        {entry.fingerprint}
+                      </td>
+                      <td className="known-hosts-table__actions">
+                        <button
+                          type="button"
+                          className="btn-icon known-hosts-table__forget"
+                          aria-label={`Forget ${entry.host}`}
+                          title="Forget this host key"
+                          disabled={busy}
+                          onClick={() => void forget(entry)}
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <footer className="known-hosts-dialog__footer">
+          <p className="known-hosts-dialog__hint">
+            Forgetting an entry deletes only Tablio's record. The next SSH
+            connection re-records the server's current key under
+            "trust-on-first-use".
+          </p>
+          <button type="button" className="btn-primary" onClick={onClose}>
+            Close
+          </button>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function entryKey(e: KnownHostEntry): string {
+  return `${e.host}|${e.port}|${e.fingerprint}`;
+}

--- a/src/components/PassphrasePrompt.css
+++ b/src/components/PassphrasePrompt.css
@@ -1,0 +1,116 @@
+.passphrase-prompt-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.passphrase-prompt {
+  width: min(420px, calc(100vw - 48px));
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-dialog);
+  overflow: hidden;
+}
+
+.passphrase-prompt__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-tertiary);
+}
+
+.passphrase-prompt__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.passphrase-prompt__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.passphrase-prompt__close:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.passphrase-prompt__body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.passphrase-prompt__lead {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.passphrase-prompt__meta {
+  margin: 0;
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 4px 12px;
+  font-size: 12px;
+}
+
+.passphrase-prompt__meta dt {
+  color: var(--text-muted);
+}
+
+.passphrase-prompt__meta dd {
+  margin: 0;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.passphrase-prompt__path {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 11px;
+}
+
+.passphrase-prompt__input {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 13px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+}
+
+.passphrase-prompt__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.passphrase-prompt__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-tertiary);
+}

--- a/src/components/PassphrasePrompt.test.tsx
+++ b/src/components/PassphrasePrompt.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { PassphrasePrompt } from "./PassphrasePrompt";
+import {
+  useConnectionStore,
+  type PendingPassphrasePrompt,
+} from "../stores/connectionStore";
+
+function setPending(partial: Partial<PendingPassphrasePrompt>) {
+  const resolve = vi.fn();
+  const reject = vi.fn();
+  const pending: PendingPassphrasePrompt = {
+    connectionName: "Test DB",
+    keyPath: "/keys/id_ed25519",
+    resolve,
+    reject,
+    ...partial,
+  };
+  useConnectionStore.setState({ pendingPassphrasePrompt: pending });
+  return { resolve, reject, pending };
+}
+
+describe("PassphrasePrompt", () => {
+  beforeEach(() => {
+    useConnectionStore.setState({ pendingPassphrasePrompt: null });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useConnectionStore.setState({ pendingPassphrasePrompt: null });
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing while no prompt is pending", () => {
+    const { container } = render(<PassphrasePrompt />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("surfaces the connection name and identity file when pending", () => {
+    setPending({
+      connectionName: "Prod replica",
+      keyPath: "/etc/ssh/prod.pem",
+    });
+    render(<PassphrasePrompt />);
+    expect(screen.getByText("Prod replica")).toBeInTheDocument();
+    expect(screen.getByText("/etc/ssh/prod.pem")).toBeInTheDocument();
+  });
+
+  it("falls back to friendly placeholders when name / key path are blank", () => {
+    setPending({ connectionName: "", keyPath: "" });
+    render(<PassphrasePrompt />);
+    expect(screen.getByText("(unnamed)")).toBeInTheDocument();
+    expect(screen.getByText("(unspecified)")).toBeInTheDocument();
+  });
+
+  it("submitting the form resolves with the entered passphrase", () => {
+    const { resolve } = setPending({});
+    render(<PassphrasePrompt />);
+    const input = screen.getByPlaceholderText(/Passphrase/i);
+    fireEvent.change(input, { target: { value: "hunter2" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(resolve).toHaveBeenCalledExactlyOnceWith("hunter2");
+  });
+
+  it("submitting an empty passphrase still resolves (unencrypted key path)", () => {
+    const { resolve } = setPending({});
+    render(<PassphrasePrompt />);
+    fireEvent.submit(
+      screen.getByPlaceholderText(/Passphrase/i).closest("form")!,
+    );
+    expect(resolve).toHaveBeenCalledExactlyOnceWith("");
+  });
+
+  it("Cancel button rejects with a cancellation error and never resolves", () => {
+    const { resolve, reject } = setPending({});
+    render(<PassphrasePrompt />);
+    const buttons = screen.getAllByRole("button", { name: /Cancel/i });
+    const footerCancel = buttons.find((b) =>
+      b.classList.contains("btn-secondary"),
+    );
+    expect(footerCancel).toBeDefined();
+    fireEvent.click(footerCancel!);
+    expect(reject).toHaveBeenCalledTimes(1);
+    expect(reject.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((reject.mock.calls[0][0] as Error).message).toMatch(/cancel/i);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("X close icon also rejects", () => {
+    const { reject } = setPending({});
+    render(<PassphrasePrompt />);
+    const xClose = screen
+      .getAllByRole("button", { name: /Cancel/i })
+      .find((b) => b.classList.contains("passphrase-prompt__close"));
+    expect(xClose).toBeDefined();
+    fireEvent.click(xClose!);
+    expect(reject).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape key rejects with a cancellation error", () => {
+    const { reject } = setPending({});
+    render(<PassphrasePrompt />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(reject).toHaveBeenCalledTimes(1);
+    expect((reject.mock.calls[0][0] as Error).message).toMatch(/cancel/i);
+  });
+
+  it("typing into a stale prompt is reset when a new prompt is raised", () => {
+    const first = setPending({ connectionName: "First" });
+    render(<PassphrasePrompt />);
+    const input = screen.getByPlaceholderText(/Passphrase/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "leaked-from-prev" } });
+    expect(input.value).toBe("leaked-from-prev");
+
+    // Resolve the first request and raise a fresh one. The input must be
+    // cleared so we never leak the previous passphrase into the next
+    // connection's submission.
+    act(() => first.resolve(""));
+    act(() => {
+      setPending({ connectionName: "Second" });
+    });
+
+    const inputAfter = screen.getByPlaceholderText(/Passphrase/i) as HTMLInputElement;
+    expect(inputAfter.value).toBe("");
+  });
+});

--- a/src/components/PassphrasePrompt.tsx
+++ b/src/components/PassphrasePrompt.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Key, X } from "lucide-react";
+import { useConnectionStore } from "../stores/connectionStore";
+import "./PassphrasePrompt.css";
+
+/**
+ * Modal that appears when a connection requires its SSH key passphrase
+ * at connect time (because the user enabled "Prompt for passphrase?" on
+ * the connection's SSH section). Subscribes to the connection store and
+ * resolves the pending request when the user submits or cancels.
+ *
+ * Mount this once near the application root.
+ */
+export function PassphrasePrompt() {
+  const pending = useConnectionStore((s) => s.pendingPassphrasePrompt);
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Reset the field whenever a new prompt is shown.
+  useEffect(() => {
+    if (pending) {
+      setValue("");
+      // Defer focus to next tick so the input exists in the DOM.
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [pending]);
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!pending) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        pending.reject(new Error("Passphrase prompt cancelled"));
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [pending]);
+
+  if (!pending) return null;
+
+  const submit = (e?: React.FormEvent) => {
+    e?.preventDefault();
+    pending.resolve(value);
+  };
+
+  const cancel = () => {
+    pending.reject(new Error("Passphrase prompt cancelled"));
+  };
+
+  return createPortal(
+    <div className="passphrase-prompt-overlay" role="dialog" aria-modal="true">
+      <form className="passphrase-prompt" onSubmit={submit}>
+        <div className="passphrase-prompt__header">
+          <div className="passphrase-prompt__title">
+            <Key size={16} />
+            <span>SSH key passphrase</span>
+          </div>
+          <button
+            type="button"
+            className="passphrase-prompt__close"
+            onClick={cancel}
+            aria-label="Cancel"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className="passphrase-prompt__body">
+          <p className="passphrase-prompt__lead">
+            Enter the passphrase for this connection's SSH identity file.
+          </p>
+          <dl className="passphrase-prompt__meta">
+            <dt>Connection</dt>
+            <dd>{pending.connectionName || "(unnamed)"}</dd>
+            <dt>Identity file</dt>
+            <dd className="passphrase-prompt__path">{pending.keyPath || "(unspecified)"}</dd>
+          </dl>
+          <input
+            ref={inputRef}
+            className="passphrase-prompt__input"
+            type="password"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="Passphrase (leave blank if the key is unencrypted)"
+            autoComplete="off"
+          />
+        </div>
+        <div className="passphrase-prompt__footer">
+          <button type="button" className="btn-secondary" onClick={cancel}>
+            Cancel
+          </button>
+          <button type="submit" className="btn-primary">
+            Continue
+          </button>
+        </div>
+      </form>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/Sidebar/ObjectTree.tsx
+++ b/src/components/Sidebar/ObjectTree.tsx
@@ -29,6 +29,7 @@ import {
   Layers,
   AlertTriangle,
   GitBranch,
+  ShieldCheck,
 } from "lucide-react";
 import "./Sidebar.css";
 
@@ -1396,6 +1397,14 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
             {isActive ? (
               <div className="tree-conn-row">
                 {renderNode(node, 0)}
+                {conn.ssh_enabled && (
+                  <span
+                    className="tree-conn-ssh-badge"
+                    title={`Tunneled through ${conn.ssh_user || "ssh"}@${conn.ssh_host || "bastion"}:${conn.ssh_port || 22}`}
+                  >
+                    <ShieldCheck size={11} />
+                  </span>
+                )}
                 <div className="tree-conn-actions">
                   <button
                     className="btn-icon tree-action"
@@ -1443,6 +1452,14 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
                 <span className="tree-label" style={{ color: "var(--text-muted)" }}>
                   {conn.name || conn.database}
                 </span>
+                {conn.ssh_enabled && (
+                  <span
+                    className="tree-conn-ssh-badge tree-conn-ssh-badge--idle"
+                    title={`Will tunnel through ${conn.ssh_user || "ssh"}@${conn.ssh_host || "bastion"}:${conn.ssh_port || 22}`}
+                  >
+                    <ShieldCheck size={11} />
+                  </span>
+                )}
                 <div className="tree-conn-actions">
                   <button
                     className="btn-icon tree-action"

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -288,6 +288,30 @@
   position: relative;
 }
 
+.tree-conn-ssh-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-left: 4px;
+  border-radius: 50%;
+  color: var(--success);
+  flex-shrink: 0;
+  /* Hide while the connection-actions overlay is showing so they don't
+     visually overlap. */
+  transition: opacity 0.15s;
+}
+
+.tree-conn-row:hover .tree-conn-ssh-badge,
+.tree-root-header:hover .tree-conn-ssh-badge {
+  opacity: 0;
+}
+
+.tree-conn-ssh-badge--idle {
+  color: var(--text-muted);
+}
+
 .tree-conn-actions {
   display: flex;
   align-items: center;

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -14,6 +14,7 @@ import type {
   TableStats as TableStatsType,
   RoleInfo,
   SavedQuery,
+  KnownHostEntry,
 } from "./tauri";
 
 const CONN_ID = "mock-conn-1";
@@ -362,3 +363,30 @@ export const mockDdl = `CREATE TABLE public.users (
 
 CREATE INDEX users_created_at_idx ON public.users USING btree (created_at);
 `;
+
+export const mockKnownHosts: KnownHostEntry[] = [
+  {
+    host: "bastion.example.com",
+    port: 22,
+    keyType: "ssh-ed25519",
+    fingerprint: "SHA256:Z2hzdGFydHMtbW9jay1maW5nZXJwcmludA",
+  },
+  {
+    host: "10.0.0.5",
+    port: 2222,
+    keyType: "ssh-rsa",
+    fingerprint: "SHA256:bW9jay1mb3ItcHJldmlldy1ldGM",
+  },
+];
+
+export function removeMockKnownHost(
+  host: string,
+  port: number,
+  fingerprint: string,
+): void {
+  const idx = mockKnownHosts.findIndex(
+    (e) =>
+      e.host === host && e.port === port && e.fingerprint === fingerprint,
+  );
+  if (idx !== -1) mockKnownHosts.splice(idx, 1);
+}

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSshHostKeyMismatch,
+  SSH_HOST_KEY_MISMATCH_PREFIX,
+} from "./tauri";
+
+describe("parseSshHostKeyMismatch", () => {
+  const validPayload = {
+    host: "bastion.example.com",
+    port: 22,
+    fingerprint: "SHA256:abc",
+    knownHostsPath: "/home/u/.tablio/known_hosts",
+  };
+
+  it("parses a string error with the magic prefix", () => {
+    const err = `${SSH_HOST_KEY_MISMATCH_PREFIX}${JSON.stringify(validPayload)}`;
+    expect(parseSshHostKeyMismatch(err)).toEqual(validPayload);
+  });
+
+  it("parses an Error instance whose message carries the prefix", () => {
+    const err = new Error(
+      `${SSH_HOST_KEY_MISMATCH_PREFIX}${JSON.stringify(validPayload)}`,
+    );
+    expect(parseSshHostKeyMismatch(err)).toEqual(validPayload);
+  });
+
+  it("returns null for unrelated string errors", () => {
+    expect(parseSshHostKeyMismatch("connection refused")).toBeNull();
+    expect(parseSshHostKeyMismatch(new Error("auth failed"))).toBeNull();
+  });
+
+  it("returns null when the JSON body is malformed", () => {
+    expect(
+      parseSshHostKeyMismatch(`${SSH_HOST_KEY_MISMATCH_PREFIX}{not json`),
+    ).toBeNull();
+  });
+
+  it("returns null when required fields are missing or wrong type", () => {
+    const badPort = `${SSH_HOST_KEY_MISMATCH_PREFIX}${JSON.stringify({
+      ...validPayload,
+      port: "22",
+    })}`;
+    expect(parseSshHostKeyMismatch(badPort)).toBeNull();
+
+    const noHost = `${SSH_HOST_KEY_MISMATCH_PREFIX}${JSON.stringify({
+      port: 22,
+      fingerprint: "x",
+      knownHostsPath: "/y",
+    })}`;
+    expect(parseSshHostKeyMismatch(noHost)).toBeNull();
+  });
+
+  it("handles plain objects with a message property", () => {
+    const obj = {
+      message: `${SSH_HOST_KEY_MISMATCH_PREFIX}${JSON.stringify(validPayload)}`,
+    };
+    expect(parseSshHostKeyMismatch(obj)).toEqual(validPayload);
+  });
+
+  it("returns null for non-string non-error inputs", () => {
+    expect(parseSshHostKeyMismatch(undefined)).toBeNull();
+    expect(parseSshHostKeyMismatch(null)).toBeNull();
+    expect(parseSshHostKeyMismatch(42)).toBeNull();
+  });
+});

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -129,6 +129,17 @@ async function mockInvoke<T>(cmd: string, args?: Record<string, unknown>): Promi
       return { available: false, message: "Mock mode", entries: [] } as T;
     case "get_app_resource_usage":
       return { memory_mb: 64.5, cpu_percent: 2.3 } as T;
+    case "list_known_hosts":
+      return mock.mockKnownHosts as T;
+    case "forget_known_host": {
+      const fp = (args?.fingerprint as string) || "";
+      mock.removeMockKnownHost(
+        (args?.host as string) || "",
+        (args?.port as number) ?? 22,
+        fp,
+      );
+      return undefined as T;
+    }
     default:
       throw new Error(`Unknown mock command: ${cmd}`);
   }
@@ -583,6 +594,68 @@ export interface DumpRestoreRequest {
   target_database: string;
 }
 
+/**
+ * One row in `~/.tablio/known_hosts` as surfaced to the UI. Field names
+ * mirror the Rust `KnownHostEntry` struct (`keyType` is camelCased on
+ * purpose to match the serde rename).
+ */
+export interface KnownHostEntry {
+  host: string;
+  port: number;
+  keyType: string;
+  fingerprint: string;
+}
+
+/**
+ * Structured payload encoded inside the
+ * `ssh_host_key_mismatch:{json}` error string returned by any backend
+ * command that opens an SSH session. Matches the Rust
+ * `SshHostKeyMismatch` struct verbatim (note the camelCased
+ * `knownHostsPath`).
+ */
+export interface SshHostKeyMismatchInfo {
+  host: string;
+  port: number;
+  fingerprint: string;
+  knownHostsPath: string;
+}
+
+export const SSH_HOST_KEY_MISMATCH_PREFIX = "ssh_host_key_mismatch:";
+
+/**
+ * Detect and parse the host-key-mismatch payload that the Rust backend
+ * emits via `commands::ssh_tunnel`. Returns `null` for any error that
+ * isn't a mismatch so callers can fall through to generic handling.
+ */
+export function parseSshHostKeyMismatch(
+  err: unknown,
+): SshHostKeyMismatchInfo | null {
+  const message =
+    typeof err === "string"
+      ? err
+      : err instanceof Error
+        ? err.message
+        : err != null && typeof err === "object" && "message" in err
+          ? String((err as { message: unknown }).message)
+          : "";
+  if (!message.startsWith(SSH_HOST_KEY_MISMATCH_PREFIX)) return null;
+  const body = message.slice(SSH_HOST_KEY_MISMATCH_PREFIX.length);
+  try {
+    const parsed = JSON.parse(body) as SshHostKeyMismatchInfo;
+    if (
+      typeof parsed?.host === "string" &&
+      typeof parsed?.port === "number" &&
+      typeof parsed?.fingerprint === "string" &&
+      typeof parsed?.knownHostsPath === "string"
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Fall through — malformed payload shouldn't crash the UI.
+  }
+  return null;
+}
+
 export const api = {
   testConnection: (config: ConnectionConfig): Promise<boolean> =>
     invoke("test_connection", { config }),
@@ -765,4 +838,13 @@ export const api = {
 
   getAppResourceUsage: (): Promise<{ memory_mb: number; cpu_percent: number }> =>
     invoke("get_app_resource_usage"),
+
+  listKnownHosts: (): Promise<KnownHostEntry[]> => invoke("list_known_hosts"),
+
+  forgetKnownHost: (
+    host: string,
+    port: number,
+    fingerprint: string,
+  ): Promise<void> =>
+    invoke("forget_known_host", { host, port, fingerprint }),
 };

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -153,7 +153,16 @@ export interface ConnectionConfig {
   ssh_user?: string;
   ssh_password?: string;
   ssh_key_path?: string;
+  ssh_auth_method?: SshAuthMethod;
+  /**
+   * When true and `ssh_auth_method === "identityfile"`, the UI prompts for
+   * the key passphrase at connect time instead of persisting it. The stored
+   * `ssh_password` stays empty and a transient one is injected for the call.
+   */
+  ssh_prompt_passphrase?: boolean;
 }
+
+export type SshAuthMethod = "password" | "identityfile";
 
 export interface DatabaseInfo {
   name: string;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -140,6 +140,23 @@ async function mockInvoke<T>(cmd: string, args?: Record<string, unknown>): Promi
       );
       return undefined as T;
     }
+    case "ssh_config_lookup": {
+      const alias = (args?.alias as string)?.trim() ?? "";
+      // Mock a single well-known alias so the connection dialog's
+      // "Apply ~/.ssh/config" button can be exercised in mock mode and
+      // E2E without a real config file.
+      if (alias === "prod-bastion") {
+        return {
+          alias: "prod-bastion",
+          hostName: "10.0.0.5",
+          port: 2222,
+          user: "admin",
+          identityFile: "/home/u/.ssh/prod_ed25519",
+          hasUnsupportedDirectives: false,
+        } as T;
+      }
+      return null as T;
+    }
     default:
       throw new Error(`Unknown mock command: ${cmd}`);
   }
@@ -173,7 +190,7 @@ export interface ConnectionConfig {
   ssh_prompt_passphrase?: boolean;
 }
 
-export type SshAuthMethod = "password" | "identityfile";
+export type SshAuthMethod = "password" | "identityfile" | "agent";
 
 export interface DatabaseInfo {
   name: string;
@@ -847,4 +864,28 @@ export const api = {
     fingerprint: string,
   ): Promise<void> =>
     invoke("forget_known_host", { host, port, fingerprint }),
+
+  /**
+   * Look up `alias` in the user's `~/.ssh/config` and return the
+   * resolved HostName/Port/User/IdentityFile (each optional). Returns
+   * `null` when the file doesn't exist or no Host block matches.
+   *
+   * Backed by `ssh_config_lookup` in `commands::ssh_config` — the
+   * parser supports glob patterns and negated patterns but does *not*
+   * follow ProxyJump / Match / Include directives. The resolved entry
+   * carries `hasUnsupportedDirectives = true` when the matching block
+   * referenced one of those, so the dialog can warn the user.
+   */
+  sshConfigLookup: (alias: string): Promise<ResolvedSshHost | null> =>
+    invoke("ssh_config_lookup", { alias }),
 };
+
+/** Resolved subset of a `~/.ssh/config` entry returned by [`api.sshConfigLookup`]. */
+export interface ResolvedSshHost {
+  alias: string;
+  hostName?: string | null;
+  port?: number | null;
+  user?: string | null;
+  identityFile?: string | null;
+  hasUnsupportedDirectives: boolean;
+}

--- a/src/stores/connectionStore.test.ts
+++ b/src/stores/connectionStore.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  api,
+  SSH_HOST_KEY_MISMATCH_PREFIX,
+  type ConnectionConfig,
+} from "../lib/tauri";
+import { useConnectionStore } from "./connectionStore";
+
+function baseConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    id: "conn-1",
+    name: "Test DB",
+    db_type: "postgres",
+    host: "db.example",
+    port: 5432,
+    user: "u",
+    password: "p",
+    database: "appdb",
+    color: "#000",
+    ssl: false,
+    trust_server_cert: false,
+    ssh_enabled: false,
+    ssh_host: "",
+    ssh_port: 22,
+    ssh_user: "",
+    ssh_password: "",
+    ssh_key_path: "",
+    ssh_auth_method: "password",
+    ssh_prompt_passphrase: false,
+    ...overrides,
+  };
+}
+
+function resetStore() {
+  useConnectionStore.setState({
+    connections: [],
+    activeConnections: new Set(),
+    loading: false,
+    error: null,
+    pendingPassphrasePrompt: null,
+    pendingHostKeyMismatch: null,
+  });
+}
+
+describe("connectionStore.connectTo — SSH passphrase prompt", () => {
+  beforeEach(() => {
+    resetStore();
+    vi.spyOn(api, "connect").mockResolvedValue("ok");
+    vi.spyOn(api, "forgetKnownHost").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does NOT raise the prompt when SSH is disabled", async () => {
+    const cfg = baseConfig({
+      ssh_enabled: false,
+      ssh_auth_method: "identityfile",
+      ssh_prompt_passphrase: true,
+    });
+    await useConnectionStore.getState().connectTo(cfg);
+    expect(useConnectionStore.getState().pendingPassphrasePrompt).toBeNull();
+    expect(api.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT raise the prompt for password auth even with the flag set", async () => {
+    const cfg = baseConfig({
+      ssh_enabled: true,
+      ssh_host: "bastion",
+      ssh_auth_method: "password",
+      ssh_prompt_passphrase: true,
+    });
+    await useConnectionStore.getState().connectTo(cfg);
+    expect(useConnectionStore.getState().pendingPassphrasePrompt).toBeNull();
+    expect(api.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the prompt and threads the entered passphrase into ssh_password", async () => {
+    const cfg = baseConfig({
+      ssh_enabled: true,
+      ssh_host: "bastion",
+      ssh_auth_method: "identityfile",
+      ssh_key_path: "/keys/id_ed25519",
+      ssh_prompt_passphrase: true,
+      ssh_password: "",
+    });
+
+    const promise = useConnectionStore.getState().connectTo(cfg);
+    // Yield so the store has a chance to set the prompt before we resolve it.
+    await Promise.resolve();
+    const pending = useConnectionStore.getState().pendingPassphrasePrompt;
+    expect(pending).not.toBeNull();
+    expect(pending?.connectionName).toBe("Test DB");
+    expect(pending?.keyPath).toBe("/keys/id_ed25519");
+
+    pending!.resolve("super-secret");
+    await promise;
+
+    expect(useConnectionStore.getState().pendingPassphrasePrompt).toBeNull();
+    expect(api.connect).toHaveBeenCalledTimes(1);
+    const passed = (api.connect as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as ConnectionConfig;
+    expect(passed.ssh_password).toBe("super-secret");
+    expect(passed.ssh_prompt_passphrase).toBe(false);
+    // Original config object must not be mutated.
+    expect(cfg.ssh_password).toBe("");
+    expect(cfg.ssh_prompt_passphrase).toBe(true);
+    expect(useConnectionStore.getState().isConnected("conn-1")).toBe(true);
+  });
+
+  it("rejecting the prompt aborts the connect and never calls api.connect", async () => {
+    const cfg = baseConfig({
+      ssh_enabled: true,
+      ssh_host: "bastion",
+      ssh_auth_method: "identityfile",
+      ssh_key_path: "/keys/id_ed25519",
+      ssh_prompt_passphrase: true,
+    });
+
+    const promise = useConnectionStore.getState().connectTo(cfg);
+    await Promise.resolve();
+    useConnectionStore
+      .getState()
+      .pendingPassphrasePrompt!.reject(new Error("user cancelled"));
+
+    await expect(promise).rejects.toThrow("user cancelled");
+    expect(api.connect).not.toHaveBeenCalled();
+    expect(useConnectionStore.getState().pendingPassphrasePrompt).toBeNull();
+    expect(useConnectionStore.getState().isConnected("conn-1")).toBe(false);
+  });
+});
+
+describe("connectionStore.connectTo — SSH host-key mismatch", () => {
+  const mismatchPayload = {
+    host: "bastion.example",
+    port: 22,
+    fingerprint: "SHA256:newkey",
+    knownHostsPath: "/home/u/.tablio/known_hosts",
+  };
+  const mismatchError = new Error(
+    `${SSH_HOST_KEY_MISMATCH_PREFIX}${JSON.stringify(mismatchPayload)}`,
+  );
+
+  beforeEach(() => {
+    resetStore();
+    vi.spyOn(api, "forgetKnownHost").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("propagates non-mismatch errors without raising the prompt", async () => {
+    vi.spyOn(api, "connect").mockRejectedValueOnce(
+      new Error("connection refused"),
+    );
+    const cfg = baseConfig({ ssh_enabled: true, ssh_host: "bastion" });
+    await expect(
+      useConnectionStore.getState().connectTo(cfg),
+    ).rejects.toThrow("connection refused");
+    expect(useConnectionStore.getState().pendingHostKeyMismatch).toBeNull();
+    expect(api.forgetKnownHost).not.toHaveBeenCalled();
+  });
+
+  it("on Forget & retry: forgets the recorded key and re-invokes api.connect once", async () => {
+    const connectMock = vi
+      .spyOn(api, "connect")
+      .mockRejectedValueOnce(mismatchError)
+      .mockResolvedValueOnce("ok");
+
+    const cfg = baseConfig({ ssh_enabled: true, ssh_host: "bastion" });
+    const promise = useConnectionStore.getState().connectTo(cfg);
+    await Promise.resolve();
+
+    const pending = useConnectionStore.getState().pendingHostKeyMismatch;
+    expect(pending).not.toBeNull();
+    expect(pending?.connectionName).toBe("Test DB");
+    expect(pending?.info).toEqual(mismatchPayload);
+
+    pending!.resolve(true);
+    await promise;
+
+    expect(api.forgetKnownHost).toHaveBeenCalledExactlyOnceWith(
+      mismatchPayload.host,
+      mismatchPayload.port,
+      mismatchPayload.fingerprint,
+    );
+    expect(connectMock).toHaveBeenCalledTimes(2);
+    expect(useConnectionStore.getState().pendingHostKeyMismatch).toBeNull();
+    expect(useConnectionStore.getState().isConnected("conn-1")).toBe(true);
+  });
+
+  it("on Cancel: throws the original mismatch error and does NOT forget or retry", async () => {
+    const connectMock = vi
+      .spyOn(api, "connect")
+      .mockRejectedValueOnce(mismatchError);
+
+    const cfg = baseConfig({ ssh_enabled: true, ssh_host: "bastion" });
+    const promise = useConnectionStore.getState().connectTo(cfg);
+    await Promise.resolve();
+
+    useConnectionStore.getState().pendingHostKeyMismatch!.resolve(false);
+
+    await expect(promise).rejects.toBe(mismatchError);
+    expect(api.forgetKnownHost).not.toHaveBeenCalled();
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    expect(useConnectionStore.getState().pendingHostKeyMismatch).toBeNull();
+    expect(useConnectionStore.getState().isConnected("conn-1")).toBe(false);
+  });
+
+  it("does NOT retry a second time if the new key also mismatches (retry budget = 1)", async () => {
+    const secondMismatch = new Error(
+      `${SSH_HOST_KEY_MISMATCH_PREFIX}${JSON.stringify({
+        ...mismatchPayload,
+        fingerprint: "SHA256:secondkey",
+      })}`,
+    );
+    const connectMock = vi
+      .spyOn(api, "connect")
+      .mockRejectedValueOnce(mismatchError)
+      .mockRejectedValueOnce(secondMismatch);
+
+    const cfg = baseConfig({ ssh_enabled: true, ssh_host: "bastion" });
+    const promise = useConnectionStore.getState().connectTo(cfg);
+    await Promise.resolve();
+    useConnectionStore.getState().pendingHostKeyMismatch!.resolve(true);
+
+    await expect(promise).rejects.toBe(secondMismatch);
+    expect(connectMock).toHaveBeenCalledTimes(2);
+    expect(api.forgetKnownHost).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/stores/connectionStore.test.ts
+++ b/src/stores/connectionStore.test.ts
@@ -4,7 +4,11 @@ import {
   SSH_HOST_KEY_MISMATCH_PREFIX,
   type ConnectionConfig,
 } from "../lib/tauri";
-import { useConnectionStore } from "./connectionStore";
+import {
+  resolveSshPassphrase,
+  useConnectionStore,
+  withHostKeyMismatchRetry,
+} from "./connectionStore";
 
 function baseConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
   return {
@@ -40,6 +44,25 @@ function resetStore() {
     pendingPassphrasePrompt: null,
     pendingHostKeyMismatch: null,
   });
+}
+
+/**
+ * Spin the event loop until `selector` returns a non-null value or the
+ * timeout expires. Used to wait for a prompt to appear when the connect
+ * helper has more than one microtask hop before raising it (e.g. after
+ * the resolveSshPassphrase / withHostKeyMismatchRetry refactor).
+ */
+async function waitForPending<T>(
+  selector: () => T | null,
+  timeoutMs = 1000,
+): Promise<T> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const v = selector();
+    if (v) return v;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  throw new Error("timed out waiting for pending prompt to be raised");
 }
 
 describe("connectionStore.connectTo — SSH passphrase prompt", () => {
@@ -87,14 +110,13 @@ describe("connectionStore.connectTo — SSH passphrase prompt", () => {
     });
 
     const promise = useConnectionStore.getState().connectTo(cfg);
-    // Yield so the store has a chance to set the prompt before we resolve it.
-    await Promise.resolve();
-    const pending = useConnectionStore.getState().pendingPassphrasePrompt;
-    expect(pending).not.toBeNull();
-    expect(pending?.connectionName).toBe("Test DB");
-    expect(pending?.keyPath).toBe("/keys/id_ed25519");
+    const pending = await waitForPending(
+      () => useConnectionStore.getState().pendingPassphrasePrompt,
+    );
+    expect(pending.connectionName).toBe("Test DB");
+    expect(pending.keyPath).toBe("/keys/id_ed25519");
 
-    pending!.resolve("super-secret");
+    pending.resolve("super-secret");
     await promise;
 
     expect(useConnectionStore.getState().pendingPassphrasePrompt).toBeNull();
@@ -119,10 +141,10 @@ describe("connectionStore.connectTo — SSH passphrase prompt", () => {
     });
 
     const promise = useConnectionStore.getState().connectTo(cfg);
-    await Promise.resolve();
-    useConnectionStore
-      .getState()
-      .pendingPassphrasePrompt!.reject(new Error("user cancelled"));
+    const pending = await waitForPending(
+      () => useConnectionStore.getState().pendingPassphrasePrompt,
+    );
+    pending.reject(new Error("user cancelled"));
 
     await expect(promise).rejects.toThrow("user cancelled");
     expect(api.connect).not.toHaveBeenCalled();
@@ -171,14 +193,13 @@ describe("connectionStore.connectTo — SSH host-key mismatch", () => {
 
     const cfg = baseConfig({ ssh_enabled: true, ssh_host: "bastion" });
     const promise = useConnectionStore.getState().connectTo(cfg);
-    await Promise.resolve();
+    const pending = await waitForPending(
+      () => useConnectionStore.getState().pendingHostKeyMismatch,
+    );
+    expect(pending.connectionName).toBe("Test DB");
+    expect(pending.info).toEqual(mismatchPayload);
 
-    const pending = useConnectionStore.getState().pendingHostKeyMismatch;
-    expect(pending).not.toBeNull();
-    expect(pending?.connectionName).toBe("Test DB");
-    expect(pending?.info).toEqual(mismatchPayload);
-
-    pending!.resolve(true);
+    pending.resolve(true);
     await promise;
 
     expect(api.forgetKnownHost).toHaveBeenCalledExactlyOnceWith(
@@ -198,9 +219,10 @@ describe("connectionStore.connectTo — SSH host-key mismatch", () => {
 
     const cfg = baseConfig({ ssh_enabled: true, ssh_host: "bastion" });
     const promise = useConnectionStore.getState().connectTo(cfg);
-    await Promise.resolve();
-
-    useConnectionStore.getState().pendingHostKeyMismatch!.resolve(false);
+    const pending = await waitForPending(
+      () => useConnectionStore.getState().pendingHostKeyMismatch,
+    );
+    pending.resolve(false);
 
     await expect(promise).rejects.toBe(mismatchError);
     expect(api.forgetKnownHost).not.toHaveBeenCalled();
@@ -223,11 +245,170 @@ describe("connectionStore.connectTo — SSH host-key mismatch", () => {
 
     const cfg = baseConfig({ ssh_enabled: true, ssh_host: "bastion" });
     const promise = useConnectionStore.getState().connectTo(cfg);
-    await Promise.resolve();
-    useConnectionStore.getState().pendingHostKeyMismatch!.resolve(true);
+    const pending = await waitForPending(
+      () => useConnectionStore.getState().pendingHostKeyMismatch,
+    );
+    pending.resolve(true);
 
     await expect(promise).rejects.toBe(secondMismatch);
     expect(connectMock).toHaveBeenCalledTimes(2);
     expect(api.forgetKnownHost).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveSshPassphrase", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("returns the original config unchanged when SSH is disabled", async () => {
+    const cfg = baseConfig({
+      ssh_enabled: false,
+      ssh_auth_method: "identityfile",
+      ssh_prompt_passphrase: true,
+      ssh_password: "kept",
+    });
+    const out = await resolveSshPassphrase(cfg);
+    expect(out).toBe(cfg);
+    expect(useConnectionStore.getState().pendingPassphrasePrompt).toBeNull();
+  });
+
+  it("returns the original config unchanged for password auth", async () => {
+    const cfg = baseConfig({
+      ssh_enabled: true,
+      ssh_host: "bastion",
+      ssh_auth_method: "password",
+      ssh_prompt_passphrase: true,
+    });
+    const out = await resolveSshPassphrase(cfg);
+    expect(out).toBe(cfg);
+    expect(useConnectionStore.getState().pendingPassphrasePrompt).toBeNull();
+  });
+
+  it("returns the original config unchanged when prompt-for-passphrase is off", async () => {
+    const cfg = baseConfig({
+      ssh_enabled: true,
+      ssh_host: "bastion",
+      ssh_auth_method: "identityfile",
+      ssh_prompt_passphrase: false,
+      ssh_password: "stored",
+    });
+    const out = await resolveSshPassphrase(cfg);
+    expect(out).toBe(cfg);
+    expect(useConnectionStore.getState().pendingPassphrasePrompt).toBeNull();
+  });
+
+  it("raises the prompt and returns a fresh config with the entered passphrase", async () => {
+    const cfg = baseConfig({
+      ssh_enabled: true,
+      ssh_host: "bastion",
+      ssh_auth_method: "identityfile",
+      ssh_key_path: "/keys/id_ed25519",
+      ssh_prompt_passphrase: true,
+      ssh_password: "",
+    });
+    const promise = resolveSshPassphrase(cfg);
+    const pending = await waitForPending(
+      () => useConnectionStore.getState().pendingPassphrasePrompt,
+    );
+    pending.resolve("entered");
+    const out = await promise;
+    expect(out).not.toBe(cfg);
+    expect(out.ssh_password).toBe("entered");
+    expect(out.ssh_prompt_passphrase).toBe(false);
+    // Original config object stays untouched.
+    expect(cfg.ssh_password).toBe("");
+    expect(cfg.ssh_prompt_passphrase).toBe(true);
+  });
+
+  it("rejects when the user cancels the prompt", async () => {
+    const cfg = baseConfig({
+      ssh_enabled: true,
+      ssh_host: "bastion",
+      ssh_auth_method: "identityfile",
+      ssh_key_path: "/keys/id_ed25519",
+      ssh_prompt_passphrase: true,
+    });
+    const promise = resolveSshPassphrase(cfg);
+    const pending = await waitForPending(
+      () => useConnectionStore.getState().pendingPassphrasePrompt,
+    );
+    pending.reject(new Error("cancelled"));
+    await expect(promise).rejects.toThrow("cancelled");
+  });
+});
+
+describe("withHostKeyMismatchRetry", () => {
+  const mismatchPayload = {
+    host: "bastion",
+    port: 22,
+    fingerprint: "SHA256:fp",
+    knownHostsPath: "/known_hosts",
+  };
+  const mismatchError = new Error(
+    `${SSH_HOST_KEY_MISMATCH_PREFIX}${JSON.stringify(mismatchPayload)}`,
+  );
+
+  beforeEach(() => {
+    resetStore();
+    vi.spyOn(api, "forgetKnownHost").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the action's value on a clean run without raising any prompt", async () => {
+    const action = vi.fn().mockResolvedValue("ok");
+    const out = await withHostKeyMismatchRetry("Test DB", action);
+    expect(out).toBe("ok");
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(useConnectionStore.getState().pendingHostKeyMismatch).toBeNull();
+    expect(api.forgetKnownHost).not.toHaveBeenCalled();
+  });
+
+  it("propagates non-mismatch errors and never raises the prompt", async () => {
+    const err = new Error("boom");
+    const action = vi.fn().mockRejectedValue(err);
+    await expect(
+      withHostKeyMismatchRetry("Test DB", action),
+    ).rejects.toBe(err);
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(useConnectionStore.getState().pendingHostKeyMismatch).toBeNull();
+    expect(api.forgetKnownHost).not.toHaveBeenCalled();
+  });
+
+  it("on Forget & retry: forgets the recorded key and re-runs the action once", async () => {
+    const action = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(mismatchError)
+      .mockResolvedValueOnce("retried");
+    const promise = withHostKeyMismatchRetry("My Conn", action);
+    const pending = await waitForPending(
+      () => useConnectionStore.getState().pendingHostKeyMismatch,
+    );
+    expect(pending.connectionName).toBe("My Conn");
+    expect(pending.info).toEqual(mismatchPayload);
+    pending.resolve(true);
+    const out = await promise;
+    expect(out).toBe("retried");
+    expect(action).toHaveBeenCalledTimes(2);
+    expect(api.forgetKnownHost).toHaveBeenCalledExactlyOnceWith(
+      mismatchPayload.host,
+      mismatchPayload.port,
+      mismatchPayload.fingerprint,
+    );
+  });
+
+  it("on Cancel: rethrows the original mismatch and does not forget", async () => {
+    const action = vi.fn().mockRejectedValueOnce(mismatchError);
+    const promise = withHostKeyMismatchRetry("My Conn", action);
+    const pending = await waitForPending(
+      () => useConnectionStore.getState().pendingHostKeyMismatch,
+    );
+    pending.resolve(false);
+    await expect(promise).rejects.toBe(mismatchError);
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(api.forgetKnownHost).not.toHaveBeenCalled();
   });
 });

--- a/src/stores/connectionStore.ts
+++ b/src/stores/connectionStore.ts
@@ -1,11 +1,28 @@
 import { create } from "zustand";
 import { api, ConnectionConfig } from "../lib/tauri";
 
+/**
+ * In-flight request for the user to enter an SSH key passphrase. The
+ * `PassphrasePrompt` component subscribes to this and resolves/rejects
+ * the connect call. The passphrase is never persisted.
+ */
+export interface PendingPassphrasePrompt {
+  /** Display name shown in the prompt UI. */
+  connectionName: string;
+  /** Identity-file path shown in the prompt UI. */
+  keyPath: string;
+  /** Caller resolves with the entered passphrase (empty string is allowed). */
+  resolve: (passphrase: string) => void;
+  /** Caller rejects to cancel the connect attempt. */
+  reject: (reason: Error) => void;
+}
+
 interface ConnectionState {
   connections: ConnectionConfig[];
   activeConnections: Set<string>;
   loading: boolean;
   error: string | null;
+  pendingPassphrasePrompt: PendingPassphrasePrompt | null;
 
   loadConnections: () => Promise<void>;
   addConnection: (config: ConnectionConfig) => Promise<void>;
@@ -21,6 +38,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   activeConnections: new Set(),
   loading: false,
   error: null,
+  pendingPassphrasePrompt: null,
 
   loadConnections: async () => {
     set({ loading: true, error: null });
@@ -65,7 +83,41 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   connectTo: async (config) => {
     try {
-      await api.connect(config);
+      // If the user opted to be prompted for the SSH key passphrase rather
+      // than persisting it, surface a one-shot modal request. The stored
+      // `ssh_password` is empty in this case; we inject a transient one
+      // for this connect call only and clear the prompt flag so the
+      // backend takes the supplied passphrase.
+      let effectiveConfig = config;
+      if (
+        config.ssh_enabled &&
+        config.ssh_auth_method === "identityfile" &&
+        config.ssh_prompt_passphrase
+      ) {
+        const passphrase = await new Promise<string>((resolve, reject) => {
+          set({
+            pendingPassphrasePrompt: {
+              connectionName: config.name,
+              keyPath: config.ssh_key_path ?? "",
+              resolve: (p) => {
+                set({ pendingPassphrasePrompt: null });
+                resolve(p);
+              },
+              reject: (err) => {
+                set({ pendingPassphrasePrompt: null });
+                reject(err);
+              },
+            },
+          });
+        });
+        effectiveConfig = {
+          ...config,
+          ssh_password: passphrase,
+          ssh_prompt_passphrase: false,
+        };
+      }
+
+      await api.connect(effectiveConfig);
       set((s) => {
         const next = new Set(s.activeConnections);
         next.add(config.id);

--- a/src/stores/connectionStore.ts
+++ b/src/stores/connectionStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
-import { api, ConnectionConfig } from "../lib/tauri";
+import {
+  api,
+  ConnectionConfig,
+  parseSshHostKeyMismatch,
+  type SshHostKeyMismatchInfo,
+} from "../lib/tauri";
 
 /**
  * In-flight request for the user to enter an SSH key passphrase. The
@@ -17,12 +22,25 @@ export interface PendingPassphrasePrompt {
   reject: (reason: Error) => void;
 }
 
+/**
+ * In-flight host-key-mismatch confirmation. The `HostKeyMismatchPrompt`
+ * subscribes to this; "Forget & retry" calls `resolve(true)` so the
+ * caller forgets the recorded key and attempts the connect again, while
+ * Cancel calls `resolve(false)` to give up.
+ */
+export interface PendingHostKeyMismatchPrompt {
+  connectionName: string;
+  info: SshHostKeyMismatchInfo;
+  resolve: (forgetAndRetry: boolean) => void;
+}
+
 interface ConnectionState {
   connections: ConnectionConfig[];
   activeConnections: Set<string>;
   loading: boolean;
   error: string | null;
   pendingPassphrasePrompt: PendingPassphrasePrompt | null;
+  pendingHostKeyMismatch: PendingHostKeyMismatchPrompt | null;
 
   loadConnections: () => Promise<void>;
   addConnection: (config: ConnectionConfig) => Promise<void>;
@@ -39,6 +57,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   loading: false,
   error: null,
   pendingPassphrasePrompt: null,
+  pendingHostKeyMismatch: null,
 
   loadConnections: async () => {
     set({ loading: true, error: null });
@@ -117,7 +136,35 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         };
       }
 
-      await api.connect(effectiveConfig);
+      // Retry once if the bastion's host key has changed and the user
+      // confirms they want to re-trust it. Anything else propagates as
+      // a normal error.
+      try {
+        await api.connect(effectiveConfig);
+      } catch (err) {
+        const mismatch = parseSshHostKeyMismatch(err);
+        if (!mismatch) throw err;
+        const forgetAndRetry = await new Promise<boolean>((resolve) => {
+          set({
+            pendingHostKeyMismatch: {
+              connectionName: config.name,
+              info: mismatch,
+              resolve: (decision) => {
+                set({ pendingHostKeyMismatch: null });
+                resolve(decision);
+              },
+            },
+          });
+        });
+        if (!forgetAndRetry) throw err;
+        await api.forgetKnownHost(
+          mismatch.host,
+          mismatch.port,
+          mismatch.fingerprint,
+        );
+        await api.connect(effectiveConfig);
+      }
+
       set((s) => {
         const next = new Set(s.activeConnections);
         next.add(config.id);

--- a/src/stores/connectionStore.ts
+++ b/src/stores/connectionStore.ts
@@ -102,68 +102,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   connectTo: async (config) => {
     try {
-      // If the user opted to be prompted for the SSH key passphrase rather
-      // than persisting it, surface a one-shot modal request. The stored
-      // `ssh_password` is empty in this case; we inject a transient one
-      // for this connect call only and clear the prompt flag so the
-      // backend takes the supplied passphrase.
-      let effectiveConfig = config;
-      if (
-        config.ssh_enabled &&
-        config.ssh_auth_method === "identityfile" &&
-        config.ssh_prompt_passphrase
-      ) {
-        const passphrase = await new Promise<string>((resolve, reject) => {
-          set({
-            pendingPassphrasePrompt: {
-              connectionName: config.name,
-              keyPath: config.ssh_key_path ?? "",
-              resolve: (p) => {
-                set({ pendingPassphrasePrompt: null });
-                resolve(p);
-              },
-              reject: (err) => {
-                set({ pendingPassphrasePrompt: null });
-                reject(err);
-              },
-            },
-          });
-        });
-        effectiveConfig = {
-          ...config,
-          ssh_password: passphrase,
-          ssh_prompt_passphrase: false,
-        };
-      }
-
-      // Retry once if the bastion's host key has changed and the user
-      // confirms they want to re-trust it. Anything else propagates as
-      // a normal error.
-      try {
-        await api.connect(effectiveConfig);
-      } catch (err) {
-        const mismatch = parseSshHostKeyMismatch(err);
-        if (!mismatch) throw err;
-        const forgetAndRetry = await new Promise<boolean>((resolve) => {
-          set({
-            pendingHostKeyMismatch: {
-              connectionName: config.name,
-              info: mismatch,
-              resolve: (decision) => {
-                set({ pendingHostKeyMismatch: null });
-                resolve(decision);
-              },
-            },
-          });
-        });
-        if (!forgetAndRetry) throw err;
-        await api.forgetKnownHost(
-          mismatch.host,
-          mismatch.port,
-          mismatch.fingerprint,
-        );
-        await api.connect(effectiveConfig);
-      }
+      const effectiveConfig = await resolveSshPassphrase(config);
+      await withHostKeyMismatchRetry(config.name, () =>
+        api.connect(effectiveConfig),
+      );
 
       set((s) => {
         const next = new Set(s.activeConnections);
@@ -191,3 +133,94 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   isConnected: (id) => get().activeConnections.has(id),
 }));
+
+/**
+ * Surface the passphrase prompt for SSH identity-file connections that
+ * opted out of persisting the passphrase, and return a config with the
+ * just-entered passphrase injected into `ssh_password` (and the prompt
+ * flag cleared so the backend uses the supplied value verbatim).
+ *
+ * For every other case the original config is returned unchanged.
+ *
+ * Exported so any caller that initiates an SSH connect — currently
+ * `connectTo` and the dialog's "Test Connection" button — can share
+ * the same UX without re-implementing the modal lifecycle.
+ */
+export async function resolveSshPassphrase(
+  config: ConnectionConfig,
+): Promise<ConnectionConfig> {
+  if (
+    !config.ssh_enabled ||
+    config.ssh_auth_method !== "identityfile" ||
+    !config.ssh_prompt_passphrase
+  ) {
+    return config;
+  }
+  const passphrase = await new Promise<string>((resolve, reject) => {
+    useConnectionStore.setState({
+      pendingPassphrasePrompt: {
+        connectionName: config.name,
+        keyPath: config.ssh_key_path ?? "",
+        resolve: (p) => {
+          useConnectionStore.setState({ pendingPassphrasePrompt: null });
+          resolve(p);
+        },
+        reject: (err) => {
+          useConnectionStore.setState({ pendingPassphrasePrompt: null });
+          reject(err);
+        },
+      },
+    });
+  });
+  return {
+    ...config,
+    ssh_password: passphrase,
+    ssh_prompt_passphrase: false,
+  };
+}
+
+/**
+ * Run `action`; if it fails with a structured `ssh_host_key_mismatch`
+ * error, surface the prompt and — when the user confirms — forget the
+ * recorded key and call `action` exactly once more. Any non-mismatch
+ * error or a Cancel decision propagates the original error.
+ *
+ * Use this around any backend call that can open an SSH session
+ * (`api.connect`, `api.testConnection`, `api.backupDatabase`,
+ * `api.restoreDatabase`, `api.dumpAndRestore`) so users get a
+ * consistent Forget & Retry experience instead of a raw
+ * `ssh_host_key_mismatch:{...}` string.
+ *
+ * `connectionName` is shown to the user in the modal — keep it stable
+ * (no IDs) so the message is meaningful.
+ */
+export async function withHostKeyMismatchRetry<T>(
+  connectionName: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await action();
+  } catch (err) {
+    const mismatch = parseSshHostKeyMismatch(err);
+    if (!mismatch) throw err;
+    const forgetAndRetry = await new Promise<boolean>((resolve) => {
+      useConnectionStore.setState({
+        pendingHostKeyMismatch: {
+          connectionName,
+          info: mismatch,
+          resolve: (decision) => {
+            useConnectionStore.setState({ pendingHostKeyMismatch: null });
+            resolve(decision);
+          },
+        },
+      });
+    });
+    if (!forgetAndRetry) throw err;
+    await api.forgetKnownHost(
+      mismatch.host,
+      mismatch.port,
+      mismatch.fingerprint,
+    );
+    return action();
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,13 +1,24 @@
 import "@testing-library/jest-dom";
 import { vi } from "vitest";
 
-vi.mock("../lib/tauri", () => ({
-  api: {
-    fetchRows: vi.fn(),
-    applyChanges: vi.fn(),
-    executeQuery: vi.fn(),
-    exportTableToFile: vi.fn(),
-    exportQueryResultToFile: vi.fn(),
-    listColumns: vi.fn(),
-  },
-}));
+// Stub the Tauri bridge module. We keep the real exports for type
+// helpers (interfaces, parseSshHostKeyMismatch, prefixes, etc.) so
+// individual tests can opt into mocking specific `api.*` methods via
+// `vi.spyOn(api, "...")` instead of having to redeclare every single
+// command up front. Only the shape that *all* relative-importers
+// previously relied on is replaced wholesale.
+vi.mock("../lib/tauri", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/tauri")>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      fetchRows: vi.fn(),
+      applyChanges: vi.fn(),
+      executeQuery: vi.fn(),
+      exportTableToFile: vi.fn(),
+      exportQueryResultToFile: vi.fn(),
+      listColumns: vi.fn(),
+    },
+  };
+});


### PR DESCRIPTION
## Summary

Lands the in-process SSH tunnel feature, plus everything that came up while polishing it: backup/restore over the tunnel, known-hosts management UI, the redesigned connection dialog, and today's gap fixes (keepalive, ssh-agent, `~/.ssh/config` import). Closes #41 and #42, fixes the long-standing `AllowTcpForwarding` issue that was about to break CI on first run, and ships real-bastion integration coverage for every auth method.

Closes #41
Closes #42

## What's in the branch

| Commit | Scope |
|---|---|
| `ab292ef` | Initial russh-based tunnel + dialog SSH section |
| `bfe049e` | Sectioned connection dialog with left nav |
| `8ea2048` | Merge master |
| `7089942` | Backup-over-tunnel (#41), known-hosts UI (#42), dialog polish |
| `e164456` | Mismatch flow coverage, SSL/Cassandra advisories, sidebar tunnel badge |
| `8a45cad` | Keepalive bug fix, ssh-agent auth, `~/.ssh/config` import |
| `cc8f8a3` | CI bastion forwarding fix + ssh-agent integration test |

## Backend

- `src-tauri/src/db/ssh_tunnel.rs` — pure-Rust russh tunnel with TOFU host-key checking, structured `SshHostKeyMismatch` error, `EffectiveTarget` helper for short-lived consumers.
  - **Liveness fix**: dropped `inactivity_timeout = 60s` (was tearing live but quiet pool sessions down). Replaced with `keepalive_interval = 30s`, `keepalive_max = 4` — mirrors OpenSSH `ServerAliveInterval=30 / ServerAliveCountMax=3`.
  - **ssh-agent auth**: new `SshAuthMethod::Agent`. Linux/macOS via `SSH_AUTH_SOCK`, Windows via Pageant; tries every loaded identity until one is accepted; clear errors on missing socket / empty agent / all-rejected.
- `src-tauri/src/commands/known_hosts.rs` — `list_known_hosts` / `forget_known_host` Tauri commands operating on `~/.tablio/known_hosts`. 11 unit tests covering hashed/comment/multi-host/bracketed-port lines and round-trip remove.
- `src-tauri/src/commands/ssh_config.rs` — `~/.ssh/config` parser (glob `*`/`?`, negation `!`, first-match-wins, `Key = value` separator). Resolves `HostName`/`Port`/`User`/`IdentityFile`. Flags `ProxyJump`/`Match`/`Include` so the dialog can warn instead of silently producing a half-resolved entry. 8 unit tests.
- `src-tauri/src/commands/backup.rs` — `effective_target()` helper routes every `pg_dump`, `pg_restore`, `psql`, `mysqldump`, `mysql` invocation through `ssh_tunnel::open_for`. The returned guard is held for the subprocess's lifetime so the tunnel can't be GC'd mid-dump.
- `src-tauri/src/db/pool.rs` — opens / drops the tunnel atomically with the pool entry; failed driver connect tears the tunnel down before propagating.

## Frontend

- New `KnownHostsDialog.{tsx,css,test.tsx}` — filterable list, refresh, forget, error / empty / loading states. Mounted from the App settings menu.
- New `HostKeyMismatchPrompt.{tsx,css,test.tsx}` — Forget-and-retry vs Cancel, surfaced through the connection store's `pendingHostKeyMismatch` slot.
- New `PassphrasePrompt.test.tsx` — covers prompt-only-when-needed, blank passphrase, cancel/escape/X.
- `ConnectionDialog.tsx` — sectioned left-nav layout (General / Authentication / Security / SSH Tunnel / Advanced), defaults Postgres to `postgres` user, drops low-contrast meta text, ssh-agent radio with inline guidance, "Apply ~/.ssh/config" auto-fill button with status banner, cross-section advisories (SSL hostname conflict, Cassandra peer discovery, persisted passphrase).
- `connectionStore.ts` — `resolveSshPassphrase` and `withHostKeyMismatchRetry` helpers consumed by `connectTo`, `handleTest`, backup/restore dialogs.

## Audit results

Re-read every SSH-touching file before pushing.

- **No command injection**: all subprocesses use the typed `cmd.arg()` API; passwords flow via `PGPASSWORD` / `MYSQL_PWD` env, never on the command line.
- **No path traversal**: `known_hosts_path_pub()` always returns `~/.tablio/known_hosts`; the frontend cannot influence the path.
- **No silent host-key rotation**: mismatched keys yield a structured `SshHostKeyMismatch` payload that the UI converts into an explicit Forget-and-retry prompt.
- **No LAN exposure**: tunnel listener bound to `127.0.0.1:0`.
- **No password leakage in logs**: only fingerprints and remaining-method lists are logged on auth failure.
- **Real bug found**: the CI bastion image disables `AllowTcpForwarding` by default — the integration suite would have failed on first run with `"server closed the connection unexpectedly"`. Reproduced locally; fixed by patching `/config/sshd/sshd_config` and bouncing sshd after the container starts.

## Tests

- **24 Rust unit tests** for SSH-related code (15 ssh_tunnel + 8 ssh_config + parser tests in known_hosts, plus 4 model tests for `SshAuthMethod`).
- **9 integration tests** against a real OpenSSH bastion + real Postgres, covering password auth, identity-file auth, ssh-agent auth, listener Drop semantics, missing-key error path, bad-password rejection, and pg_dump-through-tunnel (the contract behind #41).
- **590 frontend unit tests** (Vitest) including the new `connectionStore` SSH branches, `KnownHostsDialog`, `HostKeyMismatchPrompt`, `PassphrasePrompt`, `ssh_config_lookup` parsing.
- **Playwright E2E**: `e2e/known-hosts.spec.ts`, `e2e/connection-dialog.spec.ts` (host-key warnings, SSH section, "Apply ~/.ssh/config" mock, validation jump).

Locally verified end-to-end: `cargo fmt --check` clean, `cargo clippy --lib --tests` clean for SSH targets, all 9 integration tests pass against a Docker bastion + Postgres, frontend 590/590, Vite production build clean.

## Deferred (tracked separately)

- #73 — auto-reconnect on bastion session loss (extends today's keepalive).
- #74 — explicit first-contact fingerprint confirmation prompt (was #47).
- #75 — Cassandra/ScyllaDB peer routing through the bastion (was #45).
- #76 — `Include` / `Match` / `ProxyJump` / `ProxyCommand` in ssh-config import (extends #49).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib` and `cargo clippy --test ssh_tunnel_integration` (lib `-D warnings`)
- [x] `cargo test --lib ssh_` — 24/24 pass
- [x] Integration tests against real bastion + Postgres — 9/9 pass
- [x] `npm test` — 590/590 pass
- [x] `npm run build` — clean
- [ ] CI green on the PR (will be confirmed once GitHub runs the matrix)
