### PR TITLE
fix(connection-dialog): grow dialog so the inline form-error banner is fully visible

### DIFF
--- a/src/components/ConnectionDialog.css
+++ b/src/components/ConnectionDialog.css
@@ -25,9 +25,10 @@
   min-width: min(760px, calc(100vw - 32px));
   /* Fixed height so the dialog frame doesn't jump as the user moves
      between sections or toggles SSH options. Sized to fit the tallest
-     section (SSH with identity file) without leaving large empty space
-     below; inner content scrolls when it overflows on small viewports. */
-  height: min(82vh, 640px);
+     section (SSH with identity file) plus the inline form-error banner
+     under it without clipping; inner content scrolls when it overflows
+     on small viewports. */
+  height: min(86vh, 700px);
   overflow: hidden;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Re-opening — original PR #100 was closed when its branch got auto-deleted by a branch-cleanup automation.

## What

In the New Connection dialog, the inline "Please fix the highlighted fields." banner at the bottom of the form was clipped — the user had to scroll inside the content pane to read it.

## Why

The dialog frame is fixed at \`height: min(82vh, 640px)\` so it doesn't jump as the user moves between sections. On the General section that 640 px ceiling was just barely too tight for the section content + the trailing form-error banner, leaving roughly 25–30 px clipped at the bottom of the inner scroll container.

## Fix

Bump the ceiling to \`min(86vh, 700px)\` — enough to fit the tallest section (SSH Tunnel with identity file) plus the inline error banner without scroll. Other sections gain a small amount of breathing room but were already comfortably within bounds.

## Test plan

- [x] General section + error banner: visible without scroll
- [x] Authentication / Security / Advanced: no visual regression
- [x] SSH Tunnel with identity file (the previous ceiling driver): still fits
- [x] Narrow viewport (< 760 px) media query unaffected — that branch only overrides \`width\`/\`max-height\`, both compatible with the new desktop \`height\`