### PR TITLE
fix(ci): drop invalid `queries: default` from CodeQL init

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,10 +65,13 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          # `default` query suite matches what default setup was using;
-          # `security-extended` is also available but produces noisier
-          # findings that we don't currently triage.
-          queries: default
+          # No `queries:` input — that's the right way to ask for the
+          # action's standard suite per language (which is what default
+          # setup was running). The literal string `default` is not a
+          # valid pack reference in codeql-action v4 and made every run
+          # fail with: "A fatal error occurred: Query pack `default`
+          # cannot be found." If we ever want broader coverage, set
+          # `queries: security-extended` here.
 
       - uses: github/codeql-action/autobuild@v4
 


### PR DESCRIPTION
## Summary

Every CodeQL run on master since #86 merged has failed with:

\`\`\`
A fatal error occurred: Query pack \`default\` cannot be found.
\`\`\`

\`github/codeql-action/init@v4\` resolves \`queries:\` as a pack reference (e.g. \`security-extended\`, \`security-and-quality\`, or \`<scope>/<name>\`) or a filesystem path. The literal word \`default\` matches nothing and aborts init before any analysis runs.

Omitting the input runs the action's built-in query suite per language, which is the same set GitHub's default setup was running before.

## Test plan

- [ ] CI on this PR: only the file-touched-paths jobs and CodeQL trigger; CodeQL was push-to-master scoped after #86, so I'll trigger it via \`workflow_dispatch\` post-merge to confirm green.

## Side note (already fixed by separate API call)

The two CodeQL entries that show up under Actions → Workflows are:

1. \`.github/workflows/codeql.yml\` — this file (advanced setup).
2. A stale \`dynamic/github-code-scanning/codeql\` registration GitHub keeps in the list after default setup is disabled.

Default setup is currently \`state: not-configured\` (verified via \`gh api /repos/.../code-scanning/default-setup\`); only \#1 actually triggers runs.