### PR TITLE
fix: ensure sidebar scroll reaches last item

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -392,6 +392,7 @@ button {
 .sidebar-content {
   flex: 1;
   overflow-y: auto;
+  padding-bottom: 16px;
 }
 
 .empty-state {


### PR DESCRIPTION
Fixes an issue where the last item in the sidebar was not fully reachable when scrolling.

- Added padding-bottom to the sidebar scroll container
- Ensures last item is fully visible and clickable
- Tested at different zoom levels (80%, 100%, 125%)

Closes #58