### PR TITLE
fix(ssh): align Windows agent client type with russh 0.60 (pageant::PageantStream)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5851,6 +5851,7 @@ dependencies = [
  "chrono",
  "dirs",
  "log",
+ "pageant",
  "proptest",
  "russh",
  "rust_decimal",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,14 @@ log = "0.4"
 rust_xlsxwriter = { version = "0.94", features = ["chrono"] }
 calamine = { version = "0.34", features = ["dates"] }
 
+# Windows-only direct dep so we can name `pageant::PageantStream` in the
+# return type of `connect_agent()` on Windows. russh 0.60 already pulls
+# pageant 0.2 in transitively (its `AgentClient::connect_pageant()` returns
+# `AgentClient<pageant::PageantStream>`), but doesn't re-export the type, so
+# we declare it explicitly here.
+[target.'cfg(windows)'.dependencies]
+pageant = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
 which = "8"

--- a/src-tauri/src/db/ssh_tunnel.rs
+++ b/src-tauri/src/db/ssh_tunnel.rs
@@ -444,8 +444,7 @@ async fn connect_agent() -> Result<russh::keys::agent::client::AgentClient<tokio
 }
 
 #[cfg(target_os = "windows")]
-async fn connect_agent(
-) -> Result<russh::keys::agent::client::AgentClient<tokio::net::windows::named_pipe::NamedPipeClient>>
+async fn connect_agent() -> Result<russh::keys::agent::client::AgentClient<pageant::PageantStream>>
 {
     russh::keys::agent::client::AgentClient::connect_pageant()
         .await


### PR DESCRIPTION
## What

The Windows release build for v0.4.0 failed with:

\`\`\`
error[E0308]: mismatched types
  --> src/db/ssh_tunnel.rs:450
  expected \`AgentClient<NamedPipeClient>\`, found \`AgentClient<pageant::PageantStream>\`
\`\`\`

\`russh::keys::agent::client::AgentClient::connect_pageant()\` returns \`AgentClient<pageant::PageantStream>\`, but the Windows-only \`connect_agent()\` helper still declared its return as \`AgentClient<tokio::net::windows::named_pipe::NamedPipeClient>\`. Linux/macOS were unaffected because the function lives under \`#[cfg(target_os = "windows")]\`.

## Fix

- Add \`pageant = "0.2"\` as a Windows-only direct dep (\`[target.'cfg(windows)'.dependencies]\`) so we can name \`pageant::PageantStream\` in the signature. \`russh\` already pulls \`pageant 0.2\` in transitively, so Cargo.lock only gains a single line under the \`tablio\` package — no new transitive crates.
- Update the return type to match what \`connect_pageant()\` actually produces.

## Why this didn't get caught earlier

Tablio's PR-time CI builds Linux/macOS but not Windows (release.yml is the only place we cross-compile to windows-latest). The mismatch was introduced when \`russh\` switched its Pageant transport away from raw \`NamedPipeClient\` toward the \`pageant\` crate's stream type, and only surfaced when the v0.4.0 tag triggered the full release matrix.

Filing a follow-up issue to add a windows-latest build job to PR-time CI so this class of regression fails fast on the PR rather than at release time.

## Test plan

- [x] \`cargo fmt\` clean
- [x] \`cargo check\` (Linux) clean — Windows-gated code is excluded
- [ ] CI: full release matrix passes, including \`Build & Release (windows-latest)\`

## Release impact

Once merged, retag \`v0.4.0\` (or cut \`v0.4.1\`) so the release pipeline can rebuild and publish the Windows artifact alongside the already-built macOS + Linux artifacts.