### PR TITLE
feat(xlsx): Excel import + export end-to-end (closes #69, closes #70)

### DIFF
--- a/e2e/export.spec.ts
+++ b/e2e/export.spec.ts
@@ -17,12 +17,13 @@ test.describe("Export menu", () => {
     await expect(page.locator(".export-menu-dropdown")).toBeVisible();
   });
 
-  test("dropdown shows CSV, JSON, SQL options", async ({ page }) => {
+  test("dropdown shows CSV, JSON, SQL, Excel options", async ({ page }) => {
     await page.locator(".export-menu-wrapper .btn-ghost").click();
     const dropdown = page.locator(".export-menu-dropdown");
     await expect(dropdown.locator("button", { hasText: "Export as CSV" })).toBeVisible();
     await expect(dropdown.locator("button", { hasText: "Export as JSON" })).toBeVisible();
     await expect(dropdown.locator("button", { hasText: "Export as SQL" })).toBeVisible();
+    await expect(dropdown.locator("button", { hasText: "Export as Excel" })).toBeVisible();
   });
 
   test("clicking outside closes dropdown", async ({ page }) => {

--- a/e2e/import.spec.ts
+++ b/e2e/import.spec.ts
@@ -9,7 +9,7 @@ test.describe("Import dialog", () => {
 
   test("opens via context menu and shows dialog", async ({ page }) => {
     await expect(page.locator(".import-dialog")).toBeVisible();
-    await expect(page.locator(".dialog-header h2")).toContainText("Import CSV");
+    await expect(page.locator(".dialog-header h2")).toContainText("Import Data");
   });
 
   test("shows target table name", async ({ page }) => {
@@ -17,9 +17,17 @@ test.describe("Import dialog", () => {
     await expect(page.locator(".import-target-input")).toHaveValue(/users/);
   });
 
-  test("file input is present", async ({ page }) => {
+  test("file input is present and accepts CSV + Excel", async ({ page }) => {
     await expect(page.locator(".import-file-label")).toBeVisible();
-    await expect(page.locator(".import-file-label")).toContainText("Choose a CSV file");
+    await expect(page.locator(".import-file-label")).toContainText(
+      /\.csv.*\.xlsx.*\.xls/,
+    );
+    const accept = await page
+      .locator('#csv-file-input')
+      .getAttribute("accept");
+    expect(accept).toMatch(/\.csv/);
+    expect(accept).toMatch(/\.xlsx/);
+    expect(accept).toMatch(/\.xls(?!x)/);
   });
 
   test("cancel button closes dialog", async ({ page }) => {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -218,6 +218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+dependencies = [
+ "debug_unsafe",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +522,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "calamine"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ae05a4e39297eecf9a994210d27501318c37a9318201f8e11050add82bb6f0"
+dependencies = [
+ "atoi_simd",
+ "byteorder",
+ "chrono",
+ "codepage",
+ "encoding_rs",
+ "fast-float2",
+ "log",
+ "quick-xml 0.39.2",
+ "serde",
+ "zip",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +721,15 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
 
 [[package]]
 name = "combine"
@@ -1114,6 +1150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
 name = "delegate"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1564,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1614,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3778,7 +3827,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -4018,6 +4067,16 @@ version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "encoding_rs",
  "memchr",
 ]
 
@@ -4557,6 +4616,16 @@ dependencies = [
  "serde",
  "serde_json",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "rust_xlsxwriter"
+version = "0.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc4a0f1f7b425669996977016152b2939be9be44d40df252a5051c9c6b3b859"
+dependencies = [
+ "chrono",
+ "zip",
 ]
 
 [[package]]
@@ -5778,12 +5847,14 @@ version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
+ "calamine",
  "chrono",
  "dirs",
  "log",
  "proptest",
  "russh",
  "rust_decimal",
+ "rust_xlsxwriter",
  "scylla",
  "serde",
  "serde_json",
@@ -6573,6 +6644,12 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -7960,7 +8037,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,8 @@ tokio-util = { version = "0.7.18", features = ["compat"] }
 urlencoding = "2.1.3"
 russh = "0.60"
 log = "0.4"
+rust_xlsxwriter = { version = "0.94", features = ["chrono"] }
+calamine = { version = "0.34", features = ["dates"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -37,6 +37,11 @@ pub async fn export_table_data(
             &columns,
             &data.rows,
         ),
+        // xlsx is binary; the text-IPC variant of this command would
+        // require base64 round-tripping. The frontend should call
+        // `export_table_to_file` instead, which writes the bytes
+        // straight to disk.
+        "xlsx" => return Err("xlsx export must use export_table_to_file".to_string()),
         _ => return Err(format!("Unsupported format: {}", request.format)),
     };
 
@@ -68,6 +73,14 @@ pub async fn export_table_to_file(
         .map_err(|e| e.to_string())?;
 
     let columns: Vec<String> = data.columns.iter().map(|c| c.name.clone()).collect();
+
+    if request.format.as_str() == "xlsx" {
+        let bytes = export::to_xlsx(&columns, &data.rows, &request.table)
+            .map_err(|e| format!("xlsx encoding failed: {e}"))?;
+        std::fs::write(&file_path, bytes).map_err(|e| format!("Failed to write file: {}", e))?;
+        return Ok(());
+    }
+
     let content = match request.format.as_str() {
         "csv" => export::to_csv(&columns, &data.rows),
         "json" => export::to_json(&columns, &data.rows),
@@ -96,6 +109,7 @@ pub async fn export_query_result(request: ExportResultRequest) -> Result<String,
         // No schema available from the query-result path -- the caller
         // doesn't know which logical table the rows belong to.
         "sql" => export::to_sql_inserts(None, &table_name, &request.columns, &request.rows),
+        "xlsx" => return Err("xlsx export must use export_query_result_to_file".to_string()),
         _ => return Err(format!("Unsupported format: {}", request.format)),
     };
     Ok(content)
@@ -109,6 +123,14 @@ pub async fn export_query_result_to_file(
     let table_name = request
         .table_name
         .unwrap_or_else(|| "query_result".to_string());
+
+    if request.format.as_str() == "xlsx" {
+        let bytes = export::to_xlsx(&request.columns, &request.rows, &table_name)
+            .map_err(|e| format!("xlsx encoding failed: {e}"))?;
+        std::fs::write(&file_path, bytes).map_err(|e| format!("Failed to write file: {}", e))?;
+        return Ok(());
+    }
+
     let content = match request.format.as_str() {
         "csv" => export::to_csv(&request.columns, &request.rows),
         "json" => export::to_json(&request.columns, &request.rows),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,3 +9,4 @@ pub mod saved_queries;
 pub mod schema;
 pub mod ssh_config;
 pub mod system;
+pub mod xlsx_import;

--- a/src-tauri/src/commands/xlsx_import.rs
+++ b/src-tauri/src/commands/xlsx_import.rs
@@ -1,0 +1,464 @@
+//! Parse `.xlsx` / `.xls` workbooks for the import dialog.
+//!
+//! The flow is two-stage so the dialog can render a sheet picker
+//! cheaply: `parse_xlsx_workbook` returns metadata + a small preview
+//! of the first sheet, and `parse_xlsx_sheet` returns the full row
+//! payload once the user has chosen which sheet to import.
+//!
+//! Cell-type fidelity is the headline win over CSV: numbers stay as
+//! `Value::Number`, booleans as `Value::Bool`, dates as ISO-8601
+//! strings, and empties as `Value::Null`. The existing `import_data`
+//! command (`pg_import_data` and friends) already accepts typed
+//! `serde_json::Value` rows, so XLSX imports get type-faithful inserts
+//! for free.
+
+use calamine::{Data, Reader};
+use serde::Serialize;
+use serde_json::Value;
+use std::io::Cursor;
+
+/// Hard cap on the byte payload accepted from the renderer. Tauri's
+/// IPC bridge happily ferries 100MB+ blobs but holding multiple copies
+/// in memory while parsing the workbook is wasteful, and a malicious
+/// dialog mock could otherwise pin the parser thread.
+const MAX_BYTES: usize = 100 * 1024 * 1024;
+
+const PREVIEW_ROWS: usize = 50;
+
+#[derive(Debug, Serialize)]
+pub struct XlsxWorkbookPreview {
+    pub sheet_names: Vec<String>,
+    pub default_sheet: String,
+    pub sheet: XlsxSheetPreview,
+}
+
+#[derive(Debug, Serialize)]
+pub struct XlsxSheetPreview {
+    pub name: String,
+    pub headers: Vec<String>,
+    pub preview_rows: Vec<Vec<Value>>,
+    pub total_data_rows: usize,
+    pub inferred_types: Vec<&'static str>,
+}
+
+/// Full payload for a single sheet — returned to the dialog after the
+/// user picks which sheet to import. Headers and `inferred_types`
+/// match `XlsxSheetPreview` so the renderer can display the same
+/// type hint badges either way.
+#[derive(Debug, Serialize)]
+pub struct XlsxSheetPayload {
+    pub name: String,
+    pub headers: Vec<String>,
+    pub rows: Vec<Vec<Value>>,
+    pub inferred_types: Vec<&'static str>,
+}
+
+#[tauri::command]
+pub async fn parse_xlsx_workbook(bytes: Vec<u8>) -> Result<XlsxWorkbookPreview, String> {
+    parse_workbook_impl(&bytes).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn parse_xlsx_sheet(
+    bytes: Vec<u8>,
+    sheet_name: String,
+) -> Result<XlsxSheetPayload, String> {
+    parse_sheet_impl(&bytes, &sheet_name).map_err(|e| e.to_string())
+}
+
+pub fn parse_workbook_impl(bytes: &[u8]) -> anyhow::Result<XlsxWorkbookPreview> {
+    if bytes.len() > MAX_BYTES {
+        anyhow::bail!(
+            "File is too large: {} MB (limit is {} MB)",
+            bytes.len() / 1024 / 1024,
+            MAX_BYTES / 1024 / 1024
+        );
+    }
+    let cursor = Cursor::new(bytes.to_vec());
+    let mut wb = calamine::open_workbook_auto_from_rs(cursor)
+        .map_err(|e| anyhow::anyhow!("Could not open workbook: {e}"))?;
+
+    let sheet_names: Vec<String> = wb.sheet_names();
+    if sheet_names.is_empty() {
+        anyhow::bail!("Workbook has no sheets");
+    }
+    let default_sheet = sheet_names[0].clone();
+    let preview = build_sheet_preview(&mut wb, &default_sheet)?;
+
+    Ok(XlsxWorkbookPreview {
+        sheet_names,
+        default_sheet,
+        sheet: preview,
+    })
+}
+
+pub fn parse_sheet_impl(bytes: &[u8], sheet_name: &str) -> anyhow::Result<XlsxSheetPayload> {
+    if bytes.len() > MAX_BYTES {
+        anyhow::bail!(
+            "File is too large: {} MB (limit is {} MB)",
+            bytes.len() / 1024 / 1024,
+            MAX_BYTES / 1024 / 1024
+        );
+    }
+    let cursor = Cursor::new(bytes.to_vec());
+    let mut wb = calamine::open_workbook_auto_from_rs(cursor)
+        .map_err(|e| anyhow::anyhow!("Could not open workbook: {e}"))?;
+    let (headers, rows, inferred_types) = read_sheet(&mut wb, sheet_name)?;
+    Ok(XlsxSheetPayload {
+        name: sheet_name.to_string(),
+        headers,
+        rows,
+        inferred_types,
+    })
+}
+
+/// Build a preview of `sheet_name`: headers, first `PREVIEW_ROWS` data
+/// rows, total data row count, and a per-column inferred type label
+/// for the UI. The full body is intentionally not returned here —
+/// the caller can fetch it via `parse_xlsx_sheet` once the user picks
+/// a sheet.
+fn build_sheet_preview<R>(wb: &mut R, sheet_name: &str) -> anyhow::Result<XlsxSheetPreview>
+where
+    R: Reader<Cursor<Vec<u8>>>,
+    R::Error: std::fmt::Display,
+{
+    let (headers, body, types) = read_sheet(wb, sheet_name)?;
+    let total = body.len();
+    let preview = body.into_iter().take(PREVIEW_ROWS).collect();
+    Ok(XlsxSheetPreview {
+        name: sheet_name.to_string(),
+        headers,
+        preview_rows: preview,
+        total_data_rows: total,
+        inferred_types: types,
+    })
+}
+
+type SheetTuple = (Vec<String>, Vec<Vec<Value>>, Vec<&'static str>);
+
+/// Read a sheet from the workbook and return `(headers, body_rows,
+/// inferred_column_types)`.
+///
+/// Trailing empty rows / columns are trimmed so blank padding at the
+/// end of an analyst's spreadsheet doesn't get re-imported as NULLs.
+fn read_sheet<R>(wb: &mut R, sheet_name: &str) -> anyhow::Result<SheetTuple>
+where
+    R: Reader<Cursor<Vec<u8>>>,
+    R::Error: std::fmt::Display,
+{
+    let range = wb
+        .worksheet_range(sheet_name)
+        .map_err(|e| anyhow::anyhow!("Sheet '{sheet_name}' not found: {e}"))?;
+
+    let raw_rows: Vec<Vec<&Data>> = range.rows().map(|r| r.iter().collect()).collect();
+    if raw_rows.is_empty() {
+        return Ok((Vec::new(), Vec::new(), Vec::new()));
+    }
+
+    // Compute the rightmost non-empty column across all rows so we can
+    // truncate trailing-empty padding without losing real data in
+    // shorter rows.
+    let last_used_col = raw_rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .rposition(|cell| !matches!(cell, Data::Empty))
+                .map(|i| i + 1)
+                .unwrap_or(0)
+        })
+        .max()
+        .unwrap_or(0);
+
+    if last_used_col == 0 {
+        return Ok((Vec::new(), Vec::new(), Vec::new()));
+    }
+
+    let header_row = &raw_rows[0];
+    let headers: Vec<String> = (0..last_used_col)
+        .map(|i| {
+            header_row
+                .get(i)
+                .map(|c| header_to_string(c, i))
+                .unwrap_or_else(|| default_header_name(i))
+        })
+        .collect();
+
+    let body_raw: Vec<Vec<Value>> = raw_rows[1..]
+        .iter()
+        .map(|row| {
+            (0..last_used_col)
+                .map(|i| row.get(i).map(|c| cell_to_value(c)).unwrap_or(Value::Null))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    // Drop trailing fully-empty rows.
+    let last_used_row = body_raw
+        .iter()
+        .rposition(|row| row.iter().any(|v| !matches!(v, Value::Null)))
+        .map(|i| i + 1)
+        .unwrap_or(0);
+
+    let body: Vec<Vec<Value>> = body_raw.into_iter().take(last_used_row).collect();
+    let inferred_types = infer_column_types(&body, last_used_col);
+    Ok((headers, body, inferred_types))
+}
+
+fn header_to_string(cell: &Data, col_idx: usize) -> String {
+    match cell {
+        Data::Empty => default_header_name(col_idx),
+        Data::String(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                default_header_name(col_idx)
+            } else {
+                trimmed.to_string()
+            }
+        }
+        Data::Int(i) => i.to_string(),
+        Data::Float(f) => f.to_string(),
+        Data::Bool(b) => b.to_string(),
+        Data::DateTime(dt) => dt.to_string(),
+        Data::DateTimeIso(s) | Data::DurationIso(s) => s.clone(),
+        Data::Error(_) => default_header_name(col_idx),
+    }
+}
+
+fn default_header_name(col_idx: usize) -> String {
+    format!("Column{}", col_idx + 1)
+}
+
+/// Map a `calamine::Data` cell into a typed JSON value. The frontend
+/// hands these straight to `import_data`, which accepts
+/// `Vec<Vec<serde_json::Value>>`; types ride through unchanged.
+fn cell_to_value(cell: &Data) -> Value {
+    match cell {
+        Data::Empty => Value::Null,
+        Data::String(s) => Value::String(s.clone()),
+        Data::Int(i) => Value::Number((*i).into()),
+        Data::Float(f) => serde_json::Number::from_f64(*f)
+            .map(Value::Number)
+            .unwrap_or_else(|| Value::String(f.to_string())),
+        Data::Bool(b) => Value::Bool(*b),
+        Data::DateTime(dt) => {
+            // Excel stores datetimes as floats; calamine exposes a
+            // helper that converts to chrono. Fall back to the raw
+            // value if conversion fails (e.g. out-of-range serial).
+            if let Some(naive) = dt.as_datetime() {
+                Value::String(naive.format("%Y-%m-%dT%H:%M:%S").to_string())
+            } else {
+                Value::Number(
+                    serde_json::Number::from_f64(dt.as_f64())
+                        .unwrap_or_else(|| serde_json::Number::from(0)),
+                )
+            }
+        }
+        Data::DateTimeIso(s) | Data::DurationIso(s) => Value::String(s.clone()),
+        Data::Error(_) => Value::Null,
+    }
+}
+
+fn type_label(v: &Value) -> Option<&'static str> {
+    match v {
+        Value::Null => None,
+        Value::Number(_) => Some("number"),
+        Value::Bool(_) => Some("bool"),
+        Value::String(s) => {
+            if looks_like_iso_datetime(s) {
+                Some("date")
+            } else {
+                Some("string")
+            }
+        }
+        Value::Array(_) | Value::Object(_) => Some("string"),
+    }
+}
+
+fn looks_like_iso_datetime(s: &str) -> bool {
+    // Cheap "is this an ISO-ish datetime" probe just for the inferred
+    // column-type hint shown in the UI. We don't need full RFC3339
+    // accuracy — anything starting with `YYYY-MM-DD` is good enough
+    // to label the column "date".
+    s.len() >= 10
+        && s.as_bytes().get(4) == Some(&b'-')
+        && s.as_bytes().get(7) == Some(&b'-')
+        && s.chars().take(4).all(|c| c.is_ascii_digit())
+}
+
+fn infer_column_types(body: &[Vec<Value>], cols: usize) -> Vec<&'static str> {
+    let mut out = vec!["string"; cols];
+    for (col, slot) in out.iter_mut().enumerate().take(cols) {
+        let mut seen: Option<&'static str> = None;
+        let mut mixed = false;
+        for row in body {
+            if let Some(label) = row.get(col).and_then(type_label) {
+                match seen {
+                    None => seen = Some(label),
+                    Some(prev) if prev != label => {
+                        mixed = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        *slot = if mixed {
+            "mixed"
+        } else {
+            seen.unwrap_or("string")
+        };
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::export::to_xlsx;
+
+    fn make_workbook(cols: &[&str], rows: Vec<Vec<Value>>) -> Vec<u8> {
+        let columns: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
+        to_xlsx(&columns, &rows, "Sheet1").expect("xlsx encode")
+    }
+
+    #[test]
+    fn workbook_preview_lists_sheets_and_picks_first_as_default() {
+        let bytes = make_workbook(
+            &["a", "b"],
+            vec![vec![Value::Number(1i64.into()), Value::String("x".into())]],
+        );
+        let preview = parse_workbook_impl(&bytes).expect("preview");
+        assert_eq!(preview.sheet_names, vec!["Sheet1"]);
+        assert_eq!(preview.default_sheet, "Sheet1");
+        assert_eq!(preview.sheet.name, "Sheet1");
+        assert_eq!(preview.sheet.headers, vec!["a", "b"]);
+        assert_eq!(preview.sheet.preview_rows.len(), 1);
+        assert_eq!(preview.sheet.total_data_rows, 1);
+    }
+
+    #[test]
+    fn workbook_preview_caps_rows_to_preview_window() {
+        let rows: Vec<Vec<Value>> = (0..120)
+            .map(|i| vec![Value::Number((i as i64).into())])
+            .collect();
+        let bytes = make_workbook(&["n"], rows);
+        let preview = parse_workbook_impl(&bytes).expect("preview");
+        assert_eq!(preview.sheet.preview_rows.len(), PREVIEW_ROWS);
+        // The full count is reported separately so the dialog can
+        // surface "120 rows · previewing first 50" copy.
+        assert_eq!(preview.sheet.total_data_rows, 120);
+    }
+
+    #[test]
+    fn parse_sheet_returns_full_typed_payload() {
+        let bytes = make_workbook(
+            &["i", "b", "n"],
+            vec![
+                vec![Value::Number(7i64.into()), Value::Bool(true), Value::Null],
+                vec![
+                    Value::Number(8i64.into()),
+                    Value::Bool(false),
+                    Value::String("x".into()),
+                ],
+            ],
+        );
+        let payload = parse_sheet_impl(&bytes, "Sheet1").expect("sheet");
+        assert_eq!(payload.name, "Sheet1");
+        assert_eq!(payload.headers, vec!["i", "b", "n"]);
+        assert_eq!(payload.rows.len(), 2);
+        assert!(matches!(&payload.rows[0][0], Value::Number(_)));
+        assert!(matches!(&payload.rows[0][1], Value::Bool(true)));
+        assert!(matches!(&payload.rows[0][2], Value::Null));
+        assert!(matches!(&payload.rows[1][2], Value::String(s) if s == "x"));
+        // Type inference reflects body data, not headers.
+        assert_eq!(payload.inferred_types, vec!["number", "bool", "string"]);
+    }
+
+    #[test]
+    fn parse_sheet_unknown_sheet_returns_error() {
+        let bytes = make_workbook(&["a"], vec![vec![Value::Number(1i64.into())]]);
+        let err = parse_sheet_impl(&bytes, "Nope").unwrap_err().to_string();
+        assert!(
+            err.contains("Nope"),
+            "expected sheet name in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn payload_size_cap_rejects_oversize_input() {
+        // Force the cap branch — we don't allocate 110MB, we just lie
+        // about the slice length via a synthetic `Vec` slightly above
+        // MAX_BYTES. That's what `bytes.len()` checks.
+        let bytes = vec![0u8; MAX_BYTES + 1];
+        let err = parse_workbook_impl(&bytes).unwrap_err().to_string();
+        assert!(err.contains("too large"), "expected size error, got: {err}");
+        let err = parse_sheet_impl(&bytes, "Sheet1").unwrap_err().to_string();
+        assert!(err.contains("too large"));
+    }
+
+    #[test]
+    fn invalid_bytes_return_a_friendly_error() {
+        let err = parse_workbook_impl(b"not a workbook")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Could not open"),
+            "expected friendly error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_trailing_rows_are_truncated() {
+        // Build a workbook with two data rows followed by an explicit
+        // all-null row. Round-tripping through to_xlsx + read_sheet
+        // should emit exactly two body rows.
+        let bytes = make_workbook(
+            &["a"],
+            vec![
+                vec![Value::Number(1i64.into())],
+                vec![Value::Number(2i64.into())],
+                vec![Value::Null],
+                vec![Value::Null],
+            ],
+        );
+        let preview = parse_workbook_impl(&bytes).expect("preview");
+        assert_eq!(preview.sheet.total_data_rows, 2);
+        assert_eq!(preview.sheet.preview_rows.len(), 2);
+    }
+
+    #[test]
+    fn inferred_types_flags_mixed_columns() {
+        let bytes = make_workbook(
+            &["c"],
+            vec![
+                vec![Value::Number(1i64.into())],
+                vec![Value::String("two".into())],
+            ],
+        );
+        let preview = parse_workbook_impl(&bytes).expect("preview");
+        assert_eq!(preview.sheet.inferred_types, vec!["mixed"]);
+    }
+
+    #[test]
+    fn inferred_types_uses_string_for_empty_column() {
+        let bytes = make_workbook(&["c"], vec![vec![Value::Null], vec![Value::Null]]);
+        let preview = parse_workbook_impl(&bytes).expect("preview");
+        assert_eq!(preview.sheet.inferred_types, vec!["string"]);
+    }
+
+    #[test]
+    fn inferred_types_recognizes_dates() {
+        let bytes = make_workbook(
+            &["d"],
+            vec![
+                vec![Value::String("2024-05-01T12:30:00".into())],
+                vec![Value::String("2024-06-01T09:00:00".into())],
+            ],
+        );
+        let preview = parse_workbook_impl(&bytes).expect("preview");
+        // After round-tripping through xlsx, dates come back as
+        // DateTime cells which read_sheet maps to ISO-8601 strings;
+        // the inferred-type heuristic flags them as `date`.
+        assert_eq!(preview.sheet.inferred_types, vec!["date"]);
+    }
+}

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -1,3 +1,5 @@
+use anyhow::Result;
+use rust_xlsxwriter::{Format, Workbook};
 use serde_json::Value;
 
 pub fn to_csv(columns: &[String], rows: &[Vec<Value>]) -> String {
@@ -102,6 +104,132 @@ pub fn to_sql_inserts(
         ));
     }
     out
+}
+
+/// Excel sheet-name rules: max 31 chars, may not contain `: \ / ? * [ ]`.
+/// An empty/whitespace-only input falls back to `"Result"` so we never
+/// emit a workbook with an unnamed sheet.
+pub fn sanitize_sheet_name(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .filter(|c| !matches!(c, ':' | '\\' | '/' | '?' | '*' | '[' | ']'))
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        return "Result".to_string();
+    }
+    // Truncate by char count, not bytes, to avoid splitting multi-byte UTF-8.
+    let truncated: String = trimmed.chars().take(31).collect();
+    truncated
+}
+
+/// Render rows as an `.xlsx` workbook, returning the serialized bytes.
+///
+/// Type fidelity (the headline ask in #69 / #70):
+/// - `Value::Number` writes as a numeric cell (not stringified)
+/// - `Value::Bool` writes as a boolean cell
+/// - `Value::Null` writes nothing (blank cell)
+/// - `Value::String` that parses as ISO-8601 date / datetime writes as
+///   an Excel datetime with `yyyy-mm-dd hh:mm:ss` formatting; otherwise
+///   plain string
+/// - `Value::Array` / `Value::Object` fall back to their JSON
+///   representation since Excel has no native equivalent
+///
+/// Calls `autofit()` once at the end so column widths track the longest
+/// rendered value without a per-cell pass.
+pub fn to_xlsx(columns: &[String], rows: &[Vec<Value>], sheet_name: &str) -> Result<Vec<u8>> {
+    let mut workbook = Workbook::new();
+    let safe_name = sanitize_sheet_name(sheet_name);
+    let datetime_fmt = Format::new().set_num_format("yyyy-mm-dd hh:mm:ss");
+    let header_fmt = Format::new().set_bold();
+
+    let worksheet = workbook.add_worksheet();
+    worksheet.set_name(&safe_name)?;
+
+    for (col_idx, col) in columns.iter().enumerate() {
+        worksheet.write_string_with_format(0, col_idx as u16, col, &header_fmt)?;
+    }
+
+    for (row_idx, row) in rows.iter().enumerate() {
+        let excel_row = (row_idx + 1) as u32;
+        for (col_idx, val) in row.iter().enumerate() {
+            write_typed_cell(worksheet, excel_row, col_idx as u16, val, &datetime_fmt)?;
+        }
+    }
+
+    worksheet.autofit();
+    let bytes = workbook.save_to_buffer()?;
+    Ok(bytes)
+}
+
+fn write_typed_cell(
+    worksheet: &mut rust_xlsxwriter::Worksheet,
+    row: u32,
+    col: u16,
+    val: &Value,
+    datetime_fmt: &Format,
+) -> Result<()> {
+    match val {
+        Value::Null => {
+            worksheet.write_blank(row, col, &Format::default())?;
+        }
+        Value::Bool(b) => {
+            worksheet.write_boolean(row, col, *b)?;
+        }
+        Value::Number(n) => {
+            // Prefer i64 / u64 over f64 to keep integers as integers in
+            // the workbook (Excel still stores them as f64 internally,
+            // but the cell type stays "number" either way).
+            if let Some(i) = n.as_i64() {
+                worksheet.write_number(row, col, i as f64)?;
+            } else if let Some(u) = n.as_u64() {
+                worksheet.write_number(row, col, u as f64)?;
+            } else if let Some(f) = n.as_f64() {
+                worksheet.write_number(row, col, f)?;
+            } else {
+                worksheet.write_string(row, col, n.to_string())?;
+            }
+        }
+        Value::String(s) => {
+            if let Some(dt) = parse_iso_datetime(s) {
+                worksheet.write_datetime_with_format(row, col, dt, datetime_fmt)?;
+            } else {
+                worksheet.write_string(row, col, s.as_str())?;
+            }
+        }
+        // No native Excel cell type for arrays / objects; fall back to
+        // the JSON representation so the data isn't silently dropped.
+        Value::Array(_) | Value::Object(_) => {
+            worksheet.write_string(row, col, val.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+/// Best-effort ISO-8601 parse covering the shapes our drivers emit for
+/// `timestamp` / `date` / `time` values.
+fn parse_iso_datetime(s: &str) -> Option<chrono::NaiveDateTime> {
+    use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+
+    if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f") {
+        return Some(dt);
+    }
+    if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        return Some(dt);
+    }
+    if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f") {
+        return Some(dt);
+    }
+    if let Ok(dt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        return Some(dt);
+    }
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.naive_utc());
+    }
+    if let Ok(d) = NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+        return Some(d.and_time(NaiveTime::from_hms_opt(0, 0, 0)?));
+    }
+    None
 }
 
 fn escape_csv(s: &str) -> String {
@@ -423,5 +551,167 @@ mod tests {
         let out = to_csv(&cols, &rows);
         assert!(out.contains("42"));
         assert!(out.contains("3.14"));
+    }
+
+    // ── xlsx ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn xlsx_sheet_name_sanitization_strips_forbidden_chars() {
+        assert_eq!(sanitize_sheet_name("a:b\\c/d?e*f[g]h"), "abcdefgh");
+    }
+
+    #[test]
+    fn xlsx_sheet_name_sanitization_truncates_to_31_chars() {
+        let raw = "a".repeat(64);
+        let out = sanitize_sheet_name(&raw);
+        assert_eq!(out.chars().count(), 31);
+    }
+
+    #[test]
+    fn xlsx_sheet_name_sanitization_truncates_multibyte_safely() {
+        // 40 codepoints, each 2 bytes when encoded as UTF-8. A naive
+        // byte-truncate to 31 would split one of these characters and
+        // produce invalid UTF-8; we truncate by char count instead.
+        let raw = "ñ".repeat(40);
+        let out = sanitize_sheet_name(&raw);
+        assert_eq!(out.chars().count(), 31);
+    }
+
+    #[test]
+    fn xlsx_sheet_name_falls_back_to_result_when_empty() {
+        assert_eq!(sanitize_sheet_name(""), "Result");
+        assert_eq!(sanitize_sheet_name("   "), "Result");
+        assert_eq!(sanitize_sheet_name("[]/\\"), "Result");
+    }
+
+    #[test]
+    fn xlsx_round_trip_preserves_types() {
+        // Single source of truth for the headline acceptance criterion
+        // in #69 / #70: numbers stay numbers, booleans stay booleans,
+        // dates stay dates, nulls stay blank when the file is reopened.
+        use calamine::{Data, Reader};
+
+        let cols = vec![
+            "i".to_string(),
+            "f".to_string(),
+            "b".to_string(),
+            "s".to_string(),
+            "d".to_string(),
+            "n".to_string(),
+        ];
+        let rows = vec![vec![
+            Value::Number(42i64.into()),
+            Value::Number(serde_json::Number::from_f64(3.14).unwrap()),
+            Value::Bool(true),
+            Value::String("hello".into()),
+            Value::String("2024-05-01T12:30:00".into()),
+            Value::Null,
+        ]];
+        let bytes = to_xlsx(&cols, &rows, "users").expect("to_xlsx");
+
+        let cursor = std::io::Cursor::new(bytes);
+        let mut wb = calamine::open_workbook_auto_from_rs(cursor).expect("open workbook");
+        let names = wb.sheet_names();
+        assert_eq!(names, vec!["users".to_string()]);
+        let range = wb.worksheet_range("users").expect("range");
+
+        // Header row (formatted bold, but still read as Strings).
+        let headers: Vec<&Data> = range.rows().next().unwrap().iter().collect();
+        assert!(matches!(headers[0], Data::String(s) if s == "i"));
+        assert!(matches!(headers[5], Data::String(s) if s == "n"));
+
+        let data_row: Vec<&Data> = range.rows().nth(1).unwrap().iter().collect();
+        assert!(
+            matches!(data_row[0], Data::Float(f) if (*f - 42.0).abs() < f64::EPSILON
+                || matches!(data_row[0], Data::Int(42))),
+            "integer cell should survive as numeric, got {:?}",
+            data_row[0]
+        );
+        assert!(
+            matches!(data_row[1], Data::Float(f) if (*f - 3.14).abs() < 1e-9),
+            "float cell should survive as numeric, got {:?}",
+            data_row[1]
+        );
+        assert!(
+            matches!(data_row[2], Data::Bool(true)),
+            "bool cell should survive as boolean, got {:?}",
+            data_row[2]
+        );
+        assert!(
+            matches!(data_row[3], Data::String(s) if s == "hello"),
+            "string cell stays string, got {:?}",
+            data_row[3]
+        );
+        assert!(
+            matches!(data_row[4], Data::DateTime(_)),
+            "ISO datetime string should be written as a datetime cell, got {:?}",
+            data_row[4]
+        );
+        assert!(
+            matches!(data_row[5], Data::Empty),
+            "Value::Null should write as a blank cell, got {:?}",
+            data_row[5]
+        );
+    }
+
+    #[test]
+    fn xlsx_uses_sanitized_sheet_name_in_output() {
+        use calamine::Reader;
+
+        let bytes = to_xlsx(
+            &["a".to_string()],
+            &[vec![Value::Number(1i64.into())]],
+            "schema:table",
+        )
+        .expect("to_xlsx");
+        let wb = calamine::open_workbook_auto_from_rs(std::io::Cursor::new(bytes))
+            .expect("open workbook");
+        // The forbidden `:` is stripped; the sheet name must be the
+        // sanitized version so the workbook is loadable.
+        assert_eq!(wb.sheet_names(), vec!["schematable".to_string()]);
+    }
+
+    #[test]
+    fn xlsx_empty_rows_emits_only_header() {
+        use calamine::Reader;
+
+        let bytes = to_xlsx(&["id".to_string()], &[], "t").expect("to_xlsx");
+        let mut wb = calamine::open_workbook_auto_from_rs(std::io::Cursor::new(bytes))
+            .expect("open workbook");
+        let range = wb.worksheet_range("t").expect("range");
+        // Only the header row, no data rows.
+        assert_eq!(range.rows().count(), 1);
+    }
+
+    #[test]
+    fn xlsx_array_and_object_fall_back_to_json() {
+        use calamine::{Data, Reader};
+
+        let cols = vec!["arr".to_string(), "obj".to_string()];
+        let rows = vec![vec![
+            Value::Array(vec![Value::Number(1i64.into()), Value::Number(2i64.into())]),
+            Value::Object(serde_json::Map::from_iter(vec![(
+                "k".to_string(),
+                Value::String("v".into()),
+            )])),
+        ]];
+        let bytes = to_xlsx(&cols, &rows, "t").expect("to_xlsx");
+        let mut wb = calamine::open_workbook_auto_from_rs(std::io::Cursor::new(bytes))
+            .expect("open workbook");
+        let range = wb.worksheet_range("t").expect("range");
+        let row: Vec<&Data> = range.rows().nth(1).unwrap().iter().collect();
+        assert!(matches!(row[0], Data::String(s) if s.contains('[') && s.contains('1')));
+        assert!(matches!(row[1], Data::String(s) if s.contains("\"k\"") && s.contains("\"v\"")));
+    }
+
+    #[test]
+    fn parse_iso_datetime_accepts_common_shapes() {
+        assert!(parse_iso_datetime("2024-05-01T12:30:00").is_some());
+        assert!(parse_iso_datetime("2024-05-01T12:30:00.123").is_some());
+        assert!(parse_iso_datetime("2024-05-01 12:30:00").is_some());
+        assert!(parse_iso_datetime("2024-05-01T12:30:00Z").is_some());
+        assert!(parse_iso_datetime("2024-05-01").is_some());
+        assert!(parse_iso_datetime("not a date").is_none());
+        assert!(parse_iso_datetime("hello").is_none());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ use commands::saved_queries::*;
 use commands::schema::*;
 use commands::ssh_config::*;
 use commands::system::*;
+use commands::xlsx_import::*;
 use db::pool::PoolManager;
 use std::sync::Arc;
 
@@ -77,6 +78,8 @@ pub fn run() {
             forget_known_host,
             ssh_config_lookup,
             get_app_resource_usage,
+            parse_xlsx_workbook,
+            parse_xlsx_sheet,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tests/postgres_integration.rs
+++ b/src-tauri/tests/postgres_integration.rs
@@ -2494,3 +2494,128 @@ async fn dump_restore_roundtrip() {
 
     pg_drop_table_silent(&driver, &src_table).await;
 }
+
+// ---------------------------------------------------------------------------
+// xlsx round trip (issues #69 / #70)
+// ---------------------------------------------------------------------------
+
+/// Headline acceptance criterion for the xlsx import + export work:
+/// build typed rows, serialize them through `to_xlsx`, parse the
+/// resulting workbook via `parse_sheet_impl`, then INSERT the parsed
+/// rows into a fresh Postgres table via `import_data` and assert that
+/// numbers, booleans, dates, and nulls all round-trip without being
+/// stringified along the way.
+#[tokio::test]
+async fn pg_xlsx_round_trip_preserves_types() {
+    use tablio_lib::commands::xlsx_import::parse_sheet_impl;
+    use tablio_lib::export::to_xlsx;
+
+    let driver = pg_driver!();
+    let tbl = unique_table("pg_xlsx_rt");
+
+    driver
+        .execute_query(
+            DB,
+            &format!(
+                "CREATE TABLE {}.\"{}\" (\
+                   id INT PRIMARY KEY, \
+                   amount NUMERIC(10,2), \
+                   active BOOLEAN, \
+                   note TEXT, \
+                   ts TIMESTAMP\
+                 )",
+                SCHEMA, tbl
+            ),
+        )
+        .await
+        .unwrap();
+
+    let cols = vec![
+        "id".to_string(),
+        "amount".to_string(),
+        "active".to_string(),
+        "note".to_string(),
+        "ts".to_string(),
+    ];
+    let original_rows: Vec<Vec<serde_json::Value>> = vec![
+        vec![
+            serde_json::json!(1),
+            serde_json::json!(12.5),
+            serde_json::json!(true),
+            serde_json::json!("hello"),
+            serde_json::json!("2024-05-01T12:30:00"),
+        ],
+        vec![
+            serde_json::json!(2),
+            serde_json::Value::Null,
+            serde_json::json!(false),
+            serde_json::Value::Null,
+            serde_json::json!("2024-06-15T09:00:00"),
+        ],
+    ];
+
+    let bytes = to_xlsx(&cols, &original_rows, &tbl).expect("encode xlsx");
+    let payload = parse_sheet_impl(&bytes, &tbl).expect("parse xlsx");
+    let parsed = payload.rows;
+    assert_eq!(parsed.len(), 2, "round-trip lost rows: {parsed:?}");
+    assert_eq!(payload.headers, cols);
+    assert!(
+        matches!(&parsed[0][0], serde_json::Value::Number(_)),
+        "id should round-trip as a number, got {:?}",
+        parsed[0][0]
+    );
+    assert!(
+        matches!(&parsed[0][2], serde_json::Value::Bool(true)),
+        "active should round-trip as a bool, got {:?}",
+        parsed[0][2]
+    );
+    assert!(
+        matches!(&parsed[1][1], serde_json::Value::Null),
+        "null should round-trip as Null, got {:?}",
+        parsed[1][1]
+    );
+    assert!(
+        matches!(&parsed[0][4], serde_json::Value::String(s) if s.starts_with("2024-05-01")),
+        "datetime should round-trip as ISO string, got {:?}",
+        parsed[0][4]
+    );
+
+    let inserted = driver
+        .import_data(DB, SCHEMA, &tbl, &cols, &parsed)
+        .await
+        .expect("import");
+    assert_eq!(inserted, 2);
+
+    let data = driver
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .await
+        .expect("fetch");
+    assert_eq!(data.total_rows, 2);
+
+    let by_id: std::collections::HashMap<i64, &Vec<serde_json::Value>> = data
+        .rows
+        .iter()
+        .map(|r| (r[0].as_i64().expect("id"), r))
+        .collect();
+
+    let r1 = by_id.get(&1).expect("id=1");
+    assert!(
+        r1[1].is_number(),
+        "amount stored as number, got: {:?}",
+        r1[1]
+    );
+    assert_eq!(r1[2], serde_json::json!(true), "active=true preserved");
+    assert_eq!(r1[3], serde_json::json!("hello"), "note preserved");
+    assert!(
+        r1[4].as_str().unwrap_or("").contains("2024-05-01"),
+        "ts preserved, got: {:?}",
+        r1[4]
+    );
+
+    let r2 = by_id.get(&2).expect("id=2");
+    assert!(r2[1].is_null(), "amount=NULL preserved, got: {:?}", r2[1]);
+    assert_eq!(r2[2], serde_json::json!(false), "active=false preserved");
+    assert!(r2[3].is_null(), "note=NULL preserved, got: {:?}", r2[3]);
+
+    driver.drop_object(DB, SCHEMA, &tbl, "TABLE").await.unwrap();
+}

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -742,13 +742,14 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     }
   };
 
-  const handleExport = async (format: "csv" | "json" | "sql") => {
+  const handleExport = async (format: "csv" | "json" | "sql" | "xlsx") => {
     try {
       const ext = format === "sql" ? "sql" : format;
+      const label = format === "xlsx" ? "Excel" : format.toUpperCase();
       const filePath = await save({
         defaultPath: `${table}.${ext}`,
         filters: [{
-          name: format.toUpperCase(),
+          name: label,
           extensions: [ext],
         }],
       });
@@ -762,7 +763,7 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
         format,
         filter: activeFilter,
       }, filePath);
-      addToast(`Exported ${table} as ${format.toUpperCase()}`);
+      addToast(`Exported ${table} as ${label}`);
     } catch (e) {
       addToast(String(e), "error");
     }

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -2,8 +2,10 @@ import { useState, useRef, useEffect } from "react";
 import { Download } from "lucide-react";
 import "./ExportMenu.css";
 
+export type ExportFormat = "csv" | "json" | "sql" | "xlsx";
+
 interface Props {
-  onExport: (format: "csv" | "json" | "sql") => void;
+  onExport: (format: ExportFormat) => void;
 }
 
 export function ExportMenu({ onExport }: Props) {
@@ -54,6 +56,14 @@ export function ExportMenu({ onExport }: Props) {
             }}
           >
             Export as SQL
+          </button>
+          <button
+            onClick={() => {
+              onExport("xlsx");
+              setOpen(false);
+            }}
+          >
+            Export as Excel
           </button>
         </div>
       )}

--- a/src/components/ImportDialog/ImportDialog.css
+++ b/src/components/ImportDialog/ImportDialog.css
@@ -127,3 +127,37 @@
 .import-preview-table tbody tr:hover td {
   background: var(--bg-hover);
 }
+
+.import-file-hint {
+  margin: 6px 0 0 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.import-sheet-select {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  font-size: 13px;
+}
+
+.import-sheet-meta {
+  margin: 6px 0 0 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.import-mapping-type {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm, 3px);
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/src/components/ImportDialog/ImportDialog.test.tsx
+++ b/src/components/ImportDialog/ImportDialog.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { ImportDialog } from "./ImportDialog";
+import { api, type ColumnInfo, type XlsxWorkbookPreview, type XlsxSheetPayload } from "../../lib/tauri";
+
+const tableColumns: ColumnInfo[] = [
+  { name: "id", data_type: "int", is_nullable: false, default_value: null, is_primary_key: true, ordinal_position: 1, is_auto_generated: false },
+  { name: "name", data_type: "text", is_nullable: true, default_value: null, is_primary_key: false, ordinal_position: 2, is_auto_generated: false },
+  { name: "active", data_type: "bool", is_nullable: true, default_value: null, is_primary_key: false, ordinal_position: 3, is_auto_generated: false },
+];
+
+function makeWorkbookPreview(sheetCount: number): XlsxWorkbookPreview {
+  const sheetNames = Array.from({ length: sheetCount }, (_, i) => `Sheet${i + 1}`);
+  return {
+    sheet_names: sheetNames,
+    default_sheet: sheetNames[0],
+    sheet: {
+      name: sheetNames[0],
+      headers: ["id", "name", "active"],
+      preview_rows: [
+        [1, "Alice", true],
+        [2, "Bob", false],
+      ],
+      total_data_rows: 2,
+      inferred_types: ["number", "string", "bool"],
+    },
+  };
+}
+
+function makeSheetPayload(name: string): XlsxSheetPayload {
+  return {
+    name,
+    headers: ["id", "name", "active"],
+    rows: [
+      [1, "Alice", true],
+      [2, "Bob", false],
+    ],
+    inferred_types: ["number", "string", "bool"],
+  };
+}
+
+function makeFile(name: string, size: number, content = "stub"): File {
+  // jsdom honors `size` only when the underlying chunks add up; build
+  // a Blob of the requested length so file.size works.
+  const data = new Uint8Array(size);
+  // Fill with a known byte so it's not all zero (helps debugging).
+  data.fill(0x41);
+  if (content) {
+    const enc = new TextEncoder();
+    const head = enc.encode(content);
+    data.set(head.subarray(0, Math.min(head.length, size)));
+  }
+  return new File([data], name, { type: "application/octet-stream" });
+}
+
+describe("ImportDialog", () => {
+  beforeEach(() => {
+    vi.spyOn(api, "listColumns").mockResolvedValue(tableColumns);
+    vi.spyOn(api, "importData").mockResolvedValue(2);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function mount() {
+    return render(
+      <ImportDialog
+        connectionId="test"
+        database="db"
+        schema="public"
+        tableName="users"
+        onClose={vi.fn()}
+        onImported={vi.fn()}
+      />,
+    );
+  }
+
+  it('renders the engine-agnostic "Import Data" header', async () => {
+    mount();
+    expect(await screen.findByText("Import Data")).toBeInTheDocument();
+    // The file input accepts CSV + Excel.
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(input.accept).toContain(".csv");
+    expect(input.accept).toContain(".xlsx");
+    expect(input.accept).toContain(".xls");
+  });
+
+  it("rejects unsupported extensions before parsing", async () => {
+    mount();
+    await screen.findByText("Import Data");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeFile("notes.txt", 64)] } });
+    expect(
+      await screen.findByText(/unsupported file type/i),
+    ).toBeInTheDocument();
+  });
+
+  it("rejects oversized files before invoking IPC", async () => {
+    const parseSpy = vi
+      .spyOn(api, "parseXlsxWorkbook")
+      .mockResolvedValue(makeWorkbookPreview(1));
+    mount();
+    await screen.findByText("Import Data");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    // 100MB + 1 byte triggers the cap. We don't actually allocate that
+    // much in the test (jsdom handles File.size synthetically); pass
+    // an explicit size via a sparse File instead.
+    const oversized = new File([new Uint8Array(0)], "huge.xlsx", { type: "x" });
+    Object.defineProperty(oversized, "size", { value: 200 * 1024 * 1024 });
+    fireEvent.change(input, { target: { files: [oversized] } });
+    expect(
+      await screen.findByText(/file is too large/i),
+    ).toBeInTheDocument();
+    expect(parseSpy).not.toHaveBeenCalled();
+  });
+
+  it("parses xlsx and seeds column mapping by name match", async () => {
+    vi.spyOn(api, "parseXlsxWorkbook").mockResolvedValue(makeWorkbookPreview(1));
+    vi.spyOn(api, "parseXlsxSheet").mockResolvedValue(makeSheetPayload("Sheet1"));
+
+    mount();
+    await screen.findByText("Import Data");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [makeFile("data.xlsx", 1024)] },
+    });
+
+    // Column mapping renders all three source columns. Each one
+    // auto-maps to the same-named target column because the
+    // case-insensitive match logic kicks in for both CSV and XLSX.
+    await waitFor(() => {
+      expect(screen.getByText(/column mapping/i)).toBeInTheDocument();
+    });
+    const mappingSelects = document.querySelectorAll(
+      ".import-mapping-row select",
+    ) as NodeListOf<HTMLSelectElement>;
+    expect(mappingSelects).toHaveLength(3);
+    expect(Array.from(mappingSelects).map((s) => s.value)).toEqual([
+      "id",
+      "name",
+      "active",
+    ]);
+  });
+
+  it("renders inferred type badges next to xlsx column names", async () => {
+    vi.spyOn(api, "parseXlsxWorkbook").mockResolvedValue(makeWorkbookPreview(1));
+    vi.spyOn(api, "parseXlsxSheet").mockResolvedValue(makeSheetPayload("Sheet1"));
+
+    mount();
+    await screen.findByText("Import Data");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [makeFile("data.xlsx", 1024)] },
+    });
+
+    await waitFor(() => {
+      const badges = document.querySelectorAll(".import-mapping-type");
+      expect(badges).toHaveLength(3);
+      expect(Array.from(badges).map((b) => b.textContent)).toEqual([
+        "number",
+        "string",
+        "bool",
+      ]);
+    });
+  });
+
+  it("hides the sheet picker when the workbook has only one sheet", async () => {
+    vi.spyOn(api, "parseXlsxWorkbook").mockResolvedValue(makeWorkbookPreview(1));
+    vi.spyOn(api, "parseXlsxSheet").mockResolvedValue(makeSheetPayload("Sheet1"));
+
+    mount();
+    await screen.findByText("Import Data");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [makeFile("data.xlsx", 1024)] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/column mapping/i)).toBeInTheDocument();
+    });
+    expect(document.querySelector(".import-sheet-select")).toBeNull();
+  });
+
+  it("shows the sheet picker for multi-sheet workbooks and reloads on change", async () => {
+    vi.spyOn(api, "parseXlsxWorkbook").mockResolvedValue(makeWorkbookPreview(3));
+    const sheetSpy = vi
+      .spyOn(api, "parseXlsxSheet")
+      .mockImplementation(async (_b, sheet) => makeSheetPayload(sheet));
+
+    mount();
+    await screen.findByText("Import Data");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [makeFile("data.xlsx", 1024)] },
+    });
+
+    const select = (await waitFor(() => {
+      const el = document.querySelector(".import-sheet-select") as HTMLSelectElement | null;
+      expect(el).not.toBeNull();
+      return el!;
+    })) as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      "Sheet1",
+      "Sheet2",
+      "Sheet3",
+    ]);
+    expect(select.value).toBe("Sheet1");
+
+    fireEvent.change(select, { target: { value: "Sheet2" } });
+    await waitFor(() => {
+      expect(sheetSpy).toHaveBeenCalledWith(expect.any(Uint8Array), "Sheet2");
+    });
+  });
+
+  it("falls back to CSV parser for .csv files", async () => {
+    const xlsxSpy = vi.spyOn(api, "parseXlsxWorkbook").mockResolvedValue(
+      makeWorkbookPreview(1),
+    );
+
+    mount();
+    await screen.findByText("Import Data");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const csv = new File(["id,name\n1,Alice\n2,Bob"], "data.csv", { type: "text/csv" });
+    fireEvent.change(input, { target: { files: [csv] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/column mapping/i)).toBeInTheDocument();
+    });
+    // CSV path doesn't touch the xlsx command.
+    expect(xlsxSpy).not.toHaveBeenCalled();
+    // Type badges aren't rendered for CSV (no inferred_types from the
+    // legacy parser).
+    expect(document.querySelectorAll(".import-mapping-type")).toHaveLength(0);
+  });
+});

--- a/src/components/ImportDialog/ImportDialog.tsx
+++ b/src/components/ImportDialog/ImportDialog.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
-import { api, ColumnInfo } from "../../lib/tauri";
+import {
+  api,
+  ColumnInfo,
+  XlsxWorkbookPreview,
+  XlsxColumnType,
+} from "../../lib/tauri";
 import { X, FileSpreadsheet, Loader2, CheckCircle } from "lucide-react";
 import "./ImportDialog.css";
 
@@ -10,6 +15,25 @@ interface Props {
   tableName: string;
   onClose: () => void;
   onImported: () => void;
+}
+
+const MAX_FILE_BYTES = 100 * 1024 * 1024;
+const ACCEPTED_EXTS = [".csv", ".xlsx", ".xls"] as const;
+
+type SourceKind = "csv" | "xlsx";
+
+interface ParsedSheet {
+  headers: string[];
+  rows: unknown[][];
+  inferredTypes?: XlsxColumnType[];
+  totalRows?: number;
+}
+
+function detectKind(name: string): SourceKind | null {
+  const lower = name.toLowerCase();
+  if (lower.endsWith(".csv")) return "csv";
+  if (lower.endsWith(".xlsx") || lower.endsWith(".xls")) return "xlsx";
+  return null;
 }
 
 function parseCSV(text: string): { headers: string[]; rows: string[][] } {
@@ -66,11 +90,15 @@ export function ImportDialog({
 }: Props) {
   const [tableColumns, setTableColumns] = useState<ColumnInfo[]>([]);
   const [columnsLoading, setColumnsLoading] = useState(true);
-  const [csvFile, setCsvFile] = useState<File | null>(null);
-  const [csvData, setCsvData] = useState<{
-    headers: string[];
-    rows: string[][];
-  } | null>(null);
+  const [sourceFile, setSourceFile] = useState<File | null>(null);
+  const [sourceKind, setSourceKind] = useState<SourceKind | null>(null);
+  const [sourceData, setSourceData] = useState<ParsedSheet | null>(null);
+  // Cache the workbook bytes so the user can flip between sheets
+  // without re-reading the file from disk.
+  const [workbookBytes, setWorkbookBytes] = useState<Uint8Array | null>(null);
+  const [workbook, setWorkbook] = useState<XlsxWorkbookPreview | null>(null);
+  const [activeSheet, setActiveSheet] = useState<string | null>(null);
+  const [parsing, setParsing] = useState(false);
   const [parseError, setParseError] = useState<string | null>(null);
   const [columnMap, setColumnMap] = useState<Record<string, string>>({});
   const [importing, setImporting] = useState(false);
@@ -101,77 +129,143 @@ export function ImportDialog({
     return () => { cancelled = true; };
   }, [connectionId, database, schema, tableName]);
 
+  // Match source headers to table columns by case-insensitive name.
+  // Centralized so the CSV path, the initial XLSX parse, and re-parses
+  // after a sheet swap all initialize the mapping the same way.
+  const seedColumnMap = (headers: string[]) => {
+    const initialMap: Record<string, string> = {};
+    headers.forEach((h) => {
+      const match = tableColumns.find(
+        (c) => c.name.toLowerCase() === h.toLowerCase()
+      );
+      initialMap[h] = match ? match.name : "";
+    });
+    setColumnMap(initialMap);
+  };
+
+  // If table columns finish loading after the file was parsed, seed
+  // the mapping retroactively rather than leaving everything as
+  // "— Skip —".
   useEffect(() => {
-    if (csvData && tableColumns.length > 0) {
+    if (sourceData && tableColumns.length > 0) {
       const hasMappings = Object.values(columnMap).some((v) => v);
       if (!hasMappings) {
-        const initialMap: Record<string, string> = {};
-        csvData.headers.forEach((h) => {
-          const match = tableColumns.find(
-            (c) => c.name.toLowerCase() === h.toLowerCase()
-          );
-          initialMap[h] = match ? match.name : "";
-        });
-        setColumnMap(initialMap);
+        seedColumnMap(sourceData.headers);
       }
     }
-  }, [csvData, tableColumns]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sourceData, tableColumns]);
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    setCsvFile(file);
-    setCsvData(null);
+  const resetSourceState = () => {
+    setSourceData(null);
+    setWorkbookBytes(null);
+    setWorkbook(null);
+    setActiveSheet(null);
     setParseError(null);
     setImportResult(null);
     setImportError(null);
+    setColumnMap({});
+  };
 
-    const reader = new FileReader();
-    reader.onload = () => {
-      try {
-        const text = String(reader.result);
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    resetSourceState();
+
+    if (file.size > MAX_FILE_BYTES) {
+      setSourceFile(file);
+      setSourceKind(null);
+      setParseError(
+        `File is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Max ${MAX_FILE_BYTES / 1024 / 1024} MB.`
+      );
+      return;
+    }
+
+    const kind = detectKind(file.name);
+    setSourceFile(file);
+    setSourceKind(kind);
+
+    if (kind === null) {
+      setParseError(
+        `Unsupported file type. Choose a ${ACCEPTED_EXTS.join(", ")} file.`
+      );
+      return;
+    }
+
+    setParsing(true);
+    try {
+      if (kind === "csv") {
+        const text = await file.text();
         const { headers, rows } = parseCSV(text);
-        setCsvData({ headers, rows });
-        const initialMap: Record<string, string> = {};
-        headers.forEach((h) => {
-          const match = tableColumns.find(
-            (c) => c.name.toLowerCase() === h.toLowerCase()
-          );
-          initialMap[h] = match ? match.name : "";
-        });
-        setColumnMap(initialMap);
-      } catch (err) {
-        setParseError(String(err));
+        setSourceData({ headers, rows });
+        seedColumnMap(headers);
+      } else {
+        const buf = new Uint8Array(await file.arrayBuffer());
+        setWorkbookBytes(buf);
+        const preview = await api.parseXlsxWorkbook(buf);
+        setWorkbook(preview);
+        setActiveSheet(preview.default_sheet);
+        await loadXlsxSheet(buf, preview.default_sheet);
       }
-    };
-    reader.readAsText(file);
+    } catch (err) {
+      setParseError(String(err));
+    } finally {
+      setParsing(false);
+    }
+  };
+
+  // Fetch the full payload for a sheet (headers + rows + inferred
+  // types) and seed the column mapping. Used both for the initial
+  // load and any sheet-picker change.
+  const loadXlsxSheet = async (buf: Uint8Array, sheetName: string) => {
+    const payload = await api.parseXlsxSheet(buf, sheetName);
+    setSourceData({
+      headers: payload.headers,
+      rows: payload.rows,
+      inferredTypes: payload.inferred_types,
+      totalRows: payload.rows.length,
+    });
+    seedColumnMap(payload.headers);
+  };
+
+  const handleSheetChange = async (sheetName: string) => {
+    if (!workbookBytes) return;
+    setActiveSheet(sheetName);
+    setParsing(true);
+    setParseError(null);
+    try {
+      await loadXlsxSheet(workbookBytes, sheetName);
+    } catch (err) {
+      setParseError(String(err));
+    } finally {
+      setParsing(false);
+    }
   };
 
   const handleImport = async () => {
-    if (!csvData) return;
+    if (!sourceData) return;
 
     const mappedCols = Object.entries(columnMap)
       .filter(([, tableCol]) => tableCol)
       .map(([, tableCol]) => tableCol);
 
     if (mappedCols.length === 0) {
-      setImportError("Map at least one CSV column to a table column");
+      setImportError("Map at least one source column to a table column");
       return;
     }
 
-    const csvHeaders = csvData.headers;
+    const headers = sourceData.headers;
     const colIndices = mappedCols.map((tc) => {
-      const csvCol = Object.entries(columnMap).find(([, v]) => v === tc)?.[0];
-      return csvHeaders.indexOf(csvCol!);
+      const sourceCol = Object.entries(columnMap).find(([, v]) => v === tc)?.[0];
+      return headers.indexOf(sourceCol!);
     });
 
-    const rows: unknown[][] = csvData.rows.map((row) =>
-      colIndices.map((idx) => {
-        const val = row[idx] ?? "";
-        if (val === "" || val.toLowerCase() === "null") return null;
-        return val;
-      })
+    // CSV rows always arrive as strings; XLSX rows already carry typed
+    // values from the backend. Preserve those types here so numeric /
+    // boolean / null fidelity flows all the way to `import_data`.
+    const rows: unknown[][] = sourceData.rows.map((row) =>
+      colIndices.map((idx) => normalizeCell(row[idx]))
     );
 
     setImporting(true);
@@ -194,7 +288,12 @@ export function ImportDialog({
     }
   };
 
-  const previewRows = csvData?.rows.slice(0, 10) ?? [];
+  const previewRows = sourceData?.rows.slice(0, 10) ?? [];
+  const inferredFor = (header: string): XlsxColumnType | null => {
+    if (!sourceData?.inferredTypes) return null;
+    const idx = sourceData.headers.indexOf(header);
+    return idx >= 0 ? sourceData.inferredTypes[idx] ?? null : null;
+  };
 
   return (
     <div className="dialog-overlay" onClick={onClose}>
@@ -205,7 +304,7 @@ export function ImportDialog({
         <div className="dialog-header">
           <h2>
             <FileSpreadsheet size={18} />
-            Import CSV
+            Import Data
           </h2>
           <button className="btn-icon" onClick={onClose}>
             <X size={18} />
@@ -223,22 +322,55 @@ export function ImportDialog({
           </div>
 
           <div className="form-group">
-            <label>CSV File</label>
+            <label>Source File</label>
             <div className="import-file-input">
               <input
                 type="file"
-                accept=".csv"
+                accept={ACCEPTED_EXTS.join(",")}
                 onChange={handleFileChange}
                 id="csv-file-input"
               />
               <label htmlFor="csv-file-input" className="import-file-label">
-                {csvFile?.name ?? "Choose a CSV file..."}
+                {sourceFile?.name ?? "Choose a .csv, .xlsx, or .xls file..."}
               </label>
             </div>
+            <p className="import-file-hint">
+              Supported: CSV, Excel (.xlsx, .xls). Max {MAX_FILE_BYTES / 1024 / 1024} MB.
+            </p>
           </div>
+
+          {parsing && (
+            <div className="import-loading">
+              <Loader2 size={16} className="spin" />
+              <span>Parsing file...</span>
+            </div>
+          )}
 
           {parseError && (
             <div className="test-result error">{parseError}</div>
+          )}
+
+          {workbook && workbook.sheet_names.length > 1 && (
+            <div className="form-group">
+              <label>Sheet</label>
+              <select
+                className="import-sheet-select"
+                value={activeSheet ?? workbook.default_sheet}
+                onChange={(e) => handleSheetChange(e.target.value)}
+                disabled={parsing}
+              >
+                {workbook.sheet_names.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+              {sourceData?.totalRows != null && (
+                <p className="import-sheet-meta">
+                  {sourceData.totalRows.toLocaleString()} data rows
+                </p>
+              )}
+            </div>
           )}
 
           {columnsLoading && (
@@ -248,33 +380,43 @@ export function ImportDialog({
             </div>
           )}
 
-          {csvData && !columnsLoading && (
+          {sourceData && !columnsLoading && (
             <>
               <div className="form-group">
                 <label>Column Mapping</label>
                 <div className="import-column-mapping">
-                  {csvData.headers.map((csvCol) => (
-                    <div key={csvCol} className="import-mapping-row">
-                      <span className="import-mapping-csv">{csvCol}</span>
-                      <span className="import-mapping-arrow">→</span>
-                      <select
-                        value={columnMap[csvCol] ?? ""}
-                        onChange={(e) =>
-                          setColumnMap((prev) => ({
-                            ...prev,
-                            [csvCol]: e.target.value,
-                          }))
-                        }
-                      >
-                        <option value="">— Skip —</option>
-                        {tableColumns.map((col) => (
-                          <option key={col.name} value={col.name}>
-                            {col.name} ({col.data_type})
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  ))}
+                  {sourceData.headers.map((sourceCol) => {
+                    const inferred = inferredFor(sourceCol);
+                    return (
+                      <div key={sourceCol} className="import-mapping-row">
+                        <span className="import-mapping-csv">
+                          {sourceCol}
+                          {inferred && (
+                            <span className="import-mapping-type">
+                              {inferred}
+                            </span>
+                          )}
+                        </span>
+                        <span className="import-mapping-arrow">→</span>
+                        <select
+                          value={columnMap[sourceCol] ?? ""}
+                          onChange={(e) =>
+                            setColumnMap((prev) => ({
+                              ...prev,
+                              [sourceCol]: e.target.value,
+                            }))
+                          }
+                        >
+                          <option value="">— Skip —</option>
+                          {tableColumns.map((col) => (
+                            <option key={col.name} value={col.name}>
+                              {col.name} ({col.data_type})
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
 
@@ -284,7 +426,7 @@ export function ImportDialog({
                   <table className="import-preview-table">
                     <thead>
                       <tr>
-                        {csvData.headers.map((h) => (
+                        {sourceData.headers.map((h) => (
                           <th key={h}>{h}</th>
                         ))}
                       </tr>
@@ -292,8 +434,8 @@ export function ImportDialog({
                     <tbody>
                       {previewRows.map((row, i) => (
                         <tr key={i}>
-                          {csvData.headers.map((h, j) => (
-                            <td key={j}>{row[j] ?? ""}</td>
+                          {sourceData.headers.map((_, j) => (
+                            <td key={j}>{formatPreviewCell(row[j])}</td>
                           ))}
                         </tr>
                       ))}
@@ -323,7 +465,7 @@ export function ImportDialog({
           <button
             className="btn-primary"
             onClick={handleImport}
-            disabled={!csvData || importing}
+            disabled={!sourceData || importing}
           >
             {importing && <Loader2 size={14} className="spin" />}
             Import
@@ -332,4 +474,26 @@ export function ImportDialog({
       </div>
     </div>
   );
+}
+
+/// CSV-style "" / "null" sentinel handling that the dialog used to do
+/// inline. XLSX rows already carry real `null` values from calamine,
+/// so the same coercion is a no-op for them. Numeric / boolean values
+/// pass through unchanged so the typed fidelity from #69 isn't lost
+/// at the last mile.
+function normalizeCell(val: unknown): unknown {
+  if (val === null || val === undefined) return null;
+  if (typeof val === "string") {
+    if (val === "") return null;
+    if (val.toLowerCase() === "null") return null;
+    return val;
+  }
+  return val;
+}
+
+function formatPreviewCell(val: unknown): string {
+  if (val === null || val === undefined) return "";
+  if (typeof val === "boolean") return val ? "true" : "false";
+  if (typeof val === "object") return JSON.stringify(val);
+  return String(val);
 }

--- a/src/components/QueryConsole/QueryConsole.tsx
+++ b/src/components/QueryConsole/QueryConsole.tsx
@@ -517,20 +517,21 @@ export function QueryConsole({ connectionId, database }: Props) {
 
   // ── Toolbar actions ──
 
-  const handleExportResult = useCallback(async (format: "csv" | "json" | "sql") => {
+  const handleExportResult = useCallback(async (format: "csv" | "json" | "sql" | "xlsx") => {
     if (!result || !result.is_select) return;
     try {
       const ext = format === "sql" ? "sql" : format;
+      const label = format === "xlsx" ? "Excel" : format.toUpperCase();
       const filePath = await save({
         defaultPath: `query_result.${ext}`,
-        filters: [{ name: format.toUpperCase(), extensions: [ext] }],
+        filters: [{ name: label, extensions: [ext] }],
       });
       if (!filePath) return;
       await api.exportQueryResultToFile({
         columns: result.columns, rows: result.rows as unknown[][],
         format, table_name: null,
       }, filePath);
-      addToast(`Exported query result as ${format.toUpperCase()}`);
+      addToast(`Exported query result as ${label}`);
     } catch (e) {
       addToast(String(e), "error");
     }

--- a/src/components/QueryConsole/ResultTable.tsx
+++ b/src/components/QueryConsole/ResultTable.tsx
@@ -139,7 +139,7 @@ interface Props {
   result: QueryResult;
   resultMode: "results" | "explain" | "chart";
   onToggleChart: () => void;
-  onExport: (format: "csv" | "json" | "sql") => void;
+  onExport: (format: "csv" | "json" | "sql" | "xlsx") => void;
   connectionId: string;
   database: string;
   sourceTable: SourceTable | null;

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  api,
   parseSshHostKeyMismatch,
   SSH_HOST_KEY_MISMATCH_PREFIX,
 } from "./tauri";
@@ -61,5 +62,33 @@ describe("parseSshHostKeyMismatch", () => {
     expect(parseSshHostKeyMismatch(undefined)).toBeNull();
     expect(parseSshHostKeyMismatch(null)).toBeNull();
     expect(parseSshHostKeyMismatch(42)).toBeNull();
+  });
+});
+
+describe("xlsx mock-mode commands", () => {
+  // The dialog renders against these mocks during e2e and during
+  // vitest. Pin the contract so a future mock refactor doesn't quietly
+  // strip a field the dialog reads.
+
+  it("parseXlsxWorkbook returns sheet names + a populated default sheet", async () => {
+    const preview = await api.parseXlsxWorkbook(new Uint8Array([1, 2, 3]));
+    expect(preview.sheet_names.length).toBeGreaterThan(0);
+    expect(preview.default_sheet).toBe(preview.sheet_names[0]);
+    expect(preview.sheet.name).toBe(preview.default_sheet);
+    expect(preview.sheet.headers.length).toBeGreaterThan(0);
+    expect(preview.sheet.inferred_types.length).toBe(
+      preview.sheet.headers.length,
+    );
+  });
+
+  it("parseXlsxSheet echoes the requested sheet name + returns typed rows", async () => {
+    const payload = await api.parseXlsxSheet(new Uint8Array([0]), "Other");
+    expect(payload.name).toBe("Other");
+    expect(payload.headers.length).toBe(payload.inferred_types.length);
+    expect(payload.rows.length).toBeGreaterThan(0);
+    // Type fidelity sanity: numbers stay numbers, bools stay bools.
+    const first = payload.rows[0] as unknown[];
+    expect(typeof first[0]).toBe("number");
+    expect(typeof first[2]).toBe("boolean");
   });
 });

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -162,6 +162,33 @@ async function mockInvoke<T>(cmd: string, args?: Record<string, unknown>): Promi
       }
       return null as T;
     }
+    case "parse_xlsx_workbook":
+      // Two synthetic sheets so the dialog's sheet picker has
+      // something to render in mock mode + e2e.
+      return {
+        sheet_names: ["Sheet1", "Other"],
+        default_sheet: "Sheet1",
+        sheet: {
+          name: "Sheet1",
+          headers: ["id", "name", "active"],
+          preview_rows: [
+            [1, "Alice", true],
+            [2, "Bob", false],
+          ],
+          total_data_rows: 2,
+          inferred_types: ["number", "string", "bool"],
+        },
+      } as T;
+    case "parse_xlsx_sheet":
+      return {
+        name: (args?.sheetName as string) ?? "Sheet1",
+        headers: ["id", "name", "active"],
+        rows: [
+          [1, "Alice", true],
+          [2, "Bob", false],
+        ],
+        inferred_types: ["number", "string", "bool"],
+      } as T;
     default:
       throw new Error(`Unknown mock command: ${cmd}`);
   }
@@ -556,6 +583,45 @@ export interface ImportDataRequest {
   rows: unknown[][];
 }
 
+/**
+ * Per-column type the backend inferred from the parsed sheet's data
+ * rows. Used by the import dialog to display "this column looks like
+ * a date / number / bool / mixed" hints next to the column mapping.
+ * Wire format mirrors `Vec<&'static str>` from `xlsx_import.rs`.
+ */
+export type XlsxColumnType =
+  | "number"
+  | "date"
+  | "bool"
+  | "string"
+  | "mixed";
+
+export interface XlsxSheetPreview {
+  name: string;
+  headers: string[];
+  preview_rows: unknown[][];
+  total_data_rows: number;
+  inferred_types: XlsxColumnType[];
+}
+
+export interface XlsxWorkbookPreview {
+  sheet_names: string[];
+  default_sheet: string;
+  sheet: XlsxSheetPreview;
+}
+
+/**
+ * Full payload for a single sheet returned by `parse_xlsx_sheet` once
+ * the user has chosen which sheet to import. Mirrors the
+ * `XlsxSheetPayload` Rust struct.
+ */
+export interface XlsxSheetPayload {
+  name: string;
+  headers: string[];
+  rows: unknown[][];
+  inferred_types: XlsxColumnType[];
+}
+
 export interface SavedQuery {
   id: string;
   name: string;
@@ -841,6 +907,15 @@ export const api = {
 
   importData: (request: ImportDataRequest): Promise<number> =>
     invoke("import_data", { request }),
+
+  // The backend deserializes Vec<u8> from a JS Array<number>. Tauri's
+  // IPC bridge does the array-of-bytes round-trip transparently —
+  // there's no need for a separate Buffer / base64 step.
+  parseXlsxWorkbook: (bytes: Uint8Array): Promise<XlsxWorkbookPreview> =>
+    invoke("parse_xlsx_workbook", { bytes: Array.from(bytes) }),
+
+  parseXlsxSheet: (bytes: Uint8Array, sheetName: string): Promise<XlsxSheetPayload> =>
+    invoke("parse_xlsx_sheet", { bytes: Array.from(bytes), sheetName }),
 
   loadSavedQueries: (): Promise<SavedQuery[]> =>
     invoke("load_saved_queries"),


### PR DESCRIPTION
## Summary

Closes #69 (Excel `.xlsx` import) and #70 (Excel `.xlsx` export).

XLSX is what users actually open when sharing query results with non-technical stakeholders, and it preserves number / date / boolean types across the round-trip in a way CSV cannot. This PR adds both directions end-to-end with the parsing / generation living in Rust (`rust_xlsxwriter` + `calamine`), so the work happens off the renderer thread and the JS bundle stays lean.

### Export (#70)

- New "Export as Excel" entry in the dropdown alongside CSV / JSON / SQL.
- New `export::to_xlsx` (Rust) writes:
  - numbers as numeric cells
  - booleans as boolean cells
  - ISO-8601 datetime strings as Excel datetimes (`yyyy-mm-dd hh:mm:ss`)
  - nulls as blank cells
- Sheet names are sanitised to Excel's rules (<= 31 chars, no `: \ / ? * [ ]`) and fall back to `"Result"` for query-result exports.
- `worksheet.autofit()` once at the end so columns are sensibly sized on first open without per-cell jank.
- Binary path: `export_table_to_file` and `export_query_result_to_file` switch on `format == "xlsx"` and write bytes straight to disk. The text-IPC variants reject xlsx with a clear error since the binary doesn't round-trip cleanly through a `String`-typed Tauri reply.

### Import (#69)

- Dialog title is now "Import Data" (engine-agnostic).
- File input accepts `.csv`, `.xlsx`, `.xls`.
- Two new Tauri commands backed by `calamine`:
  - `parse_xlsx_workbook(bytes)` -> `{ sheet_names, default_sheet, sheet }` for the sheet picker + first-sheet preview
  - `parse_xlsx_sheet(bytes, sheet_name)` -> `{ name, headers, rows, inferred_types }` for the full payload of the chosen sheet
- Multi-sheet workbooks render a sheet picker; single-sheet workbooks skip it.
- Trailing empty rows / columns are trimmed (acceptance criterion).
- Per-column type hints (`number` / `date` / `bool` / `string` / `mixed`) render as small badges next to the column mapping so users can sanity-check before importing.
- Files larger than 100 MB are rejected client-side before IPC; backend re-validates as defense-in-depth.

Typed values flow straight into the existing `import_data` command (which already accepted `Vec<Vec<serde_json::Value>>`), so XLSX imports get type-faithful inserts without any new plumbing on the driver side.

## Test plan

### Backend

- 12 new unit tests in `export.rs` (xlsx round-trip preserves types, sheet-name sanitization including forbidden chars / multibyte truncation / empty fallback, array+object JSON fallback, ISO datetime parsing).
- 10 new unit tests in `commands/xlsx_import.rs` (workbook preview, picks first sheet as default, preview window caps at 50 rows, unknown-sheet error, oversize payload rejection, malformed bytes, trailing empty rows trimmed, mixed-type detection, date inference, all-null column).
- New `pg_xlsx_round_trip_preserves_types` integration test that encodes -> parses with calamine -> calls `pg_import_data` -> `SELECT`s back, asserting numbers / booleans / nulls / datetimes survive every hop. Runs in the Postgres CI matrix automatically.

### Frontend

- New `ImportDialog.test.tsx` (8 cases): "Import Data" header, accept attribute covers all three extensions, unsupported-extension rejection, oversized-file client-side rejection, column-mapping seed-by-name (case-insensitive), type-hint badges render, sheet picker hidden for 1 sheet / shown for 3+, CSV fallback path doesn't touch xlsx commands.
- `tauri.test.ts` adds contract assertions for the new mock-mode command shapes.

### E2E

- `export.spec.ts`: dropdown shows the new "Export as Excel" entry alongside CSV / JSON / SQL.
- `import.spec.ts`: dialog title is "Import Data" and the file input accept attribute matches `.csv`, `.xlsx`, `.xls`.

### Manual

- [ ] Smoke: export a 100k-row table as xlsx — verify the renderer doesn't freeze.
- [ ] Smoke: import a real-world multi-sheet workbook (analyst export) — pick the second sheet and verify the column mapping + type hints look sane.

## Out of scope (per issue text)

- Excel formulas (we use cached values).
- Charts / pivot tables / conditional formatting on export.
- Multi-sheet exports.