### PR TITLE
fix(sidebar): hide trailing border-bottom on last ungrouped .tree-root

### DIFF
--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -506,6 +506,18 @@
   border-bottom: none;
 }
 
+/* The .tree-root border-bottom above is meant as a divider between
+ * consecutive ungrouped connections. The last ungrouped connection
+ * has nothing below it, so the trailing border reads as a stray hr
+ * (especially obvious with a single connection). Drop it.
+ *
+ * Pairs cleanly with #90: once that adds padding-bottom on
+ * .sidebar-content, this rule still does the right thing because
+ * the last child remains border-less either way. */
+.sidebar-content > .tree-root:last-child {
+  border-bottom: none;
+}
+
 .connection-group .tree-root-header > .connection-dot {
   margin-left: 22px;
 }


### PR DESCRIPTION
## Summary

The sidebar shows an orphan horizontal line below the last ungrouped connection — most obvious when there is only one connection in the sidebar, since the line has nothing below it to separate from.

### Cause

\`\`\`91:93:src/components/Sidebar/Sidebar.css
.tree-root {
  border-bottom: 1px solid var(--border);
}
\`\`\`

This rule is intentional — it's a divider between consecutive ungrouped connections. The codebase already cancels it inside groups (\`src/components/Sidebar/Sidebar.css:505\`) but never for the last \`.tree-root\` directly under \`.sidebar-content\`, so a single ungrouped connection (or the last sibling in any list) carries a dangling line.

### Fix

Add a one-rule \`:last-child\` cancellation that mirrors the in-group cancel. The divider behavior between siblings is unchanged — only the trailing line goes away.

This was originally proposed as part of the PR #90 review (https://github.com/dasunNimantha/tablio/pull/90#pullrequestreview-4210943974). Landing it independently because:

- It's a strict improvement on master regardless of #90's status.
- It harmonizes cleanly with #90 when that merges — the rule is still correct after \`.sidebar-content\` gets \`padding-bottom\`.

## Test plan

- [x] Manual: open the sidebar with a single ungrouped connection — orphan hr is gone.
- [x] Manual: add a second ungrouped connection — divider between the two still renders.
- [x] Manual: connections inside a group still render without the divider (existing line 505 rule still applies).