### PR TITLE
ci: nightly stress, audit, soak & fuzz coverage

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,516 @@
+name: Nightly
+
+# Why a separate workflow?
+#   * Catches regressions PR CI cannot afford to test (slow, soak, fuzz, multi-OS).
+#   * Zero impact on PR latency or required-status surface — nothing here
+#     is wired into ci.yml's `ci-required` aggregator.
+#   * Single notification per night instead of one per check class.
+#
+# Anything that costs > ~2 min of wall-clock or has any flake risk under
+# load belongs in this file, not ci.yml.
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC nightly
+  workflow_dispatch:
+
+# Default to read-only. The cargo-fuzz job uploads crash artifacts via
+# the default GITHUB_TOKEN — `actions/upload-artifact` only writes to the
+# workflow run, not the repo, so no extra scope is needed.
+permissions:
+  contents: read
+
+# Don't cancel an in-flight nightly when a follow-up cron tick fires
+# (`cancel-in-progress: false`). A flake-finder run mid-execution carries
+# more signal than the next night's run does.
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ===========================================================================
+  # Tier 1 — security hygiene + leak surveillance + release readiness
+  # ===========================================================================
+
+  audit:
+    name: Audit (Rust + npm)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rust advisory check
+        # Surfaces RUSTSEC IDs Dependabot does NOT raise PRs for
+        # (yanked crates, unmaintained advisories, license drift).
+        uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - run: npm ci --no-audit --no-fund
+
+      - name: npm audit (high+)
+        # `--audit-level=high` skips the noisy moderate findings that
+        # are mostly transitive dev-dependency churn. `|| true` is
+        # deliberately not used — we want this to fail when a real
+        # high/critical lands.
+        run: npm audit --audit-level=high
+
+  stress-fdleak:
+    name: Resource monitor stress
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run #[ignore]-gated stress harness
+        # 5,000 sequential + 8,000 concurrent calls into get_app_resource_usage.
+        # Threshold is 0.05 fd/call — three orders of magnitude of headroom
+        # over the historical leak rate (~0.66 fd/call).
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml --lib \
+            commands::system::tests::stress_fd_leak \
+            -- --ignored --nocapture
+
+  build-rehearsal:
+    name: Build rehearsal (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - run: npm ci --no-audit --no-fund
+
+      - name: Install Linux deps
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Build Tauri app (debug)
+        # Debug build proves "would tip-of-master ship?" without the
+        # signing/notarization friction of a release build. A real
+        # release-only breakage (icon assets, bundle config) still
+        # surfaces at debug time.
+        run: npx tauri build --debug
+
+  # ===========================================================================
+  # Tier 2 — extended DB matrix + SSH soak
+  # ===========================================================================
+
+  legacy-db-matrix:
+    name: Legacy DB ${{ matrix.engine }} ${{ matrix.version }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - engine: postgres
+            version: "12"
+            test: postgres_integration
+            url_env: TEST_POSTGRES_URL
+            url: "postgres://test:test@localhost:5432/testdb"
+          - engine: postgres
+            version: "13"
+            test: postgres_integration
+            url_env: TEST_POSTGRES_URL
+            url: "postgres://test:test@localhost:5432/testdb"
+          - engine: mysql
+            version: "5.7"
+            test: mysql_integration
+            url_env: TEST_MYSQL_URL
+            url: "mysql://root:test@localhost:3306/testdb"
+    services:
+      postgres:
+        image: ${{ matrix.engine == 'postgres' && format('postgres:{0}', matrix.version) || '' }}
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mysql:
+        image: ${{ matrix.engine == 'mysql' && format('mysql:{0}', matrix.version) || '' }}
+        env:
+          MYSQL_ROOT_PASSWORD: test
+          MYSQL_DATABASE: testdb
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run integration suite
+        env:
+          TEST_POSTGRES_URL: ${{ matrix.engine == 'postgres' && matrix.url || '' }}
+          TEST_MYSQL_URL: ${{ matrix.engine == 'mysql' && matrix.url || '' }}
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml \
+            --test ${{ matrix.test }}
+
+  ssh-soak:
+    name: SSH tunnel soak
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+
+      # Identical bastion setup to ci.yml `test-ssh-tunnel` — we keep
+      # the soak isolated to its own job (rather than tacking onto the
+      # PR test) so a soak flake never blocks PR signal.
+      - name: Generate SSH key
+        id: sshkey
+        run: |
+          mkdir -p "$RUNNER_TEMP/tablio-ssh"
+          ssh-keygen -t ed25519 -N "" \
+            -f "$RUNNER_TEMP/tablio-ssh/id_ed25519" -C tablio-ci >/dev/null
+          chmod 600 "$RUNNER_TEMP/tablio-ssh/id_ed25519"
+          echo "key_path=$RUNNER_TEMP/tablio-ssh/id_ed25519" >> "$GITHUB_OUTPUT"
+          echo "pub_key=$(cat "$RUNNER_TEMP/tablio-ssh/id_ed25519.pub")" >> "$GITHUB_OUTPUT"
+
+      - name: Start OpenSSH bastion
+        run: |
+          docker run -d --name sshd \
+            --network host \
+            -e PUID=1000 -e PGID=1000 \
+            -e USER_NAME=tablio -e USER_PASSWORD=tablio-pw \
+            -e PASSWORD_ACCESS=true -e SUDO_ACCESS=false \
+            -e LISTEN_PORT=2222 \
+            -e PUBLIC_KEY="${{ steps.sshkey.outputs.pub_key }}" \
+            lscr.io/linuxserver/openssh-server:latest
+          for i in $(seq 1 30); do
+            if nc -z 127.0.0.1 2222; then break; fi
+            sleep 2
+          done
+          # linuxserver image ships with AllowTcpForwarding no — patch it
+          # so direct-tcpip channels (every -L forward) actually work.
+          docker exec sshd sh -c '
+            sed -i "s/^AllowTcpForwarding.*/AllowTcpForwarding yes/" /config/sshd/sshd_config
+            sed -i "s/^GatewayPorts.*/GatewayPorts yes/" /config/sshd/sshd_config
+            pkill -x sshd.pam || pkill -x sshd
+          '
+          for i in $(seq 1 15); do
+            if nc -z 127.0.0.1 2222; then break; fi
+            sleep 1
+          done
+
+      - name: Install Linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev librsvg2-dev \
+            libappindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run open/close soak (200 cycles)
+        env:
+          TEST_SSH_HOST: 127.0.0.1
+          TEST_SSH_PORT: "2222"
+          TEST_SSH_USER: tablio
+          TEST_SSH_PASSWORD: tablio-pw
+          TEST_SSH_TARGET_HOST: 127.0.0.1
+          TEST_SSH_TARGET_PORT: "5432"
+          TEST_POSTGRES_USER: test
+          TEST_POSTGRES_PASSWORD: test
+          TEST_POSTGRES_DB: testdb
+          # Override default (200) here when you want to dial intensity.
+          SOAK_ITERATIONS: "200"
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml \
+            --test ssh_tunnel_integration \
+            -- --ignored soak_open_close_loop \
+            --nocapture --test-threads=1
+
+      - name: Dump bastion logs on failure
+        if: failure()
+        run: docker logs sshd
+
+  # ===========================================================================
+  # Tier 3 — flake detection, big-data, fuzzing, cross-OS e2e
+  # ===========================================================================
+
+  flake-finder:
+    name: Flake finder
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Install Linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run repeated test loops
+        env:
+          ITERATIONS: "20"
+        run: bash scripts/flake-finder.sh
+
+      - name: Upload per-iteration logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: flake-finder-logs
+          path: flake-finder-logs/
+          retention-days: 14
+
+  big-data:
+    name: Big-data scenarios
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: test
+          MYSQL_DATABASE: testdb
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Linux deps + matching pg_dump
+        # PGDG repo so pg_dump matches the postgres:17 service.
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSLo /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          . /etc/os-release
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf postgresql-client-17
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run --ignored big-data tests
+        env:
+          TEST_POSTGRES_URL: "postgres://test:test@localhost:5432/testdb"
+          TEST_MYSQL_URL: "mysql://root:test@localhost:3306/testdb"
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml \
+            --test postgres_integration \
+            -- --ignored --nocapture --test-threads=1
+          cargo test --manifest-path src-tauri/Cargo.toml \
+            --test mysql_integration \
+            -- --ignored --nocapture --test-threads=1
+
+  proptest:
+    name: Property-based tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run proptest blocks (PROPTEST_CASES=4096)
+        env:
+          # 4,096 cases per property × 7 properties ≈ ~30k generated
+          # inputs total. Comfortably under the 20 min job budget.
+          PROPTEST_CASES: "4096"
+        run: |
+          cargo test --manifest-path src-tauri/Cargo.toml --lib proptests \
+            -- --nocapture
+
+  cargo-fuzz:
+    name: cargo-fuzz (${{ matrix.target }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ssh_config, proc_self_stat, sql_identifier]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf
+
+      # libfuzzer-sys requires the nightly toolchain because it links
+      # against unstable LLVM sanitiser interfaces.
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+            src-tauri/fuzz
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Fuzz ${{ matrix.target }} for 5 minutes
+        # `-max_total_time=300` caps each target at 300s of mutation;
+        # libFuzzer exits 0 on time-out (no crashes found) and non-zero
+        # on a discovered crash, which is exactly the gate we want.
+        run: |
+          cargo +nightly fuzz run ${{ matrix.target }} \
+            --fuzz-dir src-tauri/fuzz \
+            -- -max_total_time=300
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-${{ matrix.target }}-crashes
+          path: |
+            src-tauri/fuzz/artifacts/${{ matrix.target }}/
+            src-tauri/fuzz/corpus/${{ matrix.target }}/
+          retention-days: 30
+
+  cross-os-e2e:
+    name: Cross-OS E2E (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - run: npm ci --no-audit --no-fund
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run mocked e2e suite
+        run: npx playwright test
+
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: nightly-playwright-${{ matrix.os }}
+          path: test-results/
+          retention-days: 7

--- a/scripts/flake-finder.sh
+++ b/scripts/flake-finder.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Flake finder — run the fast test suites N times back-to-back and fail
+# the job if ANY single iteration is non-zero. Surfaces flakes before
+# they pollute PR signal.
+#
+# Defaults (override via env):
+#   ITERATIONS    number of repeated runs per suite (default 20)
+#   LOG_DIR       per-iteration logs are written here (default flake-finder-logs)
+#   SKIP_FRONTEND set to 1 to skip the npm test loop (e.g. when no node tools)
+#   SKIP_BACKEND  set to 1 to skip the cargo test loop
+#
+# Usage (locally):
+#   ITERATIONS=5 ./scripts/flake-finder.sh
+#
+# Usage (CI):
+#   bash scripts/flake-finder.sh
+#
+# The runner must have:
+#   - rust toolchain (cargo)
+#   - node (npm)        — only when SKIP_FRONTEND != 1
+# installed up-front. We don't bootstrap them here so this stays a thin
+# loop that's quick to debug.
+
+set -uo pipefail
+
+ITERATIONS="${ITERATIONS:-20}"
+LOG_DIR="${LOG_DIR:-flake-finder-logs}"
+SKIP_FRONTEND="${SKIP_FRONTEND:-0}"
+SKIP_BACKEND="${SKIP_BACKEND:-0}"
+
+mkdir -p "$LOG_DIR"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+declare -A SUITE_FAILURES
+declare -A SUITE_TOTALS
+
+run_loop() {
+    local suite="$1"
+    local cmd="$2"
+    local fails=0
+
+    echo "::group::$suite x$ITERATIONS"
+    for i in $(seq 1 "$ITERATIONS"); do
+        local log="$LOG_DIR/${suite}-${i}.log"
+        local ts_start
+        ts_start=$(date -u +%s)
+        if eval "$cmd" >"$log" 2>&1; then
+            local elapsed=$(( $(date -u +%s) - ts_start ))
+            echo "  [$suite] iter $i: PASS (${elapsed}s)"
+        else
+            local elapsed=$(( $(date -u +%s) - ts_start ))
+            echo "  [$suite] iter $i: FAIL (${elapsed}s) — see $log"
+            fails=$(( fails + 1 ))
+        fi
+    done
+    echo "::endgroup::"
+
+    SUITE_FAILURES["$suite"]="$fails"
+    SUITE_TOTALS["$suite"]="$ITERATIONS"
+}
+
+if [ "$SKIP_BACKEND" != "1" ]; then
+    run_loop "cargo-test-lib" \
+        "cargo test --manifest-path src-tauri/Cargo.toml --lib --quiet"
+fi
+
+if [ "$SKIP_FRONTEND" != "1" ]; then
+    if ! command -v npm >/dev/null 2>&1; then
+        echo "::warning::npm not found, skipping frontend flake loop"
+    else
+        # Reuse the same install across iterations — npm ci once, vitest
+        # uses --run which exits 0/non-zero per run.
+        if [ ! -d node_modules ]; then
+            npm ci --no-audit --no-fund
+        fi
+        run_loop "vitest-run" "npx vitest run --reporter=dot"
+    fi
+fi
+
+# ---- summary ---------------------------------------------------------------
+total_fail=0
+{
+    echo "## Flake finder results"
+    echo
+    echo "| Suite | Iterations | Failures |"
+    echo "| --- | ---: | ---: |"
+    for suite in "${!SUITE_TOTALS[@]}"; do
+        fails=${SUITE_FAILURES[$suite]}
+        total=${SUITE_TOTALS[$suite]}
+        echo "| \`$suite\` | $total | $fails |"
+        total_fail=$(( total_fail + fails ))
+    done
+} | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+if [ "$total_fail" -gt 0 ]; then
+    echo "::error::flake-finder detected $total_fail failing iteration(s)"
+    exit 1
+fi
+echo "All iterations passed."

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1496,7 +1496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2321,7 +2321,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2339,7 +2339,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3974,6 +3974,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3992,6 +4011,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -4161,6 +4186,15 @@ name = "rand_pcg"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
 ]
@@ -4590,7 +4624,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4675,6 +4709,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5277,7 +5323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5754,6 +5800,7 @@ dependencies = [
  "chrono",
  "dirs",
  "log",
+ "proptest",
  "russh",
  "rust_decimal",
  "scylla",
@@ -6119,7 +6166,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6559,6 +6606,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6760,6 +6813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 
@@ -7085,7 +7147,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,3 +46,4 @@ log = "0.4"
 [dev-dependencies]
 tempfile = "3"
 which = "6"
+proptest = "1"

--- a/src-tauri/fuzz/.gitignore
+++ b/src-tauri/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/src-tauri/fuzz/Cargo.toml
+++ b/src-tauri/fuzz/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "tablio-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+# Standard cargo-fuzz layout. The `cargo fuzz init` command would generate
+# something equivalent; we pin it manually so the workflow doesn't need to
+# rerun init on a fresh runner. To regenerate (or add a target):
+#   cargo +nightly fuzz add <target>
+# The nightly toolchain is required because libfuzzer-sys depends on
+# unstable LLVM sanitiser interfaces.
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.tablio_lib]
+path = ".."
+
+# Each fuzz target is its own bin so libfuzzer can link them with a custom
+# `_LLVMFuzzerTestOneInput` entry point. Keep the per-target sections
+# minimal — adding `test = false` and `doc = false` shaves a small but
+# noticeable chunk off cold-build time on CI.
+
+[[bin]]
+name = "ssh_config"
+path = "fuzz_targets/ssh_config.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "proc_self_stat"
+path = "fuzz_targets/proc_self_stat.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "sql_identifier"
+path = "fuzz_targets/sql_identifier.rs"
+test = false
+doc = false
+
+# We deliberately do NOT add `tablio-fuzz` to the workspace — cargo-fuzz
+# nests this crate under the parent so the `cargo fuzz` subcommand can
+# locate it via path conventions, but workspace membership would force
+# the libfuzzer-sys dep into the parent build's lockfile.
+[workspace]

--- a/src-tauri/fuzz/fuzz_targets/proc_self_stat.rs
+++ b/src-tauri/fuzz/fuzz_targets/proc_self_stat.rs
@@ -1,0 +1,26 @@
+#![no_main]
+//! Fuzz target for the `/proc/self/stat` parser used by the resource
+//! monitor to compute CPU% on Linux.
+//!
+//! Contract: arbitrary bytes (kernel can technically deliver malformed
+//! `stat` payloads during a process exec race, and `prctl(PR_SET_NAME)`
+//! lets a program embed any byte sequence except `\n` into `comm`)
+//! must NEVER panic. Returning `Err(_)` is fine — the resource monitor
+//! reports 0% CPU when parsing fails, which is the correct behaviour.
+
+use libfuzzer_sys::fuzz_target;
+
+#[cfg(target_os = "linux")]
+fuzz_target!(|data: &[u8]| {
+    let s = match std::str::from_utf8(data) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let _ = tablio_lib::commands::system::parse_self_stat_total_jiffies(s);
+});
+
+#[cfg(not(target_os = "linux"))]
+fuzz_target!(|_data: &[u8]| {
+    // The parser is `#[cfg(target_os = "linux")]` so this target is a
+    // no-op on macOS/Windows. cargo-fuzz still happily compiles it.
+});

--- a/src-tauri/fuzz/fuzz_targets/sql_identifier.rs
+++ b/src-tauri/fuzz/fuzz_targets/sql_identifier.rs
@@ -1,0 +1,48 @@
+#![no_main]
+//! Fuzz the SQL identifier quoting helpers. These are the only thing
+//! standing between user-supplied table/column names and a raw `WHERE`
+//! clause splice, so a panic or quoting bypass here is a real
+//! correctness/security regression.
+//!
+//! We exercise both the Postgres flavour (`"…"` with `""` doubling)
+//! and the MySQL flavour (`` ` ` `` with backtick doubling). Each call
+//! must:
+//!   * never panic
+//!   * produce output containing the original bytes verbatim somewhere
+//!     between the surrounding delimiters (i.e. lossless round-trip
+//!     for any embedded delimiter via doubling)
+//!   * begin and end with the expected quote char
+
+use libfuzzer_sys::fuzz_target;
+
+fn check_pg(s: &str) {
+    let q = tablio_lib::db::pg_common::quote_ident(s);
+    assert!(q.starts_with('"') && q.ends_with('"'),
+            "pg quote_ident must wrap output in double quotes: input={s:?} output={q:?}");
+    // Every embedded `"` must be doubled. Counting unescaped `"` inside
+    // the body after stripping the wrapping quotes is the simplest check.
+    let inner = &q[1..q.len() - 1];
+    // Post-doubling, every `"` should appear in pairs.
+    let count = inner.matches('"').count();
+    assert!(count % 2 == 0,
+            "pg quote_ident left an unbalanced `\"` inside: {q:?} (input={s:?})");
+}
+
+fn check_mysql(s: &str) {
+    let q = tablio_lib::db::mysql_common::quote_ident(s);
+    assert!(q.starts_with('`') && q.ends_with('`'),
+            "mysql quote_ident must wrap output in backticks: input={s:?} output={q:?}");
+    let inner = &q[1..q.len() - 1];
+    let count = inner.matches('`').count();
+    assert!(count % 2 == 0,
+            "mysql quote_ident left an unbalanced backtick inside: {q:?} (input={s:?})");
+}
+
+fuzz_target!(|data: &[u8]| {
+    let s = match std::str::from_utf8(data) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    check_pg(s);
+    check_mysql(s);
+});

--- a/src-tauri/fuzz/fuzz_targets/ssh_config.rs
+++ b/src-tauri/fuzz/fuzz_targets/ssh_config.rs
@@ -1,0 +1,40 @@
+#![no_main]
+//! Fuzz target for the `~/.ssh/config` parser.
+//!
+//! Contract: arbitrary bytes from the user's config file must NEVER
+//! cause `resolve_target` to panic — this code runs on every alias
+//! lookup in the connection dialog and a panic there crashes the
+//! Tauri renderer.
+//!
+//! The fuzzer also exercises the `target` argument because it's
+//! dialog-supplied and equally untrusted from the parser's point of
+//! view.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 4 {
+        return;
+    }
+    // First two bytes pick a target length up to 64; the rest is the
+    // config body. Splitting the input gives the fuzzer a deterministic
+    // way to mutate target vs body independently.
+    let target_len = (u16::from_le_bytes([data[0], data[1]]) as usize) % 64;
+    let rest = &data[2..];
+    if rest.len() < target_len {
+        return;
+    }
+    let target_bytes = &rest[..target_len];
+    let content_bytes = &rest[target_len..];
+
+    let target = match std::str::from_utf8(target_bytes) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let content = match std::str::from_utf8(content_bytes) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let _ = tablio_lib::commands::ssh_config::resolve_target(content, target);
+});

--- a/src-tauri/src/commands/ssh_config.rs
+++ b/src-tauri/src/commands/ssh_config.rs
@@ -315,3 +315,67 @@ Host prod-* !prod-secret
         assert!(resolve_target(cfg, "prod-secret").is_none());
     }
 }
+
+#[cfg(test)]
+mod proptests {
+    //! Property-based coverage for the SSH config parser. Real users
+    //! drop arbitrary text into `~/.ssh/config` and the parser is
+    //! invoked on every alias lookup in the connection dialog —
+    //! panicking there would crash the renderer. The contract is
+    //! simple: arbitrary input must always return cleanly.
+    use super::{glob_match, host_line_matches, resolve_target};
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// The top-level entry point must never panic on arbitrary
+        /// config text + target. Returns either `Some(_)` or `None`
+        /// — never aborts.
+        #[test]
+        fn resolve_target_never_panics(
+            content in ".{0,4096}",
+            target in "[A-Za-z0-9._-]{0,128}",
+        ) {
+            let _ = resolve_target(&content, &target);
+        }
+
+        /// Glob matching must terminate (no infinite recursion on
+        /// pathological `*?*?*` patterns) and never panic.
+        #[test]
+        fn glob_match_never_panics(
+            // Limit pattern length so worst-case `*?*?*?*?*?` doesn't
+            // blow the recursion budget on the test runner — the
+            // parser has the same implicit budget.
+            pat in "[*?A-Za-z0-9.-]{0,32}",
+            name in "[A-Za-z0-9.-]{0,64}",
+        ) {
+            let _ = glob_match(&pat, &name);
+        }
+
+        /// Negation guard: if a positive pattern matches AND a
+        /// negated pattern also matches, the line must not match.
+        /// This is the OpenSSH semantic our SSH-config import relies
+        /// on; a regression here would silently leak credentials
+        /// across host aliases.
+        #[test]
+        fn negation_always_wins(name in "prod-[a-z]{1,8}") {
+            // Build `prod-* !<name>` — the literal target is excluded.
+            let neg = format!("!{name}");
+            let pats = vec!["prod-*", neg.as_str()];
+            prop_assert!(!host_line_matches(&pats, &name));
+        }
+
+        /// A `Host *` block must always match any non-empty target.
+        /// Regressions here would silently break every wildcard
+        /// fallback users rely on for default username / identity.
+        #[test]
+        fn star_block_matches_any_target(target in "[A-Za-z0-9.-]{1,64}") {
+            let cfg = format!(
+                "Host *\n  HostName {target}.example.com\n  User deploy\n"
+            );
+            let r = resolve_target(&cfg, &target).expect("Host * must match");
+            prop_assert_eq!(r.user.as_deref(), Some("deploy"));
+        }
+    }
+}

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -234,6 +234,100 @@ mod tests {
         );
     }
 
+    /// Long-form stress harness — sequential AND concurrent. Not part
+    /// of the regular test suite (it's slow and noisy); invoke manually
+    /// with:
+    ///
+    /// ```text
+    /// cargo test --manifest-path src-tauri/Cargo.toml --lib \
+    ///     commands::system::tests::stress_fd_leak -- --ignored --nocapture
+    /// ```
+    ///
+    /// What it proves: a real per-call leak shows linear fd growth
+    /// (e.g. 5000 iterations → 5000+ extra fds). Anything sub-linear
+    /// is GitHub-runner / kernel jitter, not a leak we own.
+    #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[ignore]
+    async fn stress_fd_leak() {
+        const SEQ_ITERATIONS: usize = 5_000;
+        const CONCURRENT_TASKS: usize = 16;
+        const CONCURRENT_PER_TASK: usize = 500;
+        const SAMPLE_EVERY: usize = 500;
+
+        fn open_fd_count() -> usize {
+            std::fs::read_dir("/proc/self/fd")
+                .map(|d| d.count())
+                .unwrap_or(0)
+        }
+
+        // ───────────────────── warmup ─────────────────────
+        for _ in 0..10 {
+            let _ = get_app_resource_usage().await.unwrap();
+        }
+
+        // ─────────────── sequential phase ─────────────────
+        let baseline_seq = open_fd_count();
+        let mut samples: Vec<(usize, usize)> = Vec::new();
+        for i in 1..=SEQ_ITERATIONS {
+            let _ = get_app_resource_usage().await.unwrap();
+            if i % SAMPLE_EVERY == 0 {
+                samples.push((i, open_fd_count()));
+            }
+        }
+        let after_seq = open_fd_count();
+
+        eprintln!("\n[stress] sequential phase ({SEQ_ITERATIONS} calls)");
+        eprintln!("[stress]   baseline fds: {baseline_seq}");
+        for (i, fds) in &samples {
+            let growth = (*fds as i64) - baseline_seq as i64;
+            eprintln!("[stress]   after {i:>5} calls: fds={fds:>4} (Δ={growth:+})");
+        }
+        let seq_growth = (after_seq as i64) - baseline_seq as i64;
+        let seq_per_call = seq_growth as f64 / SEQ_ITERATIONS as f64;
+        eprintln!("[stress]   final: {after_seq} (Δ={seq_growth:+}, ≈{seq_per_call:.4} fd/call)");
+
+        // ─────────────── concurrent phase ─────────────────
+        let baseline_conc = open_fd_count();
+        let mut handles = Vec::with_capacity(CONCURRENT_TASKS);
+        for _ in 0..CONCURRENT_TASKS {
+            handles.push(tokio::spawn(async move {
+                for _ in 0..CONCURRENT_PER_TASK {
+                    let _ = get_app_resource_usage().await.unwrap();
+                }
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        let after_conc = open_fd_count();
+        let conc_calls = CONCURRENT_TASKS * CONCURRENT_PER_TASK;
+        let conc_growth = (after_conc as i64) - baseline_conc as i64;
+        let conc_per_call = conc_growth as f64 / conc_calls as f64;
+
+        eprintln!(
+            "\n[stress] concurrent phase ({} tasks × {} = {} calls)",
+            CONCURRENT_TASKS, CONCURRENT_PER_TASK, conc_calls
+        );
+        eprintln!("[stress]   baseline fds: {baseline_conc}");
+        eprintln!(
+            "[stress]   final: {after_conc} (Δ={conc_growth:+}, ≈{conc_per_call:.4} fd/call)"
+        );
+
+        // ─────────────── gate: per-call growth must be sublinear ───
+        // 0.01 fd/call ≅ ~50 leaked fds over 5000 calls. The original
+        // bug was ~0.66 fd/call (one /proc handle per ~1.5 calls in
+        // some kernels). Catching anything north of 0.05 is plenty.
+        assert!(
+            seq_per_call < 0.05,
+            "sequential leak rate too high: {seq_per_call:.4} fd/call (Δ={seq_growth} over {SEQ_ITERATIONS})"
+        );
+        assert!(
+            conc_per_call < 0.05,
+            "concurrent leak rate too high: {conc_per_call:.4} fd/call (Δ={conc_growth} over {conc_calls})"
+        );
+    }
+
     /// Linux fast-path parses /proc/self/stat correctly. The parser
     /// must split the line at the LAST `)` so that a `comm` field
     /// containing arbitrary characters (whitespace, more parens —

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -122,13 +122,28 @@ fn read_cpu_percent_linux() -> Result<f32, String> {
 #[cfg(target_os = "linux")]
 fn read_self_stat_total_jiffies() -> Result<u64, String> {
     let s = std::fs::read_to_string("/proc/self/stat").map_err(|e| e.to_string())?;
-    // The `comm` field can contain arbitrary characters including
-    // whitespace and `(`/`)`, so the only safe way to parse `stat` is
-    // to find the LAST `)` and treat everything after it as
-    // whitespace-separated fields. After the `)` the layout is:
-    //   state ppid pgrp session tty_nr tpgid flags minflt cminflt
-    //   majflt cmajflt utime stime cutime cstime ...
-    // utime is index 11, stime is index 12 (0-based) of `rest`.
+    parse_self_stat_total_jiffies(&s)
+}
+
+/// Pure parser exposed for proptest + cargo-fuzz coverage. The
+/// `/proc/self/stat` layout is documented in `proc(5)`; the trick is
+/// that the `comm` field may contain arbitrary bytes including
+/// whitespace and unbalanced `)`/`(`, so the only safe way to locate
+/// the post-comm fields is to anchor on the LAST `)` in the line.
+/// After that `)` the layout is:
+///   state ppid pgrp session tty_nr tpgid flags minflt cminflt
+///   majflt cmajflt utime stime cutime cstime ...
+/// utime is index 11, stime is index 12 (0-based) of `rest`.
+///
+/// Must never panic on arbitrary input — the kernel can theoretically
+/// hand us malformed bytes during e.g. a process exec race, so any
+/// failure becomes a clean `Err(_)` that the CPU sampler reports as 0.
+///
+/// Visibility is `pub` (rather than `pub(crate)`) so the cargo-fuzz
+/// targets in `src-tauri/fuzz/` can drive it directly. The function
+/// has no side effects and produces no FFI bindings.
+#[cfg(target_os = "linux")]
+pub fn parse_self_stat_total_jiffies(s: &str) -> Result<u64, String> {
     let after_comm = s.rfind(')').ok_or("malformed /proc/self/stat")?;
     let rest = s
         .get(after_comm + 1..)
@@ -145,7 +160,9 @@ fn read_self_stat_total_jiffies() -> Result<u64, String> {
         .ok_or("missing stime")?
         .parse()
         .map_err(|e: std::num::ParseIntError| e.to_string())?;
-    Ok(utime + stime)
+    utime
+        .checked_add(stime)
+        .ok_or_else(|| "jiffy overflow".to_string())
 }
 
 #[cfg(target_os = "linux")]
@@ -354,5 +371,80 @@ mod tests {
             after >= before,
             "/proc/self/stat parsing must be monotonic: before={before}, after={after}"
         );
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(test)]
+mod proptests {
+    //! Property-based coverage for the `/proc/self/stat` parser.
+    //!
+    //! The parser handles untrusted-shape input (kernel can race a
+    //! process exec, prctl(PR_SET_NAME) lets a process embed unbalanced
+    //! parens or whitespace into `comm`, etc.). The contract is
+    //! "never panic, always return Ok or Err". These properties
+    //! exercise both axes with a few thousand cases per nightly run.
+    use super::parse_self_stat_total_jiffies;
+    use proptest::prelude::*;
+
+    /// Build a syntactically-plausible `/proc/<pid>/stat` line whose
+    /// `comm` field is the arbitrary `comm` parameter (parens
+    /// included). All other fields are deterministic except utime
+    /// and stime which we want to round-trip back out of the parser.
+    fn synthesize_stat(comm: &str, utime: u64, stime: u64) -> String {
+        // Layout: pid (comm) state ppid pgrp session tty_nr tpgid flags
+        //         minflt cminflt majflt cmajflt utime stime ...
+        // After `)` the post-comm fields (rest indices 0..) are:
+        //   0:state 1:ppid 2:pgrp 3:session 4:tty 5:tpgid 6:flags
+        //   7:minflt 8:cminflt 9:majflt 10:cmajflt 11:utime 12:stime ...
+        format!(
+            "1234 ({}) S 1 1 1 0 -1 0 0 0 0 0 {} {} 0 0 20 0 1 0 100 0 0 0\n",
+            comm, utime, stime
+        )
+    }
+
+    proptest! {
+        // 256 cases per property keeps the local default-cases run fast;
+        // the nightly proptest job overrides this via PROPTEST_CASES=4096.
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// The parser must never panic on arbitrary bytes. The kernel
+        /// gives us bytes; we owe it not to crash the resource monitor.
+        #[test]
+        fn parser_never_panics(s in ".{0,4096}") {
+            let _ = parse_self_stat_total_jiffies(&s);
+        }
+
+        /// On well-formed input — even with adversarial `comm` (parens,
+        /// whitespace, embedded `)`) — the parser MUST return the
+        /// utime+stime sum we put in.
+        #[test]
+        fn round_trip_arbitrary_comm(
+            // `comm` may contain anything except newlines (the kernel
+            // never embeds `\n` because `/proc/self/stat` is one line).
+            comm in "[^\n]{0,255}",
+            utime in 0u64..1_000_000_000,
+            stime in 0u64..1_000_000_000,
+        ) {
+            let stat = synthesize_stat(&comm, utime, stime);
+            let total = parse_self_stat_total_jiffies(&stat)
+                .expect("synthetic stat with valid utime/stime must parse");
+            prop_assert_eq!(total, utime + stime);
+        }
+
+        /// Truncating any prefix of well-formed input must not panic
+        /// (it's allowed to return Err — the contract is just "no
+        /// process aborts").
+        #[test]
+        fn truncated_input_is_safe(
+            comm in "[^\n]{0,64}",
+            utime in 0u64..u32::MAX as u64,
+            stime in 0u64..u32::MAX as u64,
+            cut in 0usize..256,
+        ) {
+            let stat = synthesize_stat(&comm, utime, stime);
+            let truncated: String = stat.chars().take(cut).collect();
+            let _ = parse_self_stat_total_jiffies(&truncated);
+        }
     }
 }

--- a/src-tauri/tests/mysql_integration.rs
+++ b/src-tauri/tests/mysql_integration.rs
@@ -1787,3 +1787,104 @@ async fn validate_query_empty_string() {
     let result = driver.validate_query(&db, "").await.unwrap();
     assert!(result.is_some(), "empty SQL should be an error");
 }
+
+// ---------------------------------------------------------------------------
+// Big-data soak — nightly only (`#[ignore]`-gated)
+// ---------------------------------------------------------------------------
+
+const MYSQL_BIG_DATA_ROWS: i64 = 1_000_000;
+
+/// MySQL has no `generate_series`, so we materialise a million rows by
+/// chained joins on a CTE numbers table. Faster than a million round-trips
+/// and works on every supported MySQL/MariaDB version.
+async fn mysql_seed_million_rows(
+    driver: &MysqlDriver,
+    db: &str,
+    table: &str,
+) -> anyhow::Result<()> {
+    let create_sql = format!(
+        "CREATE TABLE `{db}`.`{table}` ( \
+             id BIGINT PRIMARY KEY, \
+             payload TEXT NOT NULL, \
+             created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP \
+         )"
+    );
+    driver.execute_query(db, &create_sql).await?;
+
+    // Recursive CTE produces the integers 1..=N in a single statement.
+    // MySQL caps `cte_max_recursion_depth` at 1000 by default; bump it
+    // to N so we can fan out without partitioning the insert.
+    let bump = format!(
+        "SET SESSION cte_max_recursion_depth = {n}",
+        n = MYSQL_BIG_DATA_ROWS + 1
+    );
+    let _ = driver.execute_query(db, &bump).await; // ignored on MariaDB
+
+    let insert_sql = format!(
+        "INSERT INTO `{db}`.`{table}` (id, payload) \
+         WITH RECURSIVE seq(n) AS ( \
+             SELECT 1 \
+             UNION ALL \
+             SELECT n + 1 FROM seq WHERE n < {n} \
+         ) \
+         SELECT n, CONCAT('row-', n) FROM seq",
+        n = MYSQL_BIG_DATA_ROWS
+    );
+    driver.execute_query(db, &insert_sql).await?;
+    Ok(())
+}
+
+async fn mysql_drop_table_silent(driver: &MysqlDriver, db: &str, table: &str) {
+    let _ = driver
+        .execute_query(db, &format!("DROP TABLE IF EXISTS `{db}`.`{table}`"))
+        .await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn million_row_paginate() {
+    let (driver, db) = mysql_driver!();
+    let table = unique_table("big_data_paginate");
+
+    mysql_drop_table_silent(&driver, &db, &table).await;
+    mysql_seed_million_rows(&driver, &db, &table)
+        .await
+        .expect("seed million rows");
+
+    const PAGE: u64 = 5_000;
+    const MAX_PAGE_MS: u128 = 5_000;
+    let mut offset: u64 = 0;
+    let mut total: u64 = 0;
+    let mut pages: u64 = 0;
+    let started = std::time::Instant::now();
+
+    loop {
+        let t = std::time::Instant::now();
+        let data = driver
+            .fetch_rows(&db, &db, &table, offset, PAGE, None, None)
+            .await
+            .expect("fetch_rows page");
+        let elapsed = t.elapsed().as_millis();
+        assert!(
+            elapsed < MAX_PAGE_MS,
+            "page at offset {offset} took {elapsed}ms (>{MAX_PAGE_MS}ms budget)"
+        );
+        let n = data.rows.len() as u64;
+        total += n;
+        pages += 1;
+        if n < PAGE {
+            break;
+        }
+        offset += PAGE;
+    }
+
+    let total_elapsed = started.elapsed().as_secs_f64();
+    eprintln!("[big-data][mysql] paginated {total} rows in {pages} pages in {total_elapsed:.2}s");
+
+    assert_eq!(
+        total, MYSQL_BIG_DATA_ROWS as u64,
+        "expected {MYSQL_BIG_DATA_ROWS} rows total, got {total} across {pages} pages"
+    );
+
+    mysql_drop_table_silent(&driver, &db, &table).await;
+}

--- a/src-tauri/tests/postgres_integration.rs
+++ b/src-tauri/tests/postgres_integration.rs
@@ -2265,3 +2265,227 @@ async fn validate_query_valid_with_cte() {
         .unwrap();
     assert!(result.is_none(), "valid CTE should return None");
 }
+
+// ---------------------------------------------------------------------------
+// Big-data soak — nightly only (`#[ignore]`-gated)
+// ---------------------------------------------------------------------------
+//
+// These tests seed a temporary table with a million rows and exercise the
+// production fetch_rows pagination path on a payload size representative of
+// real users with substantial datasets. They are NOT part of the regular CI
+// matrix because seeding alone takes ~30s on the smallest CI runners; the
+// nightly `big-data` job invokes them via `--ignored`.
+
+const BIG_DATA_ROWS: i64 = 1_000_000;
+
+/// Seed a one-million-row table named `<table>` in `SCHEMA.DB` using a
+/// single `INSERT … SELECT generate_series(...)` so the work happens
+/// server-side. Returns the table name (qualified).
+async fn pg_seed_million_rows(driver: &PostgresDriver, table: &str) -> anyhow::Result<()> {
+    let create_sql = format!(
+        "CREATE TABLE {schema}.{table} ( \
+             id BIGINT PRIMARY KEY, \
+             payload TEXT NOT NULL, \
+             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW() \
+         )",
+        schema = SCHEMA,
+        table = table
+    );
+    driver.execute_query(DB, &create_sql).await?;
+    let insert_sql = format!(
+        "INSERT INTO {schema}.{table} (id, payload) \
+         SELECT g, 'row-' || g \
+         FROM generate_series(1, {n}) g",
+        schema = SCHEMA,
+        table = table,
+        n = BIG_DATA_ROWS
+    );
+    driver.execute_query(DB, &insert_sql).await?;
+    Ok(())
+}
+
+async fn pg_drop_table_silent(driver: &PostgresDriver, table: &str) {
+    let _ = driver
+        .execute_query(DB, &format!("DROP TABLE IF EXISTS {SCHEMA}.{table}"))
+        .await;
+}
+
+/// Paginate through a million-row table via the same `fetch_rows` code path
+/// the renderer drives. Asserts:
+///   * every page returns exactly `LIMIT` rows except possibly the last
+///   * each page comes back within `MAX_PAGE_MS`
+///   * total fetched row count matches the table cardinality
+///
+/// The wall-clock budget is intentionally loose (per-page, not total) so a
+/// noisy CI runner can stretch the soak without flaking. A real perf
+/// regression would push individual pages over a hard limit, not redistribute
+/// time evenly across them.
+#[tokio::test]
+#[ignore]
+async fn million_row_paginate() {
+    let driver = pg_driver!();
+    let table = unique_table("big_data_paginate");
+
+    // Best-effort cleanup before AND after — a previous aborted run could
+    // leave the table behind on the same DB.
+    pg_drop_table_silent(&driver, &table).await;
+    pg_seed_million_rows(&driver, &table)
+        .await
+        .expect("seed million rows");
+
+    const PAGE: u64 = 5_000;
+    const MAX_PAGE_MS: u128 = 5_000;
+    let mut offset: u64 = 0;
+    let mut total: u64 = 0;
+    let mut pages: u64 = 0;
+    let started = std::time::Instant::now();
+
+    loop {
+        let t = std::time::Instant::now();
+        let data = driver
+            .fetch_rows(DB, SCHEMA, &table, offset, PAGE, None, None)
+            .await
+            .expect("fetch_rows page");
+        let elapsed = t.elapsed().as_millis();
+        assert!(
+            elapsed < MAX_PAGE_MS,
+            "page at offset {offset} took {elapsed}ms (>{MAX_PAGE_MS}ms budget)"
+        );
+        let n = data.rows.len() as u64;
+        total += n;
+        pages += 1;
+        if n < PAGE {
+            break;
+        }
+        offset += PAGE;
+    }
+
+    let total_elapsed = started.elapsed().as_secs_f64();
+    eprintln!("[big-data][pg] paginated {total} rows in {pages} pages in {total_elapsed:.2}s");
+
+    assert_eq!(
+        total, BIG_DATA_ROWS as u64,
+        "expected {BIG_DATA_ROWS} rows total, got {total} across {pages} pages"
+    );
+
+    pg_drop_table_silent(&driver, &table).await;
+}
+
+/// End-to-end pg_dump → pg_restore round-trip on a sizeable fixture. Skips
+/// cleanly when `pg_dump` / `pg_restore` aren't on PATH (the nightly job
+/// installs them; local devs without them just see the test skip).
+#[tokio::test]
+#[ignore]
+async fn dump_restore_roundtrip() {
+    use std::process::Command;
+
+    if which::which("pg_dump").is_err() || which::which("pg_restore").is_err() {
+        eprintln!("Skipping dump_restore_roundtrip: pg_dump/pg_restore not on PATH");
+        return;
+    }
+
+    let url = match std::env::var("TEST_POSTGRES_URL") {
+        Ok(v) if !v.is_empty() => v,
+        _ => {
+            eprintln!("Skipping dump_restore_roundtrip: TEST_POSTGRES_URL not set");
+            return;
+        }
+    };
+
+    let driver = pg_driver!();
+    let src_table = unique_table("big_data_dump_src");
+
+    pg_drop_table_silent(&driver, &src_table).await;
+    pg_seed_million_rows(&driver, &src_table)
+        .await
+        .expect("seed dump source");
+
+    // Parse the URL once for the pg_dump/restore env vars.
+    // postgres://user:pw@host:port/db
+    let stripped = url
+        .strip_prefix("postgres://")
+        .or_else(|| url.strip_prefix("postgresql://"))
+        .expect("bad TEST_POSTGRES_URL");
+    let (user_pass, rest) = stripped.split_once('@').expect("@");
+    let (user, password) = user_pass.split_once(':').expect(":");
+    let (host_port, database) = rest.split_once('/').expect("/");
+    let database = database.split('?').next().unwrap();
+    let (host, port) = host_port.split_once(':').expect("port");
+
+    let dump_file = tempfile::Builder::new()
+        .prefix("tablio-bigdata-dump-")
+        .suffix(".dump")
+        .tempfile()
+        .expect("tempfile");
+    let dump_path = dump_file.path().to_owned();
+
+    let dump_status = Command::new("pg_dump")
+        .arg("-h")
+        .arg(host)
+        .arg("-p")
+        .arg(port)
+        .arg("-U")
+        .arg(user)
+        .arg("-d")
+        .arg(database)
+        .arg("-Fc") // custom format — required by pg_restore -t with --data-only
+        .arg("-t")
+        .arg(format!("{SCHEMA}.{src_table}"))
+        .arg("-f")
+        .arg(&dump_path)
+        .env("PGPASSWORD", password)
+        .status()
+        .expect("pg_dump must spawn");
+    assert!(
+        dump_status.success(),
+        "pg_dump exited non-zero: {dump_status:?}"
+    );
+
+    // Truncate src so the data-only restore is a real round-trip:
+    // every row that comes back has to have travelled through the
+    // dump file, not just been left behind from the seed.
+    driver
+        .execute_query(DB, &format!("TRUNCATE {SCHEMA}.{src_table}"))
+        .await
+        .expect("truncate src");
+
+    let restore_status = Command::new("pg_restore")
+        .arg("-h")
+        .arg(host)
+        .arg("-p")
+        .arg(port)
+        .arg("-U")
+        .arg(user)
+        .arg("-d")
+        .arg(database)
+        .arg("--data-only")
+        .arg(&dump_path)
+        .env("PGPASSWORD", password)
+        .status()
+        .expect("pg_restore must spawn");
+    assert!(
+        restore_status.success(),
+        "pg_restore exited non-zero: {restore_status:?}"
+    );
+
+    // Verify cardinality survives a full round-trip.
+    let count_q = driver
+        .execute_query(
+            DB,
+            &format!("SELECT COUNT(*)::BIGINT AS n FROM {SCHEMA}.{src_table}"),
+        )
+        .await
+        .expect("count after restore");
+    let n = count_q
+        .rows
+        .first()
+        .and_then(|r| r.first())
+        .and_then(|v| v.as_i64())
+        .expect("count column");
+    assert_eq!(
+        n, BIG_DATA_ROWS,
+        "round-trip lost rows: expected {BIG_DATA_ROWS}, got {n}"
+    );
+
+    pg_drop_table_silent(&driver, &src_table).await;
+}

--- a/src-tauri/tests/ssh_tunnel_integration.rs
+++ b/src-tauri/tests/ssh_tunnel_integration.rs
@@ -352,3 +352,129 @@ async fn ssh_tunnel_open_rejects_bad_password() {
         "expected an auth error, got: {msg}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Soak harness — nightly only
+// ---------------------------------------------------------------------------
+
+/// Best-effort fd count for the current process. Linux only — every
+/// other platform returns `0` and the soak test simply skips its
+/// growth assertion.
+fn open_fd_count() -> usize {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_dir("/proc/self/fd")
+            .map(|d| d.count())
+            .unwrap_or(0)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        0
+    }
+}
+
+/// Long-running open→port-forward→query→close soak, gated by `#[ignore]`
+/// so it stays out of regular CI. The nightly workflow invokes it via
+///
+/// ```text
+/// cargo test --manifest-path src-tauri/Cargo.toml --test ssh_tunnel_integration \
+///     -- --ignored soak_open_close_loop --nocapture --test-threads=1
+/// ```
+///
+/// Why this exists: a per-iteration leak in russh, the local TCP
+/// listener, or PoolManager would manifest as linear fd / channel
+/// growth over many cycles. The regular integration tests open ~5
+/// tunnels and would never see it. This harness opens hundreds.
+///
+/// Threshold rationale: the same `0.05 fd/cycle` budget the resource-
+/// monitor stress test uses (`commands::system::tests::stress_fd_leak`).
+/// A real per-cycle leak shows linear growth; everything below that
+/// rate is kernel/runner jitter.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
+async fn soak_open_close_loop() {
+    let Some(config) = ssh_test_config() else {
+        eprintln!("Skipping soak_open_close_loop: TEST_SSH_* env vars not set");
+        return;
+    };
+
+    // Tunable via env so the nightly workflow can dial intensity up
+    // or down without recompiling. Default is ~5 minutes of cycles
+    // on a typical CI runner (~200 cycles, each open+query+close).
+    let iterations: usize = std::env::var("SOAK_ITERATIONS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(200);
+    let sample_every: usize = (iterations / 10).max(1);
+
+    // Warm up the pool / russh internals so the first sample isn't
+    // skewed by lazy initialisation (rustls cipher tables, allocators,
+    // etc.).
+    {
+        let pool = PoolManager::new();
+        pool.connect(config.clone()).await.expect("warmup connect");
+        pool.disconnect(&config.id)
+            .await
+            .expect("warmup disconnect");
+    }
+
+    let baseline = open_fd_count();
+    let mut samples: Vec<(usize, usize)> = Vec::new();
+
+    for i in 1..=iterations {
+        let mut cfg = config.clone();
+        // Unique pool id per cycle so the PoolManager genuinely opens
+        // a fresh tunnel each time instead of reusing a cached driver.
+        cfg.id = format!("ssh-soak-{i}");
+        cfg.name = cfg.id.clone();
+        let pool = PoolManager::new();
+        pool.connect(cfg.clone())
+            .await
+            .expect("soak iteration connect");
+        let driver = pool
+            .get_driver(&cfg.id)
+            .await
+            .expect("soak iteration driver");
+        // Round-trip a real query through the tunnel so we exercise
+        // the channel path, not just session establishment.
+        assert!(
+            driver
+                .test_connection()
+                .await
+                .expect("soak test_connection"),
+            "iteration {i} test_connection returned false"
+        );
+        pool.disconnect(&cfg.id)
+            .await
+            .expect("soak iteration disconnect");
+        // Drop pool explicitly so any task-scoped guards run before we
+        // sample.
+        drop(pool);
+
+        if i % sample_every == 0 {
+            let fds = open_fd_count();
+            samples.push((i, fds));
+            eprintln!(
+                "[ssh-soak] after {i:>4} cycles: fds={fds:>4} (Δ={:+})",
+                fds as i64 - baseline as i64
+            );
+        }
+    }
+
+    let after = open_fd_count();
+    let growth = (after as i64) - (baseline as i64);
+    let per_cycle = growth as f64 / iterations as f64;
+    eprintln!(
+        "[ssh-soak] final: fds={after} (Δ={growth:+}, ≈{per_cycle:.4} fd/cycle over {iterations} cycles)"
+    );
+
+    // Skip the assertion on platforms where /proc/self/fd doesn't
+    // exist — the loop itself still proves the cycle doesn't error
+    // out, which is the more important guarantee.
+    if cfg!(target_os = "linux") && baseline > 0 {
+        assert!(
+            per_cycle < 0.05,
+            "ssh tunnel leak rate too high: {per_cycle:.4} fd/cycle (Δ={growth} over {iterations}); samples={samples:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `Nightly` GitHub Actions workflow that runs ten scheduled jobs (security audit, leak/soak/fuzz/big-data harnesses, build rehearsal, flake-finder, cross-OS e2e) at 04:00 UTC daily and on `workflow_dispatch`.

Nothing here is wired into `ci.yml`'s `ci-required` aggregator — PR latency and required-status surface are untouched.

## What's new

### Test-side scaffolding (commit 1)

| Component | Where | Trigger |
| --- | --- | --- |
| `proptest` properties | `src/commands/{ssh_config,system}.rs` `mod proptests` | Regular CI (256 cases) + nightly (4096 cases) |
| Pure parser refactor | `commands::system::parse_self_stat_total_jiffies` made `pub` (was private) | n/a — fuzz/proptest reachable |
| SSH tunnel soak | `tests/ssh_tunnel_integration::soak_open_close_loop` | `#[ignore]`, ~200 open/close cycles |
| 1M-row paginate | `tests/{postgres,mysql}_integration::million_row_paginate` | `#[ignore]`, server-side seed via `generate_series` / `WITH RECURSIVE` |
| Dump/restore round-trip | `tests/postgres_integration::dump_restore_roundtrip` | `#[ignore]`, real `pg_dump` + `pg_restore` |
| cargo-fuzz crate | `src-tauri/fuzz/` (separate `[workspace]`) | Nightly only — needs nightly toolchain + libfuzzer-sys |
| Flake finder | `scripts/flake-finder.sh` | Nightly + manual |

### Nightly workflow jobs (commit 2)

| Job | Tier | Wall-clock budget | What it catches |
| --- | --- | --- | --- |
| `audit` | 1 | 10m | RUSTSEC IDs Dependabot misses, high+ npm advisories |
| `stress-fdleak` | 1 | 15m | Sub-threshold fd trickle leaks |
| `build-rehearsal` (3-OS) | 1 | 60m | Release-only breakage on tip-of-master |
| `legacy-db-matrix` | 2 | 25m | Regressions on PG 12/13, MySQL 5.7 |
| `ssh-soak` | 2 | 30m | russh / pool channel/fd leaks at scale |
| `flake-finder` | 3 | 60m | Per-iteration flakes in lib + vitest |
| `big-data` | 3 | 45m | Pagination perf + dump cardinality drift |
| `proptest` | 3 | 20m | Parser invariant violations across ~30k inputs |
| `cargo-fuzz` (3 targets) | 3 | 20m | Coverage-guided crashes in 3 untrusted-input parsers |
| `cross-os-e2e` (3-OS) | 3 | 30m | Platform-specific Playwright/render bugs |

## Test plan

- [x] All `#[ignore]`-gated tests skip cleanly when their env vars aren't set
- [x] 7 proptest properties green at `PROPTEST_CASES=4096` (~9s locally)
- [x] `scripts/flake-finder.sh` exits 0 on a clean tree
- [x] `cargo build --tests` passes (no new warnings introduced by this PR — pre-existing clippy issues in untouched files are out of scope)
- [x] `cargo fmt --check` clean
- [ ] First scheduled run / `workflow_dispatch` confirms every job either passes or fails for reasons unrelated to the workflow plumbing
- [ ] cargo-fuzz job link-step succeeds on a fresh runner (libfuzzer-sys + nightly + cargo-fuzz install)

## Notes

- This branch cherry-picks `f552bfb` (`stress_fd_leak` harness) from PR #83 so the `stress-fdleak` job has a real target on master regardless of merge order. PR #83 still owns the slack bump on the *regular* fd-leak regression test.
- The cargo-fuzz crate is deliberately a *separate workspace* (its own `[workspace]` block) so libfuzzer-sys doesn't leak into the main lockfile; `cargo-fuzz` will find it via the conventional `--fuzz-dir` path.