### PR TITLE
ci: run CodeQL on push to master only, not on PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,77 @@
+name: CodeQL
+
+# Why advanced setup instead of GitHub's default code-scanning?
+#
+#   * Default setup ALWAYS runs on every PR to the default branch.
+#     There's no knob in repo settings to turn that off — the only way
+#     to get push-only scanning is to disable default setup and supply
+#     this advanced-setup workflow.
+#   * PR scanning duplicates work the regular CI matrix already covers
+#     (clippy on Rust, eslint+vitest on TS, etc.) and adds 3-7 minutes
+#     to every PR for findings that almost never need to be addressed
+#     before merge.
+#   * Push-to-master + weekly schedule keeps the security tab
+#     populated without paying that PR-time tax.
+#
+# Languages match what default setup was configured for as of
+# 2026-04-30 ({"actions","javascript","javascript-typescript","rust",
+# "typescript"} — the `javascript` and `typescript` slots are aliases
+# of `javascript-typescript` so we collapse them here).
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    # Weekly Friday at 07:34 UTC. Randomised minute (not :00) keeps us
+    # off GitHub's hourly burst window so the queue stays warm.
+    - cron: "34 7 * * 5"
+  workflow_dispatch:
+
+# `security-events: write` is the only token scope CodeQL strictly
+# needs (to upload SARIF). `contents: read` for checkout, `actions: read`
+# for workflow analysis. Nothing else.
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript, rust]
+    steps:
+      - uses: actions/checkout@v6
+
+      # Tauri's Rust crate needs the same system libs CI's other Rust
+      # jobs install — the autobuild step shells out to `cargo build`,
+      # which would otherwise fail on missing webkit2gtk headers.
+      - name: Install Linux deps (Rust autobuild prerequisite)
+        if: matrix.language == 'rust'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev librsvg2-dev \
+            libayatana-appindicator3-dev patchelf
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # `default` query suite matches what default setup was using;
+          # `security-extended` is also available but produces noisier
+          # findings that we don't currently triage.
+          queries: default
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Why

GitHub's default code-scanning setup always scans every PR to the default branch — there's no setting to turn that off. CodeQL on every PR adds 3-7 minutes of wall-clock and produces findings the regular CI matrix (clippy / eslint / vitest) already covers for the kinds of changes we ship.

This switches to advanced setup so we control the trigger surface ourselves.

## What changes

- **New file**: \`.github/workflows/codeql.yml\` — advanced-setup CodeQL workflow.
- **Triggers**: \`push: branches: [master]\`, \`schedule: cron: '34 7 * * 5'\` (weekly Fridays 07:34 UTC), \`workflow_dispatch\`. **No \`pull_request\`** — that's the whole point.
- **Languages**: \`actions\`, \`javascript-typescript\`, \`rust\` — matches the current default-setup configuration (the \`javascript\` / \`typescript\` slots are aliases of \`javascript-typescript\` so they collapse).
- **Permissions**: minimum CodeQL needs (\`security-events: write\`, \`contents: read\`, \`actions: read\`).
- **Tauri Rust autobuild deps**: same system libs the other Rust CI jobs install.

## Required post-merge step

GitHub doesn't let advanced setup take over while default setup is still on. After this PR merges, run:

\`\`\`bash
gh api -X PATCH /repos/dasunNimantha/tablio/code-scanning/default-setup \\
  -f state=not-configured
\`\`\`

…or in the UI: **Settings → Code security → Code scanning → CodeQL → switch to advanced**.

The first push to master after that will trigger the new workflow and re-populate the Security tab. Until that step happens, default setup keeps scanning PRs as before — there's no scanning gap.

## Test plan

- [x] YAML parses cleanly
- [ ] After merge: disable default setup
- [ ] First push-to-master after disable shows the new \`Analyze (...)\` jobs in the Actions tab
- [ ] PR after that does NOT have CodeQL in its check list