### PR TITLE
Query stats parity for MySQL/MariaDB, MSSQL, TiDB + coverage CI (#52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,62 @@ jobs:
           TEST_TIDB_URL: "mysql://root@localhost:4000/testdb"
         run: cargo test --manifest-path src-tauri/Cargo.toml --test tidb_integration
 
+  # SQL Server is wired into PR CI (not just release.yml) because the new
+  # get_query_stats DMV-backed implementation needs continuous coverage.
+  # Single-version (2022) here to keep PR latency in check; the 2019/2022
+  # matrix still runs on release.yml.
+  test-mssql:
+    name: SQL Server
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Str0ng_Passw0rd!"
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U SA -P 'Str0ng_Passw0rd!' -C -Q 'SELECT 1' || /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'Str0ng_Passw0rd!' -Q 'SELECT 1'"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 10
+          --health-start-period 30s
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create test database
+        run: |
+          for i in $(seq 1 30); do
+            if docker exec $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2022-latest) /opt/mssql-tools18/bin/sqlcmd -S localhost -U SA -P 'Str0ng_Passw0rd!' -C -Q "SELECT 1" 2>/dev/null || \
+               docker exec $(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2022-latest) /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'Str0ng_Passw0rd!' -Q "SELECT 1" 2>/dev/null; then
+              echo "SQL Server is ready"
+              break
+            fi
+            echo "Waiting for SQL Server... (attempt $i/30)"
+            sleep 2
+          done
+          CONTAINER_ID=$(docker ps -q --filter ancestor=mcr.microsoft.com/mssql/server:2022-latest)
+          docker exec "$CONTAINER_ID" bash -c "/opt/mssql-tools18/bin/sqlcmd -S localhost -U SA -P 'Str0ng_Passw0rd!' -C -Q 'CREATE DATABASE testdb' 2>/dev/null || /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'Str0ng_Passw0rd!' -Q 'CREATE DATABASE testdb'"
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Run MSSQL integration tests
+        env:
+          TEST_MSSQL_URL: "mssql://SA:Str0ng_Passw0rd!@localhost:1433/testdb"
+        run: cargo test --manifest-path src-tauri/Cargo.toml --test mssql_integration
+
   test-sqlite:
     name: SQLite
     needs: [changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,40 @@ jobs:
       - name: TypeScript type check
         run: npx tsc --noEmit
 
-      - name: Run tests
-        run: npm run test
+      # Run vitest with v8 coverage. The lcov + json-summary reporters power
+      # the artifact upload below and the PR job-summary block; the html
+      # reporter gives reviewers a browsable report when they download the
+      # artifact locally.
+      - name: Run tests with coverage
+        run: npm run test -- --coverage
+
+      - name: Frontend coverage summary
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            {
+              echo "## Frontend coverage (vitest / v8)"
+              echo
+              echo "| Metric | Covered | Total | Pct |"
+              echo "| --- | --- | --- | --- |"
+              node -e '
+                const s = require("./coverage/coverage-summary.json").total;
+                for (const k of ["lines","statements","functions","branches"]) {
+                  const m = s[k];
+                  console.log(`| ${k} | ${m.covered} | ${m.total} | ${m.pct.toFixed(2)}% |`);
+                }
+              '
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload frontend coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-frontend
+          path: coverage/
+          retention-days: 14
+          if-no-files-found: ignore
 
   fmt-and-clippy:
     name: Format & Clippy
@@ -89,6 +121,68 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+
+  # Backend code coverage via cargo-llvm-cov. Scoped to the lib + the SQLite
+  # integration suite (the only one that doesn't need an external service);
+  # the per-engine integration jobs cover the driver-specific paths and
+  # could feed lcov into a merge step in a follow-up. Coverage is a signal,
+  # not a gate — no thresholds today.
+  coverage-backend:
+    name: Backend Coverage
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      # Single coverage run; emit lcov for the artifact, then re-render the
+      # already-collected profraw data as a summary table for the PR job
+      # summary. `report` does not re-execute tests.
+      - name: Run coverage (lib + sqlite)
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml \
+            --lib --test sqlite_integration \
+            --no-report
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml report \
+            --lcov --output-path lcov.info
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          {
+            echo "## Backend coverage (cargo-llvm-cov, lib + sqlite)"
+            echo
+            echo '```'
+            cargo llvm-cov --manifest-path src-tauri/Cargo.toml report \
+              --summary-only 2>/dev/null || echo "(no coverage data collected)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload backend coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-backend
+          path: lcov.info
+          retention-days: 14
+          if-no-files-found: ignore
 
   test-postgres:
     name: Postgres ${{ matrix.pg_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ src-tauri/target/
 test-results/
 playwright-report/
 
+# Coverage reports (vitest v8, cargo-llvm-cov)
+coverage/
+lcov.info
+
 # Frontend build output, but keep dist/aur/ and dist/flatpak/
 dist/*
 !dist/aur/

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.5",
         "jsdom": "^29.0.0",
         "typescript": "^6.0.2",
         "vite": "^8.0.6",
@@ -83,15 +84,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -102,6 +128,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -194,12 +244,33 @@
         }
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
@@ -979,6 +1050,37 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -1171,6 +1273,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -1383,6 +1504,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -1395,6 +1526,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -1412,6 +1550,45 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -1904,6 +2081,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/marked": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
@@ -2322,6 +2527,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2380,6 +2598,19 @@
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "jsdom": "^29.0.0",
     "typescript": "^6.0.2",
     "vite": "^8.0.6",

--- a/src-tauri/src/db/cassandra.rs
+++ b/src-tauri/src/db/cassandra.rs
@@ -921,6 +921,7 @@ impl DatabaseDriver for CassandraDriver {
     async fn get_query_stats(&self) -> Result<QueryStatsResponse> {
         Ok(QueryStatsResponse {
             available: false,
+            kind: QueryStatsKind::EngineUnsupported,
             message: Some("Query statistics are not available for Cassandra/ScyllaDB".to_string()),
             entries: vec![],
         })

--- a/src-tauri/src/db/cockroachdb.rs
+++ b/src-tauri/src/db/cockroachdb.rs
@@ -511,6 +511,7 @@ impl DatabaseDriver for CockroachdbDriver {
     async fn get_query_stats(&self) -> Result<QueryStatsResponse> {
         Ok(QueryStatsResponse {
             available: false,
+            kind: QueryStatsKind::EngineUnsupported,
             message: Some(
                 "Query statistics (pg_stat_statements) are not available in CockroachDB. \
                 Use the CockroachDB Admin UI for query insights."

--- a/src-tauri/src/db/mssql.rs
+++ b/src-tauri/src/db/mssql.rs
@@ -156,6 +156,30 @@ fn column_data_to_json(data: &ColumnData<'_>) -> serde_json::Value {
     }
 }
 
+/// Decode a `serde_json::Value` cell as `i64`, accepting integer numbers,
+/// floats with fractional part `.0`, and BIGINT-as-string (some drivers
+/// serialize BIGINT as a JSON string to avoid 53-bit precision loss).
+fn json_as_i64(v: &serde_json::Value) -> Option<i64> {
+    match v {
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .or_else(|| n.as_u64().and_then(|u| i64::try_from(u).ok()))
+            .or_else(|| n.as_f64().map(|f| f as i64)),
+        serde_json::Value::String(s) => s.parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+/// Decode a `serde_json::Value` cell as `f64`, with the same string-fallback
+/// the BIGINT case requires.
+fn json_as_f64(v: &serde_json::Value) -> Option<f64> {
+    match v {
+        serde_json::Value::Number(n) => n.as_f64(),
+        serde_json::Value::String(s) => s.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
 fn rows_to_grid(rows: Vec<Row>) -> (Vec<String>, Vec<Vec<serde_json::Value>>) {
     if rows.is_empty() {
         return (vec![], vec![]);
@@ -1404,10 +1428,132 @@ impl DatabaseDriver for MssqlDriver {
     }
 
     async fn get_query_stats(&self) -> Result<QueryStatsResponse> {
+        // `sys.dm_exec_query_stats` is always-on; the only realistic failure
+        // mode is the connecting login lacking `VIEW SERVER STATE`. A small
+        // probe lets us classify that into a structured `kind` rather than
+        // bubbling a raw error to the UI.
+        if let Err(e) = self
+            .run_select("SELECT TOP 1 1 AS probe FROM sys.dm_exec_query_stats")
+            .await
+        {
+            let msg = e.to_string();
+            let lower = msg.to_ascii_lowercase();
+            if lower.contains("view server state") || lower.contains("permission") {
+                return Ok(QueryStatsResponse {
+                    available: false,
+                    kind: QueryStatsKind::MssqlMissingViewServerState,
+                    message: Some(
+                        "The connecting login does not have VIEW SERVER STATE.\n\n\
+                         Ask a sysadmin to run:\n\
+                         \u{2003}GRANT VIEW SERVER STATE TO [<your_login>];\n\n\
+                         Without it, sys.dm_exec_query_stats is not readable."
+                            .to_string(),
+                    ),
+                    entries: vec![],
+                });
+            }
+            return Err(e);
+        }
+
+        // `*_worker_time` columns are microseconds; divide by 1000.0 (force
+        // float division) to land in milliseconds. `query_hash` is binary(8)
+        // and casts cleanly to BIGINT for an i64 `queryid`.
+        let sql = "SELECT TOP 200 \
+                SUBSTRING(t.text, (qs.statement_start_offset/2)+1, \
+                  ((CASE qs.statement_end_offset \
+                       WHEN -1 THEN DATALENGTH(t.text) \
+                       ELSE qs.statement_end_offset \
+                    END - qs.statement_start_offset)/2) + 1) AS query, \
+                CAST(qs.query_hash AS BIGINT)                AS queryid, \
+                qs.execution_count                           AS calls, \
+                (qs.total_worker_time / 1000.0)              AS total_exec_time_ms, \
+                ((qs.total_worker_time * 1.0 / NULLIF(qs.execution_count, 0)) / 1000.0) \
+                                                             AS mean_exec_time_ms, \
+                (qs.min_worker_time / 1000.0)                AS min_exec_time_ms, \
+                (qs.max_worker_time / 1000.0)                AS max_exec_time_ms, \
+                qs.total_rows                                AS rows_count, \
+                qs.total_logical_reads                       AS shared_blks_hit, \
+                qs.total_physical_reads                      AS shared_blks_read, \
+                CASE WHEN (qs.total_logical_reads + qs.total_physical_reads) > 0 \
+                     THEN qs.total_logical_reads * 100.0 / \
+                          (qs.total_logical_reads + qs.total_physical_reads) \
+                     ELSE 0 END                              AS cache_hit_ratio \
+            FROM sys.dm_exec_query_stats qs \
+            CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) t \
+            ORDER BY qs.total_worker_time DESC";
+
+        let (cols, rows) = self.run_select(sql).await?;
+
+        // Build a name -> index map so the row-decode loop is column-order
+        // agnostic and survives reordering of the SELECT list.
+        let idx = |name: &str| cols.iter().position(|c| c.eq_ignore_ascii_case(name));
+        let i_query = idx("query");
+        let i_queryid = idx("queryid");
+        let i_calls = idx("calls");
+        let i_total = idx("total_exec_time_ms");
+        let i_mean = idx("mean_exec_time_ms");
+        let i_min = idx("min_exec_time_ms");
+        let i_max = idx("max_exec_time_ms");
+        let i_rows = idx("rows_count");
+        let i_hit = idx("shared_blks_hit");
+        let i_read = idx("shared_blks_read");
+        let i_ratio = idx("cache_hit_ratio");
+
+        let entries = rows
+            .into_iter()
+            .map(|row| QueryStatEntry {
+                query: i_query
+                    .and_then(|i| row.get(i))
+                    .and_then(|v| v.as_str().map(String::from))
+                    .unwrap_or_default(),
+                queryid: i_queryid.and_then(|i| row.get(i)).and_then(json_as_i64),
+                user: String::new(),
+                calls: i_calls
+                    .and_then(|i| row.get(i))
+                    .and_then(json_as_i64)
+                    .unwrap_or(0),
+                total_exec_time_ms: i_total
+                    .and_then(|i| row.get(i))
+                    .and_then(json_as_f64)
+                    .unwrap_or(0.0),
+                mean_exec_time_ms: i_mean
+                    .and_then(|i| row.get(i))
+                    .and_then(json_as_f64)
+                    .unwrap_or(0.0),
+                min_exec_time_ms: i_min
+                    .and_then(|i| row.get(i))
+                    .and_then(json_as_f64)
+                    .unwrap_or(0.0),
+                max_exec_time_ms: i_max
+                    .and_then(|i| row.get(i))
+                    .and_then(json_as_f64)
+                    .unwrap_or(0.0),
+                rows: i_rows
+                    .and_then(|i| row.get(i))
+                    .and_then(json_as_i64)
+                    .unwrap_or(0),
+                shared_blks_hit: i_hit
+                    .and_then(|i| row.get(i))
+                    .and_then(json_as_i64)
+                    .unwrap_or(0),
+                shared_blks_read: i_read
+                    .and_then(|i| row.get(i))
+                    .and_then(json_as_i64)
+                    .unwrap_or(0),
+                cache_hit_ratio: i_ratio
+                    .and_then(|i| row.get(i))
+                    .and_then(json_as_f64)
+                    .unwrap_or(0.0),
+                total_plan_time_ms: None,
+                mean_plan_time_ms: None,
+            })
+            .collect();
+
         Ok(QueryStatsResponse {
-            available: false,
-            message: Some("Query statistics are not wired for SQL Server yet".to_string()),
-            entries: vec![],
+            available: true,
+            kind: QueryStatsKind::Available,
+            message: None,
+            entries,
         })
     }
 

--- a/src-tauri/src/db/mysql_common.rs
+++ b/src-tauri/src/db/mysql_common.rs
@@ -1052,11 +1052,89 @@ pub async fn my_get_server_config(pool: &MySqlPool) -> Result<Vec<ServerConfigEn
         .collect())
 }
 
-pub async fn my_get_query_stats(_pool: &MySqlPool) -> Result<QueryStatsResponse> {
+/// Per-query stats sourced from the always-on (since MySQL 5.6 / MariaDB 10.0)
+/// `performance_schema.events_statements_summary_by_digest` view.
+///
+/// Failure modes the UI cares about (all surface as
+/// `kind = MysqlPerfSchemaDisabled`):
+/// - performance_schema is compiled-out or `performance_schema = OFF`,
+/// - the `*_summary_by_digest` instrument / consumer is disabled,
+/// - the connecting user lacks `SELECT` on `performance_schema`.
+///
+/// Time fields in `performance_schema` are reported in **picoseconds**, so we
+/// divide by `1_000_000_000` to land in milliseconds for the shared
+/// `QueryStatEntry` shape.
+///
+/// MySQL has no shared-buffer / cache-hit equivalent, so `shared_blks_*` and
+/// `cache_hit_ratio` are reported as honest zeros rather than fabricated
+/// numbers. Plan times are `None` for the same reason. The 32-byte hex
+/// `DIGEST` column doesn't fit in `i64`, so `queryid` stays `None` — the
+/// `query` text is the de-facto identifier in the UI.
+pub async fn my_get_query_stats(pool: &MySqlPool) -> Result<QueryStatsResponse> {
+    if let Err(e) =
+        sqlx::query("SELECT 1 FROM performance_schema.events_statements_summary_by_digest LIMIT 1")
+            .fetch_optional(pool)
+            .await
+    {
+        return Ok(QueryStatsResponse {
+            available: false,
+            kind: QueryStatsKind::MysqlPerfSchemaDisabled,
+            message: Some(format!(
+                "Performance Schema digest table is not readable: {e}.\n\n\
+                 To enable query statistics:\n\n\
+                 1. In your my.cnf / my.ini under [mysqld]:\n   performance_schema = ON\n\n\
+                 2. Restart the server.\n\n\
+                 3. Grant the connecting user read access:\n   \
+                 GRANT SELECT ON performance_schema.* TO '<user>'@'<host>';"
+            )),
+            entries: vec![],
+        });
+    }
+
+    // `1000000000.0` (vs `1000000000`) forces float division — without it MySQL
+    // truncates to integer milliseconds and we lose sub-ms precision on cheap
+    // queries.
+    let sql = "SELECT \
+            COALESCE(DIGEST_TEXT, '')                            AS query, \
+            COALESCE(SCHEMA_NAME, '')                            AS user, \
+            CAST(COUNT_STAR AS SIGNED)                           AS calls, \
+            (SUM_TIMER_WAIT / 1000000000.0)                      AS total_exec_time_ms, \
+            (AVG_TIMER_WAIT / 1000000000.0)                      AS mean_exec_time_ms, \
+            (MIN_TIMER_WAIT / 1000000000.0)                      AS min_exec_time_ms, \
+            (MAX_TIMER_WAIT / 1000000000.0)                      AS max_exec_time_ms, \
+            CAST(SUM_ROWS_SENT AS SIGNED)                        AS rows_sent \
+         FROM performance_schema.events_statements_summary_by_digest \
+         WHERE DIGEST_TEXT IS NOT NULL \
+         ORDER BY SUM_TIMER_WAIT DESC \
+         LIMIT 200";
+
+    let rows = sqlx::query(sql).fetch_all(pool).await?;
+
+    let entries = rows
+        .iter()
+        .map(|r| QueryStatEntry {
+            query: r.try_get::<String, _>("query").unwrap_or_default(),
+            queryid: None,
+            user: r.try_get::<String, _>("user").unwrap_or_default(),
+            calls: r.try_get::<i64, _>("calls").unwrap_or(0),
+            total_exec_time_ms: r.try_get::<f64, _>("total_exec_time_ms").unwrap_or(0.0),
+            mean_exec_time_ms: r.try_get::<f64, _>("mean_exec_time_ms").unwrap_or(0.0),
+            min_exec_time_ms: r.try_get::<f64, _>("min_exec_time_ms").unwrap_or(0.0),
+            max_exec_time_ms: r.try_get::<f64, _>("max_exec_time_ms").unwrap_or(0.0),
+            rows: r.try_get::<i64, _>("rows_sent").unwrap_or(0),
+            shared_blks_hit: 0,
+            shared_blks_read: 0,
+            cache_hit_ratio: 0.0,
+            total_plan_time_ms: None,
+            mean_plan_time_ms: None,
+        })
+        .collect();
+
     Ok(QueryStatsResponse {
-        available: false,
-        message: Some("Query statistics are not supported for MySQL. Use performance_schema for similar functionality.".to_string()),
-        entries: vec![],
+        available: true,
+        kind: QueryStatsKind::Available,
+        message: None,
+        entries,
     })
 }
 

--- a/src-tauri/src/db/postgres.rs
+++ b/src-tauri/src/db/postgres.rs
@@ -559,6 +559,7 @@ impl DatabaseDriver for PostgresDriver {
         if ext_check.is_none() {
             return Ok(QueryStatsResponse {
                 available: false,
+                kind: QueryStatsKind::PgStatStatementsMissing,
                 message: Some(
                     "The pg_stat_statements extension is not installed. To enable it:\n\n\
                      1. Add to postgresql.conf:\n   shared_preload_libraries = 'pg_stat_statements'\n\n\
@@ -637,6 +638,7 @@ impl DatabaseDriver for PostgresDriver {
 
         Ok(QueryStatsResponse {
             available: true,
+            kind: QueryStatsKind::Available,
             message: None,
             entries,
         })

--- a/src-tauri/src/db/sqlite.rs
+++ b/src-tauri/src/db/sqlite.rs
@@ -851,6 +851,7 @@ impl DatabaseDriver for SqliteDriver {
     async fn get_query_stats(&self) -> Result<QueryStatsResponse> {
         Ok(QueryStatsResponse {
             available: false,
+            kind: QueryStatsKind::EngineUnsupported,
             message: Some("Query statistics are not supported for SQLite.".to_string()),
             entries: vec![],
         })

--- a/src-tauri/src/db/tidb.rs
+++ b/src-tauri/src/db/tidb.rs
@@ -376,15 +376,22 @@ impl DatabaseDriver for TidbDriver {
         // in milliseconds (forced float division). `DIGEST` is a 64-char hex
         // string and won't fit in an `i64`, so `queryid` stays None and the
         // UI keys off the digest text.
+        //
+        // Rows: TiDB's STATEMENTS_SUMMARY only exposes `AVG_*`/`MAX_*`/
+        // `MIN_*` aggregates for rows — no `SUM_*` column. We multiply
+        // `EXEC_COUNT * AVG_RESULT_ROWS` to recover the total result rows
+        // (analog to MySQL's `SUM_ROWS_SENT`). `AVG_RESULT_ROWS` lands in
+        // TiDB v6.5+; the workspace image is `pingcap/tidb:latest`, so this
+        // is fine on supported versions.
         let sql = "SELECT \
-                COALESCE(DIGEST_TEXT, '')                       AS query, \
-                COALESCE(SCHEMA_NAME, '')                       AS user, \
-                CAST(EXEC_COUNT AS SIGNED)                      AS calls, \
-                (SUM_LATENCY / 1000000.0)                       AS total_exec_time_ms, \
-                (AVG_LATENCY / 1000000.0)                       AS mean_exec_time_ms, \
-                (MIN_LATENCY / 1000000.0)                       AS min_exec_time_ms, \
-                (MAX_LATENCY / 1000000.0)                       AS max_exec_time_ms, \
-                CAST(SUM_AFFECTED_ROWS AS SIGNED)               AS rows_affected \
+                COALESCE(DIGEST_TEXT, '')                            AS query, \
+                COALESCE(SCHEMA_NAME, '')                            AS user, \
+                CAST(EXEC_COUNT AS SIGNED)                           AS calls, \
+                (SUM_LATENCY / 1000000.0)                            AS total_exec_time_ms, \
+                (AVG_LATENCY / 1000000.0)                            AS mean_exec_time_ms, \
+                (MIN_LATENCY / 1000000.0)                            AS min_exec_time_ms, \
+                (MAX_LATENCY / 1000000.0)                            AS max_exec_time_ms, \
+                CAST(EXEC_COUNT * AVG_RESULT_ROWS AS SIGNED)         AS rows_returned \
             FROM INFORMATION_SCHEMA.STATEMENTS_SUMMARY \
             WHERE DIGEST_TEXT IS NOT NULL \
             ORDER BY SUM_LATENCY DESC \
@@ -403,7 +410,7 @@ impl DatabaseDriver for TidbDriver {
                 mean_exec_time_ms: r.try_get::<f64, _>("mean_exec_time_ms").unwrap_or(0.0),
                 min_exec_time_ms: r.try_get::<f64, _>("min_exec_time_ms").unwrap_or(0.0),
                 max_exec_time_ms: r.try_get::<f64, _>("max_exec_time_ms").unwrap_or(0.0),
-                rows: r.try_get::<i64, _>("rows_affected").unwrap_or(0),
+                rows: r.try_get::<i64, _>("rows_returned").unwrap_or(0),
                 shared_blks_hit: 0,
                 shared_blks_read: 0,
                 cache_hit_ratio: 0.0,

--- a/src-tauri/src/db/tidb.rs
+++ b/src-tauri/src/db/tidb.rs
@@ -338,10 +338,79 @@ impl DatabaseDriver for TidbDriver {
     }
 
     async fn get_query_stats(&self) -> Result<QueryStatsResponse> {
+        // TiDB exposes per-query digests via `INFORMATION_SCHEMA.STATEMENTS_SUMMARY`,
+        // gated on `tidb_enable_stmt_summary` (ON by default in 4.0+ but
+        // operators sometimes flip it off to save memory).
+        let enabled: Option<String> = sqlx::query_scalar("SELECT @@tidb_enable_stmt_summary")
+            .fetch_optional(&self.pool)
+            .await?;
+        let on = enabled
+            .as_deref()
+            .map(|s| {
+                let t = s.trim();
+                t == "1" || t.eq_ignore_ascii_case("ON")
+            })
+            .unwrap_or(false);
+        if !on {
+            return Ok(QueryStatsResponse {
+                available: false,
+                kind: QueryStatsKind::TidbStmtSummaryDisabled,
+                message: Some(
+                    "Statement summary is disabled. To enable query statistics:\n\n\
+                     SET GLOBAL tidb_enable_stmt_summary = ON;\n\n\
+                     Then re-run the queries you want to inspect — TiDB only \
+                     records statements after the variable flips on."
+                        .to_string(),
+                ),
+                entries: vec![],
+            });
+        }
+
+        // `*_LATENCY` columns are nanoseconds; divide by 1_000_000.0 to land
+        // in milliseconds (forced float division). `DIGEST` is a 64-char hex
+        // string and won't fit in an `i64`, so `queryid` stays None and the
+        // UI keys off the digest text.
+        let sql = "SELECT \
+                COALESCE(DIGEST_TEXT, '')                       AS query, \
+                COALESCE(SCHEMA_NAME, '')                       AS user, \
+                CAST(EXEC_COUNT AS SIGNED)                      AS calls, \
+                (SUM_LATENCY / 1000000.0)                       AS total_exec_time_ms, \
+                (AVG_LATENCY / 1000000.0)                       AS mean_exec_time_ms, \
+                (MIN_LATENCY / 1000000.0)                       AS min_exec_time_ms, \
+                (MAX_LATENCY / 1000000.0)                       AS max_exec_time_ms, \
+                CAST(SUM_AFFECTED_ROWS AS SIGNED)               AS rows_affected \
+            FROM INFORMATION_SCHEMA.STATEMENTS_SUMMARY \
+            WHERE DIGEST_TEXT IS NOT NULL \
+            ORDER BY SUM_LATENCY DESC \
+            LIMIT 200";
+
+        let rows = sqlx::query(sql).fetch_all(&self.pool).await?;
+
+        let entries = rows
+            .iter()
+            .map(|r| QueryStatEntry {
+                query: r.try_get::<String, _>("query").unwrap_or_default(),
+                queryid: None,
+                user: r.try_get::<String, _>("user").unwrap_or_default(),
+                calls: r.try_get::<i64, _>("calls").unwrap_or(0),
+                total_exec_time_ms: r.try_get::<f64, _>("total_exec_time_ms").unwrap_or(0.0),
+                mean_exec_time_ms: r.try_get::<f64, _>("mean_exec_time_ms").unwrap_or(0.0),
+                min_exec_time_ms: r.try_get::<f64, _>("min_exec_time_ms").unwrap_or(0.0),
+                max_exec_time_ms: r.try_get::<f64, _>("max_exec_time_ms").unwrap_or(0.0),
+                rows: r.try_get::<i64, _>("rows_affected").unwrap_or(0),
+                shared_blks_hit: 0,
+                shared_blks_read: 0,
+                cache_hit_ratio: 0.0,
+                total_plan_time_ms: None,
+                mean_plan_time_ms: None,
+            })
+            .collect();
+
         Ok(QueryStatsResponse {
-            available: false,
-            message: Some("Query statistics are not available in TiDB. Use the TiDB Dashboard for query insights.".to_string()),
-            entries: vec![],
+            available: true,
+            kind: QueryStatsKind::Available,
+            message: None,
+            entries,
         })
     }
 }

--- a/src-tauri/src/db/tidb.rs
+++ b/src-tauri/src/db/tidb.rs
@@ -341,9 +341,15 @@ impl DatabaseDriver for TidbDriver {
         // TiDB exposes per-query digests via `INFORMATION_SCHEMA.STATEMENTS_SUMMARY`,
         // gated on `tidb_enable_stmt_summary` (ON by default in 4.0+ but
         // operators sometimes flip it off to save memory).
-        let enabled: Option<String> = sqlx::query_scalar("SELECT @@tidb_enable_stmt_summary")
-            .fetch_optional(&self.pool)
-            .await?;
+        //
+        // The session variable comes back as BIGINT (0/1), not a string —
+        // forcing a CAST to CHAR sidesteps both the BIGINT-decode surprise
+        // we tripped on in CI and any future TiDB build that flips the
+        // representation back to "ON"/"OFF".
+        let enabled: Option<String> =
+            sqlx::query_scalar("SELECT CAST(@@tidb_enable_stmt_summary AS CHAR)")
+                .fetch_optional(&self.pool)
+                .await?;
         let on = enabled
             .as_deref()
             .map(|s| {

--- a/src-tauri/src/models/types.rs
+++ b/src-tauri/src/models/types.rs
@@ -428,9 +428,24 @@ pub struct QueryStatEntry {
     pub mean_plan_time_ms: Option<f64>,
 }
 
+/// Reason-keyed enum the frontend uses to pick the right "unavailable" copy
+/// and CTA without sniffing `message` strings. New variants must be added in
+/// lock-step with `src/types/queryStats.ts` (the wire format is snake_case).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryStatsKind {
+    Available,
+    PgStatStatementsMissing,
+    MysqlPerfSchemaDisabled,
+    MssqlMissingViewServerState,
+    TidbStmtSummaryDisabled,
+    EngineUnsupported,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryStatsResponse {
     pub available: bool,
+    pub kind: QueryStatsKind,
     pub message: Option<String>,
     pub entries: Vec<QueryStatEntry>,
 }
@@ -811,11 +826,41 @@ mod tests {
 
     #[test]
     fn query_stats_response_unavailable() {
-        let json = r#"{"available": false, "message": "Extension not installed", "entries": []}"#;
+        let json = r#"{"available": false, "kind": "pg_stat_statements_missing", "message": "Extension not installed", "entries": []}"#;
         let resp: QueryStatsResponse = serde_json::from_str(json).unwrap();
         assert!(!resp.available);
+        assert_eq!(resp.kind, QueryStatsKind::PgStatStatementsMissing);
         assert_eq!(resp.message.unwrap(), "Extension not installed");
         assert!(resp.entries.is_empty());
+    }
+
+    #[test]
+    fn query_stats_kind_wire_format_is_snake_case() {
+        // The TS type union must match the Rust enum byte-for-byte. If you
+        // add a variant on either side, this test forces the contract check.
+        let cases = [
+            (QueryStatsKind::Available, "\"available\""),
+            (
+                QueryStatsKind::PgStatStatementsMissing,
+                "\"pg_stat_statements_missing\"",
+            ),
+            (
+                QueryStatsKind::MysqlPerfSchemaDisabled,
+                "\"mysql_perf_schema_disabled\"",
+            ),
+            (
+                QueryStatsKind::MssqlMissingViewServerState,
+                "\"mssql_missing_view_server_state\"",
+            ),
+            (
+                QueryStatsKind::TidbStmtSummaryDisabled,
+                "\"tidb_stmt_summary_disabled\"",
+            ),
+            (QueryStatsKind::EngineUnsupported, "\"engine_unsupported\""),
+        ];
+        for (k, expected) in cases {
+            assert_eq!(serde_json::to_string(&k).unwrap(), expected);
+        }
     }
 
     #[test]
@@ -989,6 +1034,7 @@ mod tests {
     fn query_stats_response_with_entries() {
         let resp = QueryStatsResponse {
             available: true,
+            kind: QueryStatsKind::Available,
             message: None,
             entries: vec![QueryStatEntry {
                 query: "SELECT 1".into(),

--- a/src-tauri/tests/mariadb_integration.rs
+++ b/src-tauri/tests/mariadb_integration.rs
@@ -1316,13 +1316,6 @@ async fn mariadb_get_server_config() {
 }
 
 #[tokio::test]
-async fn mariadb_get_query_stats() {
-    let (driver, _db) = mariadb_driver!();
-    let qs = driver.get_query_stats().await.unwrap();
-    assert!(!qs.available);
-}
-
-#[tokio::test]
 async fn mariadb_list_roles() {
     let (driver, _db) = mariadb_driver!();
     let roles = driver.list_roles().await.unwrap();

--- a/src-tauri/tests/mariadb_integration.rs
+++ b/src-tauri/tests/mariadb_integration.rs
@@ -1455,3 +1455,22 @@ async fn validate_query_empty_string() {
     let result = driver.validate_query(&db, "").await.unwrap();
     assert!(result.is_some(), "empty SQL should be an error");
 }
+
+#[tokio::test]
+async fn mariadb_get_query_stats_ok_or_perf_schema_message() {
+    let (driver, _db) = mariadb_driver!();
+    let res = driver.get_query_stats().await;
+    assert!(res.is_ok(), "get_query_stats returned: {:?}", res.err());
+    let qs = res.unwrap();
+    if qs.available {
+        assert_eq!(qs.kind, QueryStatsKind::Available);
+        assert!(qs.message.is_none());
+    } else {
+        assert_eq!(qs.kind, QueryStatsKind::MysqlPerfSchemaDisabled);
+        let msg = qs.message.as_deref().unwrap_or("");
+        assert!(
+            msg.contains("performance_schema") || msg.contains("Performance Schema"),
+            "unexpected unavailable message: {msg}"
+        );
+    }
+}

--- a/src-tauri/tests/mssql_integration.rs
+++ b/src-tauri/tests/mssql_integration.rs
@@ -1663,18 +1663,6 @@ async fn mssql_get_server_config_ok() {
 }
 
 // ===========================================================================
-// get_query_stats (returns unavailable for SQL Server)
-// ===========================================================================
-
-#[tokio::test]
-async fn mssql_get_query_stats_ok() {
-    let (driver, _db) = mssql_driver!();
-    let qs = driver.get_query_stats().await.unwrap();
-    assert!(!qs.available);
-    assert!(qs.message.is_some());
-}
-
-// ===========================================================================
 // cancel_query: invalid session id
 // ===========================================================================
 

--- a/src-tauri/tests/mssql_integration.rs
+++ b/src-tauri/tests/mssql_integration.rs
@@ -1886,3 +1886,22 @@ async fn validate_query_empty_string() {
     let result = driver.validate_query(&db, "").await.unwrap();
     assert!(result.is_some(), "empty SQL should be an error");
 }
+
+#[tokio::test]
+async fn mssql_get_query_stats_ok_or_view_server_state_message() {
+    let (driver, _db) = mssql_driver!();
+    let res = driver.get_query_stats().await;
+    assert!(res.is_ok(), "get_query_stats returned: {:?}", res.err());
+    let qs = res.unwrap();
+    if qs.available {
+        assert_eq!(qs.kind, QueryStatsKind::Available);
+        assert!(qs.message.is_none());
+    } else {
+        assert_eq!(qs.kind, QueryStatsKind::MssqlMissingViewServerState);
+        let msg = qs.message.as_deref().unwrap_or("");
+        assert!(
+            msg.to_ascii_lowercase().contains("view server state"),
+            "unexpected unavailable message: {msg}"
+        );
+    }
+}

--- a/src-tauri/tests/mysql_integration.rs
+++ b/src-tauri/tests/mysql_integration.rs
@@ -1888,3 +1888,22 @@ async fn million_row_paginate() {
 
     mysql_drop_table_silent(&driver, &db, &table).await;
 }
+
+#[tokio::test]
+async fn my_get_query_stats_ok_or_perf_schema_message() {
+    let (driver, _db) = mysql_driver!();
+    let res = driver.get_query_stats().await;
+    assert!(res.is_ok(), "get_query_stats returned: {:?}", res.err());
+    let qs = res.unwrap();
+    if qs.available {
+        assert_eq!(qs.kind, QueryStatsKind::Available);
+        assert!(qs.message.is_none());
+    } else {
+        assert_eq!(qs.kind, QueryStatsKind::MysqlPerfSchemaDisabled);
+        let msg = qs.message.as_deref().unwrap_or("");
+        assert!(
+            msg.contains("performance_schema") || msg.contains("Performance Schema"),
+            "unexpected unavailable message: {msg}"
+        );
+    }
+}

--- a/src-tauri/tests/mysql_integration.rs
+++ b/src-tauri/tests/mysql_integration.rs
@@ -1355,14 +1355,6 @@ async fn mysql_get_server_config() {
 }
 
 #[tokio::test]
-async fn mysql_get_query_stats() {
-    let (driver, _db) = mysql_driver!();
-    let qs = driver.get_query_stats().await.unwrap();
-    assert!(!qs.available);
-    assert!(qs.message.is_some());
-}
-
-#[tokio::test]
 async fn mysql_list_roles() {
     let (driver, _db) = mysql_driver!();
     let roles = driver.list_roles().await.unwrap();

--- a/src-tauri/tests/postgres_integration.rs
+++ b/src-tauri/tests/postgres_integration.rs
@@ -1849,11 +1849,16 @@ async fn pg_get_server_config_ok() {
 
 #[tokio::test]
 async fn pg_get_query_stats_ok_or_extension_message() {
+    use tablio_lib::models::QueryStatsKind;
     let driver = pg_driver!();
     let res = driver.get_query_stats().await;
     assert!(res.is_ok());
     let qs = res.unwrap();
-    if !qs.available {
+    if qs.available {
+        assert_eq!(qs.kind, QueryStatsKind::Available);
+        assert!(qs.message.is_none());
+    } else {
+        assert_eq!(qs.kind, QueryStatsKind::PgStatStatementsMissing);
         let msg = qs.message.as_deref().unwrap_or("");
         assert!(
             msg.contains("pg_stat_statements")

--- a/src-tauri/tests/tidb_integration.rs
+++ b/src-tauri/tests/tidb_integration.rs
@@ -1356,3 +1356,22 @@ async fn validate_query_empty_string() {
     let result = driver.validate_query(&db, "").await.unwrap();
     assert!(result.is_some(), "empty SQL should be an error");
 }
+
+#[tokio::test]
+async fn tidb_get_query_stats_ok_or_stmt_summary_message() {
+    let (driver, _db) = tidb_driver!();
+    let res = driver.get_query_stats().await;
+    assert!(res.is_ok(), "get_query_stats returned: {:?}", res.err());
+    let qs = res.unwrap();
+    if qs.available {
+        assert_eq!(qs.kind, QueryStatsKind::Available);
+        assert!(qs.message.is_none());
+    } else {
+        assert_eq!(qs.kind, QueryStatsKind::TidbStmtSummaryDisabled);
+        let msg = qs.message.as_deref().unwrap_or("");
+        assert!(
+            msg.contains("tidb_enable_stmt_summary") || msg.contains("Statement summary"),
+            "unexpected unavailable message: {msg}"
+        );
+    }
+}

--- a/src-tauri/tests/tidb_integration.rs
+++ b/src-tauri/tests/tidb_integration.rs
@@ -1217,13 +1217,6 @@ async fn tidb_get_server_config() {
 }
 
 #[tokio::test]
-async fn tidb_get_query_stats() {
-    let (driver, _db) = tidb_driver!();
-    let qs = driver.get_query_stats().await.unwrap();
-    assert!(!qs.available);
-}
-
-#[tokio::test]
 async fn tidb_list_roles() {
     let (driver, _db) = tidb_driver!();
     let roles = driver.list_roles().await;

--- a/src/components/QueryStats/QueryStats.tsx
+++ b/src/components/QueryStats/QueryStats.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useCallback, useMemo } from "react";
-import { api, QueryStatEntry, QueryStatsResponse } from "../../lib/tauri";
+import { useEffect, useState, useCallback, useMemo, type ReactNode } from "react";
+import { api, QueryStatEntry, QueryStatsKind, QueryStatsResponse } from "../../lib/tauri";
 import { usePolling } from "../../hooks/usePolling";
 import { formatQueryDuration as formatDuration, cacheHitClass, speedClass } from "../../lib/dashboardUtils";
 import {
@@ -158,62 +158,19 @@ export function QueryStats({ connectionId }: Props) {
 
   if (data && !data.available) {
     return (
-      <div className="qs-dashboard">
-        <div className="qs-toolbar">
-          <span className="qs-title">Query Statistics</span>
-        </div>
-        <div className="qs-unavailable">
-          <div className="qs-unavailable-icon">
-            <Database size={36} />
-          </div>
-          <h3>pg_stat_statements not enabled</h3>
-          <p>This extension is required to track query performance statistics.</p>
-
-          <div className="qs-setup-card">
-            <div className="qs-setup-steps">
-              <div className="qs-step">
-                <span className="qs-step-num">1</span>
-                <div>
-                  <strong>Add to postgresql.conf</strong>
-                  <code>shared_preload_libraries = 'pg_stat_statements'</code>
-                </div>
-              </div>
-              <div className="qs-step">
-                <span className="qs-step-num">2</span>
-                <div>
-                  <strong>Restart PostgreSQL</strong>
-                  <code>sudo systemctl restart postgresql</code>
-                </div>
-              </div>
-              <div className="qs-step">
-                <span className="qs-step-num">3</span>
-                <div>
-                  <strong>Create the extension</strong>
-                  <code>CREATE EXTENSION pg_stat_statements;</code>
-                </div>
-              </div>
-            </div>
-
-            <div className="qs-setup-actions">
-              <button
-                className="btn-primary qs-enable-btn"
-                onClick={handleEnableExtension}
-                disabled={enabling}
-              >
-                {enabling ? <><Loader2 size={14} className="spin" /> Enabling...</> : "Enable Extension"}
-              </button>
-              <button className="btn-ghost" disabled={checking} onClick={async () => { setChecking(true); await fetchStats(); setChecking(false); }}>
-                {checking ? <Loader2 size={14} className="spin" /> : <RefreshCw size={14} />} {checking ? "Checking..." : "Check"}
-              </button>
-            </div>
-            {enableError && (
-              <div className="qs-enable-error">
-                <AlertTriangle size={13} /> {enableError}
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <UnavailablePanel
+        kind={data.kind}
+        message={data.message}
+        enabling={enabling}
+        enableError={enableError}
+        checking={checking}
+        onEnableExtension={handleEnableExtension}
+        onCheck={async () => {
+          setChecking(true);
+          await fetchStats();
+          setChecking(false);
+        }}
+      />
     );
   }
 
@@ -281,7 +238,7 @@ export function QueryStats({ connectionId }: Props) {
               <th style={{ width: 32 }}></th>
               <th style={{ maxWidth: 420 }}>Query</th>
               <th style={{ width: 90 }} title="Total number of times this query has been executed">Calls</th>
-              <th style={{ width: 90 }} title="PostgreSQL role that executed the query">User</th>
+              <th style={{ width: 90 }} title="Database role or schema that executed the query">User</th>
               <th style={{ width: 110 }} title="Cumulative execution time across all calls">Total Time</th>
               <th style={{ width: 100 }} title="Average execution time per call">Mean Time</th>
               <th style={{ width: 100 }} title="Longest single execution of this query">Max Time</th>
@@ -403,8 +360,161 @@ function QueryRow({
   );
 }
 
+/**
+ * Engine-aware "Query Statistics not available" panel. The PostgreSQL branch
+ * keeps the original copy + the in-app "Enable Extension" CTA verbatim;
+ * other engines render their own copy and (where applicable) a code snippet
+ * the operator can paste, since auto-enabling them requires server config
+ * changes that aren't safe to fire from the client.
+ */
+function UnavailablePanel({
+  kind,
+  message,
+  enabling,
+  enableError,
+  checking,
+  onEnableExtension,
+  onCheck,
+}: {
+  kind: QueryStatsKind;
+  message: string | null;
+  enabling: boolean;
+  enableError: string | null;
+  checking: boolean;
+  onEnableExtension: () => void;
+  onCheck: () => void;
+}) {
+  const refreshButton = (
+    <button className="btn-ghost" disabled={checking} onClick={onCheck}>
+      {checking ? <Loader2 size={14} className="spin" /> : <RefreshCw size={14} />}{" "}
+      {checking ? "Checking..." : "Check"}
+    </button>
+  );
+
+  let title = "Query statistics not available";
+  let subtitle = message ?? "This database engine does not expose per-query statistics.";
+  let steps: { label: string; code: string }[] | null = null;
+  let primaryAction: ReactNode = null;
+
+  switch (kind) {
+    case "pg_stat_statements_missing":
+      title = "pg_stat_statements not enabled";
+      subtitle = "This extension is required to track query performance statistics.";
+      steps = [
+        { label: "Add to postgresql.conf", code: "shared_preload_libraries = 'pg_stat_statements'" },
+        { label: "Restart PostgreSQL", code: "sudo systemctl restart postgresql" },
+        { label: "Create the extension", code: "CREATE EXTENSION pg_stat_statements;" },
+      ];
+      primaryAction = (
+        <button
+          className="btn-primary qs-enable-btn"
+          onClick={onEnableExtension}
+          disabled={enabling}
+        >
+          {enabling ? (
+            <>
+              <Loader2 size={14} className="spin" /> Enabling...
+            </>
+          ) : (
+            "Enable Extension"
+          )}
+        </button>
+      );
+      break;
+    case "mysql_perf_schema_disabled":
+      title = "Performance Schema digest not readable";
+      subtitle =
+        "MySQL/MariaDB exposes per-query stats via performance_schema, but it's either disabled or the connecting user can't read it.";
+      steps = [
+        { label: "Enable in my.cnf under [mysqld]", code: "performance_schema = ON" },
+        { label: "Restart the server", code: "sudo systemctl restart mysqld" },
+        {
+          label: "Grant read access to your user",
+          code: "GRANT SELECT ON performance_schema.* TO '<user>'@'<host>';",
+        },
+      ];
+      break;
+    case "mssql_missing_view_server_state":
+      title = "Missing VIEW SERVER STATE permission";
+      subtitle =
+        "SQL Server's sys.dm_exec_query_stats DMV needs server-level read access. Auto-granting it from the client isn't safe — ask your DBA.";
+      steps = [
+        {
+          label: "Have a sysadmin run",
+          code: "GRANT VIEW SERVER STATE TO [<your_login>];",
+        },
+      ];
+      break;
+    case "tidb_stmt_summary_disabled":
+      title = "Statement summary disabled";
+      subtitle =
+        "TiDB only records per-query digests when tidb_enable_stmt_summary is ON. Flip it on, then re-run the queries you want to inspect.";
+      steps = [
+        { label: "Enable globally", code: "SET GLOBAL tidb_enable_stmt_summary = ON;" },
+      ];
+      break;
+    case "engine_unsupported":
+      title = "Query statistics not supported";
+      subtitle =
+        message ?? "This database engine does not expose a per-query stats catalog.";
+      steps = null;
+      break;
+    case "available":
+      // Defensive: shouldn't reach here when available=false, but render
+      // something coherent if a backend bug ever does.
+      break;
+  }
+
+  return (
+    <div className="qs-dashboard">
+      <div className="qs-toolbar">
+        <span className="qs-title">Query Statistics</span>
+      </div>
+      <div className="qs-unavailable">
+        <div className="qs-unavailable-icon">
+          <Database size={36} />
+        </div>
+        <h3>{title}</h3>
+        <p>{subtitle}</p>
+
+        <div className="qs-setup-card">
+          {steps && steps.length > 0 && (
+            <div className="qs-setup-steps">
+              {steps.map((s, i) => (
+                <div className="qs-step" key={i}>
+                  <span className="qs-step-num">{i + 1}</span>
+                  <div>
+                    <strong>{s.label}</strong>
+                    <code>{s.code}</code>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="qs-setup-actions">
+            {primaryAction}
+            {refreshButton}
+          </div>
+          {enableError && (
+            <div className="qs-enable-error">
+              <AlertTriangle size={13} /> {enableError}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function QueryDetail({ entry }: { entry: QueryStatEntry }) {
   const rowsPerCall = entry.calls > 0 ? entry.rows / entry.calls : 0;
+  // Engines that don't track shared-buffer counters (MySQL, MariaDB, TiDB)
+  // report honest zeros from the backend. Hide the cache panel in that case
+  // so the detail view doesn't suggest fake hit ratios.
+  const hasCacheData =
+    entry.shared_blks_hit + entry.shared_blks_read > 0 ||
+    entry.cache_hit_ratio > 0;
 
   return (
     <div className="qs-detail">
@@ -445,27 +555,29 @@ function QueryDetail({ entry }: { entry: QueryStatEntry }) {
             <dd>{rowsPerCall.toFixed(1)}</dd>
           </dl>
         </div>
-        <div className="qs-detail-section">
-          <h4>Cache</h4>
-          <dl>
-            <dt>Shared blocks hit</dt>
-            <dd>{formatNumber(entry.shared_blks_hit)}</dd>
-            <dt>Shared blocks read</dt>
-            <dd>{formatNumber(entry.shared_blks_read)}</dd>
-            <dt>Hit ratio</dt>
-            <dd>
-              <div className={`qs-cache-bar qs-cache-bar-lg ${cacheHitClass(entry.cache_hit_ratio)}`}>
-                <div
-                  className="qs-cache-fill"
-                  style={{ width: `${Math.min(entry.cache_hit_ratio, 100)}%` }}
-                />
-                <span className="qs-cache-label">
-                  {entry.cache_hit_ratio.toFixed(2)}%
-                </span>
-              </div>
-            </dd>
-          </dl>
-        </div>
+        {hasCacheData && (
+          <div className="qs-detail-section">
+            <h4>Cache</h4>
+            <dl>
+              <dt>Shared blocks hit</dt>
+              <dd>{formatNumber(entry.shared_blks_hit)}</dd>
+              <dt>Shared blocks read</dt>
+              <dd>{formatNumber(entry.shared_blks_read)}</dd>
+              <dt>Hit ratio</dt>
+              <dd>
+                <div className={`qs-cache-bar qs-cache-bar-lg ${cacheHitClass(entry.cache_hit_ratio)}`}>
+                  <div
+                    className="qs-cache-fill"
+                    style={{ width: `${Math.min(entry.cache_hit_ratio, 100)}%` }}
+                  />
+                  <span className="qs-cache-label">
+                    {entry.cache_hit_ratio.toFixed(2)}%
+                  </span>
+                </div>
+              </dd>
+            </dl>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -126,7 +126,12 @@ async function mockInvoke<T>(cmd: string, args?: Record<string, unknown>): Promi
     case "get_server_config":
       return [] as T;
     case "get_query_stats":
-      return { available: false, message: "Mock mode", entries: [] } as T;
+      return {
+        available: false,
+        kind: "pg_stat_statements_missing",
+        message: "Mock mode",
+        entries: [],
+      } as T;
     case "get_app_resource_usage":
       return { memory_mb: 64.5, cpu_percent: 2.3 } as T;
     case "list_known_hosts":

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -436,8 +436,22 @@ export interface QueryStatEntry {
   mean_plan_time_ms: number | null;
 }
 
+/**
+ * Reason-keyed enum that lets the QueryStats UI pick the right "unavailable"
+ * copy and CTA without sniffing message strings. Wire format is snake_case
+ * to match the Rust `QueryStatsKind` enum (`#[serde(rename_all = "snake_case")]`).
+ */
+export type QueryStatsKind =
+  | "available"
+  | "pg_stat_statements_missing"
+  | "mysql_perf_schema_disabled"
+  | "mssql_missing_view_server_state"
+  | "tidb_stmt_summary_disabled"
+  | "engine_unsupported";
+
 export interface QueryStatsResponse {
   available: boolean;
+  kind: QueryStatsKind;
   message: string | null;
   entries: QueryStatEntry[];
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,11 @@ export default defineConfig(async () => ({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
-    coverage: { provider: "v8", reporter: ["text", "json", "html"], exclude: ["node_modules/", "src/test/"] },
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "text-summary", "json", "json-summary", "html", "lcov"],
+      exclude: ["node_modules/", "src/test/", "**/*.d.ts", "**/*.config.*"],
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #52.

## Summary

- **Backend**: real `get_query_stats` for MySQL/MariaDB (shared helper in `mysql_common`), SQL Server (`sys.dm_exec_query_stats` + `sys.dm_exec_sql_text`), and TiDB (`INFORMATION_SCHEMA.STATEMENTS_SUMMARY`). Each driver detects its own failure mode (Performance Schema disabled, missing VIEW SERVER STATE, stmt_summary off) and surfaces it as a structured `QueryStatsKind` rather than a free-form message. Postgres + the unsupported engines (CockroachDB, SQLite, Cassandra) are tagged with the matching variants.
- **UI**: `QueryStats.tsx` switches on `kind` to render engine-specific copy + CTAs in a new `<UnavailablePanel>` helper. Postgres copy + the auto-fire \"Enable Extension\" button are preserved verbatim. User-column tooltip is now engine-agnostic. Cache detail block hides itself when shared-block counters are all zero (MySQL/TiDB).
- **CI**:
  - **MSSQL** added to PR CI (was release-only) so the new test runs on every PR.
  - **Coverage** jobs added: vitest v8 for the frontend, cargo-llvm-cov for the backend (lib + sqlite). Both render summaries to \$GITHUB_STEP_SUMMARY and upload artifacts (14-day retention). Coverage is a signal, not a gate.

Time-unit normalization happens at the driver edge — picoseconds (MySQL `*_TIMER_WAIT`), microseconds (MSSQL `*_worker_time`), nanoseconds (TiDB `*_LATENCY`) — so the shared `QueryStatEntry` shape and the frontend stay engine-agnostic.

## Reason-keyed taxonomy

| kind | Engine | When |
| --- | --- | --- |
| `available` | all | driver returned real entries |
| `pg_stat_statements_missing` | PG | extension not installed |
| `mysql_perf_schema_disabled` | MySQL/MariaDB | digest table not readable |
| `mssql_missing_view_server_state` | MSSQL | DMV permission denied |
| `tidb_stmt_summary_disabled` | TiDB | `tidb_enable_stmt_summary = OFF` |
| `engine_unsupported` | CRDB / SQLite / Cassandra | no catalog equivalent |

Pinned by `query_stats_kind_wire_format_is_snake_case` so Rust ↔ TS strings can't drift.

## Test plan

- [x] \`cargo build --tests\`, \`cargo clippy --lib -- -D warnings\`, \`cargo fmt --check\` clean
- [x] \`cargo test --lib\` 344/344 pass (incl. new wire-format test)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` 599/599 pass
- [x] \`npm run test -- --coverage\` produces lcov + html locally
- [ ] CI: per-engine integration jobs (postgres, mysql, mariadb, mssql, tidb) exercise the new \`*_get_query_stats_*\` tests
- [ ] CI: \`coverage-backend\` and updated \`test-frontend\` upload artifacts and render summaries
- [ ] Manual: connect to PG / MySQL / MSSQL / TiDB and visually verify both branches (available + each unavailable variant) — left for reviewer / post-merge smoke

## Out of scope

- CockroachDB \`crdb_internal.statement_statistics\` — issue defers to a design call.
- Aggregating coverage across the per-engine DB jobs into a single merged report — follow-up.