### PR TITLE
docs(readme): refresh feature list to match Q2 landings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Most database GUIs are either bloated, expensive, or locked to a single engine. 
 ## Features
 
 ### Multi-Database Support
-Connect to PostgreSQL, MySQL, MariaDB, SQL Server, CockroachDB, TiDB, SQLite, and Cassandra/ScyllaDB from one application. Each database has a dedicated driver with engine-specific optimizations. Save, organize, and color-code your connections. Supports SSL/TLS with configurable certificate validation and SSH tunnels.
+Connect to PostgreSQL, MySQL, MariaDB, SQL Server, CockroachDB, TiDB, SQLite, and Cassandra/ScyllaDB from one application. Each database has a dedicated driver with engine-specific optimizations. Save, organize, and color-code your connections. Supports SSL/TLS with configurable certificate validation and SSH tunnels with password / identity-file / agent auth, host-key fingerprint confirmation, persistent known-hosts, and `~/.ssh/config` import.
 
 ### Data Browsing and Inline Editing
 - Paginated, sortable, and filterable data grid powered by AG Grid
@@ -60,13 +60,13 @@ Connect to PostgreSQL, MySQL, MariaDB, SQL Server, CockroachDB, TiDB, SQLite, an
 
 ### Server Administration
 - Live activity dashboard with active sessions, locks, and server configuration
-- Query performance statistics from pg_stat_statements
+- Per-query performance statistics for PostgreSQL (`pg_stat_statements`), MySQL/MariaDB (`performance_schema`), SQL Server (`sys.dm_exec_query_stats`), and TiDB (`INFORMATION_SCHEMA.STATEMENTS_SUMMARY`), with engine-specific setup guidance when the source view is unavailable
 - Role management: create, alter, and drop database roles
 - Application resource usage in the status bar
 
 ### Data Import and Export
-- Export to CSV, JSON, or SQL INSERT statements
-- Import data from files
+- Export to CSV, JSON, SQL INSERT statements, or Excel (`.xlsx`) with native type fidelity (numbers, booleans, and ISO-8601 datetimes round-trip)
+- Import from CSV and Excel (`.xlsx`, `.xls`) with multi-sheet picker, per-column type inference, and column mapping
 - Backup and restore databases with cross-connection support
 - Uses native tools (pg_dump, mysqldump) when available
 
@@ -206,7 +206,7 @@ tablio/
 
 | Layer | Stack |
 |-------|-------|
-| Backend | Rust, sqlx, tiberius, scylla, Tokio, Tauri 2 |
+| Backend | Rust, sqlx, tiberius, scylla, russh, rust_xlsxwriter, calamine, Tokio, Tauri 2 |
 | Frontend | React, TypeScript, AG Grid, Monaco Editor, Chart.js |
 | State | Zustand with localStorage persistence |
 | IPC | Tauri invoke commands |


### PR DESCRIPTION
## Summary

The README's Features section had drifted from what's actually in master after this quarter's work landed. Four targeted updates:

- **Query stats**: was "from pg_stat_statements" (single engine); now spells out the four engines covered by PR #88 (PostgreSQL, MySQL/MariaDB, SQL Server, TiDB) and notes the engine-specific setup guidance shown when the source view is unavailable.
- **Export formats**: added Excel (`.xlsx`) with the type-fidelity callout, matching PR #93.
- **Import formats**: was "Import data from files" (vague); now reflects CSV + Excel (.xlsx, .xls) with the multi-sheet picker, per-column type inference, and column mapping that #93 ships.
- **SSH tunnels**: expanded from a one-line mention to call out the four major capabilities (password / identity-file / agent auth, host-key fingerprint confirmation, persistent known-hosts, `~/.ssh/config` import) that landed across #77 + follow-ups.
- **Stack table**: added `russh`, `rust_xlsxwriter`, and `calamine` to the backend crate list so the architecture row matches the dependency tree.

No code changes; docs only.

## Test plan

- [x] Render-checked the markdown locally — list bullets and the stack table still align.
- [x] Cross-referenced every claim against `src-tauri/src/db/{mysql_common,mssql,tidb,postgres}.rs`, `src-tauri/src/export.rs`, `src/components/ImportDialog/ImportDialog.tsx`, and `src-tauri/Cargo.toml` to confirm the new copy reflects what's actually shipped.