### PR TITLE
chore(system): gate Linux-only CPU sample state to silence non-Linux warnings

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -1,5 +1,7 @@
 use serde::Serialize;
+#[cfg(target_os = "linux")]
 use std::sync::Mutex;
+#[cfg(target_os = "linux")]
 use std::time::{Duration, Instant};
 #[cfg(not(target_os = "linux"))]
 use sysinfo::ProcessRefreshKind;
@@ -23,13 +25,19 @@ pub struct AppResourceUsage {
 /// fell behind on Tauri IPC, the WebKit IPC socket's Recv-Q backed
 /// up, and the entire UI froze — recoverable only by restarting the
 /// app. See `fix/resource-monitor-fd-leak`.
+///
+/// Only the Linux fast path consumes this state; the macOS/Windows
+/// fallback in [`read_cpu_percent`] uses sysinfo's own back-to-back
+/// snapshot mechanism and doesn't carry any cached jiffy count, so we
+/// gate the cache (and its `Duration`/`Instant`/`Mutex` imports) to
+/// `target_os = "linux"` to keep non-Linux builds warning-free.
+#[cfg(target_os = "linux")]
 struct CpuSample {
     /// Last `(now, /proc/self/stat utime+stime in jiffies)` we observed.
-    /// Linux fast path only; other platforms always set this to `None`
-    /// and rely on the sysinfo fallback inside [`read_cpu_percent`].
     last: Option<(Instant, u64)>,
 }
 
+#[cfg(target_os = "linux")]
 static CPU_SAMPLE: std::sync::LazyLock<Mutex<CpuSample>> =
     std::sync::LazyLock::new(|| Mutex::new(CpuSample { last: None }));
 


### PR DESCRIPTION
## What

The macOS and Windows release builds for v0.4.1 were emitting three Rust warnings out of \`src-tauri/src/commands/system.rs\`:

\`\`\`
warning: unused import: \`Duration\`
warning: struct \`CpuSample\` is never constructed
warning: static \`CPU_SAMPLE\` is never used
\`\`\`

## Why

\`Duration\`, \`Instant\`, \`Mutex\`, the \`CpuSample\` struct and the \`CPU_SAMPLE\` static are consumed exclusively from the \`#[cfg(target_os = \"linux\")]\` fast path in \`read_cpu_percent_linux()\` (which diffs \`/proc/self/stat\` jiffies between calls). On macOS and Windows that function falls through to the sysinfo back-to-back snapshot path, which carries no cached state — so the items are dead on those platforms.

## Fix

Gate the imports (\`Duration\`/\`Instant\`/\`Mutex\`), the \`CpuSample\` struct, and the \`CPU_SAMPLE\` static to \`#[cfg(target_os = \"linux\")]\` so they only exist on the platform that uses them.

- Linux behaviour is unchanged (same imports, same cache, same callers).
- macOS/Windows compiles emit zero warnings from this module.

## Test plan

- [x] \`cargo check\` (Linux) clean — 0 warnings
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -- -D warnings\` clean
- [ ] CI: macOS + Windows release builds report 0 warnings from \`system.rs\`

## Release impact

Cosmetic only — no behaviour change. Can ride along in the next patch release or whenever convenient.