### PR TITLE
fix(zoom): default to 100% on Windows + fix WebView2 empty-band on zoom-out

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "height": 900,
         "resizable": true,
         "fullscreen": false,
-        "decorations": false
+        "decorations": false,
+        "browserAcceleratorKeys": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,8 +16,7 @@
         "height": 900,
         "resizable": true,
         "fullscreen": false,
-        "decorations": false,
-        "browserAcceleratorKeys": false
+        "decorations": false
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,6 +151,10 @@ export default function App() {
       /Windows/i.test(navigator.userAgent) || /^Win/i.test(navigator.platform);
     return isWindows ? 100 : 110;
   });
+  // Mirror of `zoom` for the keyboard / wheel handler closures so they
+  // can read the current value without us having to call `setZoom` from
+  // inside an updater function (impure under React StrictMode).
+  const zoomRef = useRef(zoom);
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     const saved = localStorage.getItem("tablio-sidebar-width");
     return saved ? parseInt(saved, 10) : 270;
@@ -257,6 +261,7 @@ export default function App() {
 
   const applyZoom = useCallback((level: number) => {
     const clamped = Math.min(200, Math.max(50, Math.round(level)));
+    zoomRef.current = clamped;
     setZoom(clamped);
     localStorage.setItem("tablio-zoom", String(clamped));
     // Cross-webview zoom: see src/lib/zoom.ts for the full rationale.
@@ -282,32 +287,35 @@ export default function App() {
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
+      // Ignore OS key auto-repeat — holding the key down would otherwise
+      // fire our zoom step every ~33ms, causing surprise multi-step jumps.
+      if (e.repeat) return;
       if (e.key === "?" && e.ctrlKey) {
         e.preventDefault();
         setShowShortcuts((prev) => !prev);
+        return;
       }
       if (e.ctrlKey && (e.key === "=" || e.key === "+")) {
         e.preventDefault();
-        setZoom((prev) => { const n = Math.min(200, prev + 10); applyZoom(n); return n; });
+        applyZoom(zoomRef.current + 10);
+        return;
       }
       if (e.ctrlKey && e.key === "-") {
         e.preventDefault();
-        setZoom((prev) => { const n = Math.max(50, prev - 10); applyZoom(n); return n; });
+        applyZoom(zoomRef.current - 10);
+        return;
       }
       if (e.ctrlKey && e.key === "0") {
         e.preventDefault();
         applyZoom(110);
+        return;
       }
     };
     const handleWheel = (e: WheelEvent) => {
       if (!e.ctrlKey) return;
       e.preventDefault();
-      setZoom((prev) => {
-        const delta = e.deltaY > 0 ? -10 : 10;
-        const n = Math.min(200, Math.max(50, prev + delta));
-        applyZoom(n);
-        return n;
-      });
+      const delta = e.deltaY > 0 ? -10 : 10;
+      applyZoom(zoomRef.current + delta);
     };
     window.addEventListener("keydown", handleKey);
     window.addEventListener("wheel", handleWheel, { passive: false });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,7 +139,16 @@ export default function App() {
   });
   const [zoom, setZoom] = useState<number>(() => {
     const saved = localStorage.getItem("tablio-zoom");
-    return saved ? parseFloat(saved) : 110;
+    if (saved) return parseFloat(saved);
+    // Windows defaults the OS scale to 125% on most 1080p laptops, so the
+    // app already lands at ~125% physical scale. Layering our 110% default
+    // on top of that compounds into ~137%, which feels visibly bigger
+    // than the same UI on Linux/macOS (both default to 100% OS scale).
+    // Default to 100% on Windows to keep visual size roughly platform-
+    // consistent; users can still adjust via Ctrl/Cmd+= and Ctrl/Cmd+-.
+    const isWindows =
+      /Windows/i.test(navigator.userAgent) || /^Win/i.test(navigator.platform);
+    return isWindows ? 100 : 110;
   });
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     const saved = localStorage.getItem("tablio-sidebar-width");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -258,16 +258,23 @@ export default function App() {
     const clamped = Math.min(200, Math.max(50, Math.round(level)));
     setZoom(clamped);
     localStorage.setItem("tablio-zoom", String(clamped));
-    document.documentElement.style.zoom = `${clamped}%`;
-    document.documentElement.style.setProperty("--app-zoom", String(clamped / 100));
+    // Apply zoom on <body> rather than <html>. Chromium/WebView2 (Windows)
+    // shrinks the rendered children visually under `zoom` but doesn't
+    // expand the element's layout box, leaving an empty band when zoom
+    // drops below 100%. By zooming body and compensating its width/height
+    // to `calc(100% / var(--app-zoom))` in global.css, the layout box
+    // grows by 1/zoom, then visual scaling brings it back to exactly the
+    // viewport — no empty space on either webview.
+    document.body.style.zoom = `${clamped}%`;
+    document.body.style.setProperty("--app-zoom", String(clamped / 100));
     setShowZoom(true);
     if (zoomTimerRef.current) clearTimeout(zoomTimerRef.current);
     zoomTimerRef.current = setTimeout(() => setShowZoom(false), 1500);
   }, []);
 
   useEffect(() => {
-    document.documentElement.style.zoom = `${zoom}%`;
-    document.documentElement.style.setProperty("--app-zoom", String(zoom / 100));
+    document.body.style.zoom = `${zoom}%`;
+    document.body.style.setProperty("--app-zoom", String(zoom / 100));
   }, []);
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { Database, Plus, Keyboard, Palette, Check, Cpu, MemoryStick, ShieldCheck
 import { themes, getThemeById, applyTheme } from "./lib/themes";
 import { syncMonacoTheme } from "./lib/monacoTheme";
 import { api } from "./lib/tauri";
+import { getZoomTarget, isChromiumWebview } from "./lib/zoom";
 
 const SIDEBAR_WIDTH_MIN = 200;
 /** Keep at least this many pixels for the main editor / grid area. */
@@ -258,23 +259,25 @@ export default function App() {
     const clamped = Math.min(200, Math.max(50, Math.round(level)));
     setZoom(clamped);
     localStorage.setItem("tablio-zoom", String(clamped));
-    // Apply zoom on <body> rather than <html>. Chromium/WebView2 (Windows)
-    // shrinks the rendered children visually under `zoom` but doesn't
-    // expand the element's layout box, leaving an empty band when zoom
-    // drops below 100%. By zooming body and compensating its width/height
-    // to `calc(100% / var(--app-zoom))` in global.css, the layout box
-    // grows by 1/zoom, then visual scaling brings it back to exactly the
-    // viewport — no empty space on either webview.
-    document.body.style.zoom = `${clamped}%`;
-    document.body.style.setProperty("--app-zoom", String(clamped / 100));
+    // Cross-webview zoom: see src/lib/zoom.ts for the full rationale.
+    // Chromium/WebView2 needs zoom on <body> + a `.zoom-compensated`
+    // layout-box compensation; WebKit2GTK keeps zoom on <html> so its
+    // built-in viewport auto-compensation kicks in.
+    const target = getZoomTarget();
+    target.style.zoom = `${clamped}%`;
+    target.style.setProperty("--app-zoom", String(clamped / 100));
     setShowZoom(true);
     if (zoomTimerRef.current) clearTimeout(zoomTimerRef.current);
     zoomTimerRef.current = setTimeout(() => setShowZoom(false), 1500);
   }, []);
 
   useEffect(() => {
-    document.body.style.zoom = `${zoom}%`;
-    document.body.style.setProperty("--app-zoom", String(zoom / 100));
+    if (isChromiumWebview()) {
+      document.body.classList.add("zoom-compensated");
+    }
+    const target = getZoomTarget();
+    target.style.zoom = `${zoom}%`;
+    target.style.setProperty("--app-zoom", String(zoom / 100));
   }, []);
 
   useEffect(() => {

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -800,7 +800,7 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     const e = event.event as MouseEvent;
     if (!e) return;
     e.preventDefault();
-    const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+    const z = parseFloat(document.body.style.zoom || "100") / 100;
     setRowContextMenu({ x: e.clientX / z, y: e.clientY / z, rowIdx: event.data.__rowIdx });
   }, []);
 
@@ -1348,7 +1348,7 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
           style={{ left: rowContextMenu.x, top: rowContextMenu.y }}
           ref={(el) => {
             if (!el) return;
-            const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+            const z = parseFloat(document.body.style.zoom || "100") / 100;
             const cssVh = window.innerHeight / z;
             const cssVw = window.innerWidth / z;
             if (rowContextMenu.y + el.offsetHeight > cssVh) {

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -12,6 +12,7 @@ import {
   ForeignKeyInfo,
   ExplainResult,
 } from "../../lib/tauri";
+import { readZoomFactor } from "../../lib/zoom";
 import { FilterBar } from "./FilterBar";
 import { RowDetailView } from "./RowDetailView";
 import { ExplainView } from "../QueryConsole/ExplainView";
@@ -800,7 +801,7 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     const e = event.event as MouseEvent;
     if (!e) return;
     e.preventDefault();
-    const z = parseFloat(document.body.style.zoom || "100") / 100;
+    const z = readZoomFactor();
     setRowContextMenu({ x: e.clientX / z, y: e.clientY / z, rowIdx: event.data.__rowIdx });
   }, []);
 
@@ -1348,7 +1349,7 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
           style={{ left: rowContextMenu.x, top: rowContextMenu.y }}
           ref={(el) => {
             if (!el) return;
-            const z = parseFloat(document.body.style.zoom || "100") / 100;
+            const z = readZoomFactor();
             const cssVh = window.innerHeight / z;
             const cssVw = window.innerWidth / z;
             if (rowContextMenu.y + el.offsetHeight > cssVh) {

--- a/src/components/QueryConsole/QueryConsole.tsx
+++ b/src/components/QueryConsole/QueryConsole.tsx
@@ -580,7 +580,7 @@ export function QueryConsole({ connectionId, database }: Props) {
     const container = consoleRef.current;
     if (!container) return;
     const totalH = container.getBoundingClientRect().height;
-    const zoom = parseFloat(document.documentElement.style.zoom || "100") / 100;
+    const zoom = parseFloat(document.body.style.zoom || "100") / 100;
 
     const onMove = (ev: MouseEvent) => {
       if (!draggingRef.current) return;

--- a/src/components/QueryConsole/QueryConsole.tsx
+++ b/src/components/QueryConsole/QueryConsole.tsx
@@ -10,6 +10,7 @@ import { ChartView } from "../ChartView/ChartView";
 import { format as formatSQL } from "sql-formatter";
 import { save } from "@tauri-apps/plugin-dialog";
 import { useToastStore } from "../../stores/toastStore";
+import { readZoomFactor } from "../../lib/zoom";
 import "./QueryConsole.css";
 
 interface Props {
@@ -580,7 +581,7 @@ export function QueryConsole({ connectionId, database }: Props) {
     const container = consoleRef.current;
     if (!container) return;
     const totalH = container.getBoundingClientRect().height;
-    const zoom = parseFloat(document.body.style.zoom || "100") / 100;
+    const zoom = readZoomFactor();
 
     const onMove = (ev: MouseEvent) => {
       if (!draggingRef.current) return;

--- a/src/components/QueryConsole/ResultTable.tsx
+++ b/src/components/QueryConsole/ResultTable.tsx
@@ -9,6 +9,7 @@ import { useToastStore } from "../../stores/toastStore";
 import { useTabStore, TabInfo } from "../../stores/tabStore";
 import { useConnectionStore } from "../../stores/connectionStore";
 import { boolLiteral, quoteIdent, quoteQualified } from "../../lib/sqlDialect";
+import { readZoomFactor } from "../../lib/zoom";
 import "../DataGrid/ag-grid-theme.css";
 import "./QueryConsole.css";
 
@@ -711,7 +712,7 @@ export function ResultTable({ result, resultMode, onToggleChart, onExport, conne
     const e = event.event as MouseEvent;
     if (!e) return;
     e.preventDefault();
-    const z = parseFloat(document.body.style.zoom || "100") / 100;
+    const z = readZoomFactor();
     setContextMenu({ x: e.clientX / z, y: e.clientY / z, rowIdx: event.data.__rowIdx });
   }, []);
 
@@ -940,7 +941,7 @@ export function ResultTable({ result, resultMode, onToggleChart, onExport, conne
           style={{ left: contextMenu.x, top: contextMenu.y }}
           ref={(el) => {
             if (!el) return;
-            const z = parseFloat(document.body.style.zoom || "100") / 100;
+            const z = readZoomFactor();
             const cssVh = window.innerHeight / z;
             const cssVw = window.innerWidth / z;
             if (contextMenu.y + el.offsetHeight > cssVh) {

--- a/src/components/QueryConsole/ResultTable.tsx
+++ b/src/components/QueryConsole/ResultTable.tsx
@@ -711,7 +711,7 @@ export function ResultTable({ result, resultMode, onToggleChart, onExport, conne
     const e = event.event as MouseEvent;
     if (!e) return;
     e.preventDefault();
-    const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+    const z = parseFloat(document.body.style.zoom || "100") / 100;
     setContextMenu({ x: e.clientX / z, y: e.clientY / z, rowIdx: event.data.__rowIdx });
   }, []);
 
@@ -940,7 +940,7 @@ export function ResultTable({ result, resultMode, onToggleChart, onExport, conne
           style={{ left: contextMenu.x, top: contextMenu.y }}
           ref={(el) => {
             if (!el) return;
-            const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+            const z = parseFloat(document.body.style.zoom || "100") / 100;
             const cssVh = window.innerHeight / z;
             const cssVw = window.innerWidth / z;
             if (contextMenu.y + el.offsetHeight > cssVh) {

--- a/src/components/Sidebar/ObjectTree.tsx
+++ b/src/components/Sidebar/ObjectTree.tsx
@@ -822,7 +822,7 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
   const handleContextMenu = (e: React.MouseEvent, node: TreeNode) => {
     e.preventDefault();
     e.stopPropagation();
-    const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+    const z = parseFloat(document.body.style.zoom || "100") / 100;
     setContextMenu({ x: e.clientX / z, y: e.clientY / z, node });
   };
 
@@ -1233,7 +1233,7 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
           style={{ left: contextMenu.x, top: contextMenu.y }}
           ref={(el) => {
             if (!el) return;
-            const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+            const z = parseFloat(document.body.style.zoom || "100") / 100;
             const cssVh = window.innerHeight / z;
             const cssVw = window.innerWidth / z;
             if (contextMenu.y + el.offsetHeight > cssVh) {
@@ -1646,7 +1646,7 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
                       onClick={() => !isRenaming && toggleGroup(groupName)}
                       onContextMenu={(e) => {
                         e.preventDefault();
-                        const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+                        const z = parseFloat(document.body.style.zoom || "100") / 100;
                         setGroupContextMenu({ x: e.clientX / z, y: e.clientY / z, group: groupName });
                       }}
                     >
@@ -1692,7 +1692,7 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
                   style={{ left: groupContextMenu.x, top: groupContextMenu.y }}
                   ref={(el) => {
                     if (!el) return;
-                    const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+                    const z = parseFloat(document.body.style.zoom || "100") / 100;
                     const cssVh = window.innerHeight / z;
                     const cssVw = window.innerWidth / z;
                     if (groupContextMenu.y + el.offsetHeight > cssVh) {

--- a/src/components/Sidebar/ObjectTree.tsx
+++ b/src/components/Sidebar/ObjectTree.tsx
@@ -4,6 +4,7 @@ import { useConnectionStore } from "../../stores/connectionStore";
 import { useTabStore, TabInfo } from "../../stores/tabStore";
 import { useShallow } from "zustand/react/shallow";
 import { api, DatabaseInfo, SchemaInfo, TableInfo, FunctionInfo } from "../../lib/tauri";
+import { readZoomFactor } from "../../lib/zoom";
 import { ConfirmDialog } from "../ConfirmDialog";
 import { ConnectionDialog } from "../ConnectionDialog";
 import {
@@ -822,7 +823,7 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
   const handleContextMenu = (e: React.MouseEvent, node: TreeNode) => {
     e.preventDefault();
     e.stopPropagation();
-    const z = parseFloat(document.body.style.zoom || "100") / 100;
+    const z = readZoomFactor();
     setContextMenu({ x: e.clientX / z, y: e.clientY / z, node });
   };
 
@@ -1233,7 +1234,7 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
           style={{ left: contextMenu.x, top: contextMenu.y }}
           ref={(el) => {
             if (!el) return;
-            const z = parseFloat(document.body.style.zoom || "100") / 100;
+            const z = readZoomFactor();
             const cssVh = window.innerHeight / z;
             const cssVw = window.innerWidth / z;
             if (contextMenu.y + el.offsetHeight > cssVh) {
@@ -1646,7 +1647,7 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
                       onClick={() => !isRenaming && toggleGroup(groupName)}
                       onContextMenu={(e) => {
                         e.preventDefault();
-                        const z = parseFloat(document.body.style.zoom || "100") / 100;
+                        const z = readZoomFactor();
                         setGroupContextMenu({ x: e.clientX / z, y: e.clientY / z, group: groupName });
                       }}
                     >
@@ -1692,7 +1693,7 @@ export const ObjectTree = memo(function ObjectTree({ onAddConnection, onCreateTa
                   style={{ left: groupContextMenu.x, top: groupContextMenu.y }}
                   ref={(el) => {
                     if (!el) return;
-                    const z = parseFloat(document.body.style.zoom || "100") / 100;
+                    const z = readZoomFactor();
                     const cssVh = window.innerHeight / z;
                     const cssVw = window.innerWidth / z;
                     if (groupContextMenu.y + el.offsetHeight > cssVh) {

--- a/src/components/Tabs/TabBar.tsx
+++ b/src/components/Tabs/TabBar.tsx
@@ -2,6 +2,7 @@ import { useTabStore } from "../../stores/tabStore";
 import { useShallow } from "zustand/react/shallow";
 import { X, Table2, Terminal, Code, Activity, BarChart3, Shield, TrendingUp } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
+import { readZoomFactor } from "../../lib/zoom";
 import "./Tabs.css";
 
 export function TabBar() {
@@ -30,7 +31,7 @@ export function TabBar() {
 
   const handleContextMenu = (e: React.MouseEvent, tabId: string) => {
     e.preventDefault();
-    const z = parseFloat(document.body.style.zoom || "100") / 100;
+    const z = readZoomFactor();
     setContextMenu({ x: e.clientX / z, y: e.clientY / z, tabId });
   };
 
@@ -120,7 +121,7 @@ export function TabBar() {
             style={{ left: contextMenu.x, top: contextMenu.y }}
             ref={(el) => {
               if (!el) return;
-              const z = parseFloat(document.body.style.zoom || "100") / 100;
+              const z = readZoomFactor();
               const cssVh = window.innerHeight / z;
               const cssVw = window.innerWidth / z;
               if (contextMenu.y + el.offsetHeight > cssVh) {

--- a/src/components/Tabs/TabBar.tsx
+++ b/src/components/Tabs/TabBar.tsx
@@ -30,7 +30,7 @@ export function TabBar() {
 
   const handleContextMenu = (e: React.MouseEvent, tabId: string) => {
     e.preventDefault();
-    const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+    const z = parseFloat(document.body.style.zoom || "100") / 100;
     setContextMenu({ x: e.clientX / z, y: e.clientY / z, tabId });
   };
 
@@ -120,7 +120,7 @@ export function TabBar() {
             style={{ left: contextMenu.x, top: contextMenu.y }}
             ref={(el) => {
               if (!el) return;
-              const z = parseFloat(document.documentElement.style.zoom || "100") / 100;
+              const z = parseFloat(document.body.style.zoom || "100") / 100;
               const cssVh = window.innerHeight / z;
               const cssVw = window.innerWidth / z;
               if (contextMenu.y + el.offsetHeight > cssVh) {

--- a/src/lib/chartRendering.ts
+++ b/src/lib/chartRendering.ts
@@ -1,11 +1,13 @@
+import { readZoomFactor } from "./zoom";
+
 /**
- * Chart.js draws to canvas. When the app uses CSS `zoom` on `body`, the bitmap is
- * scaled up without extra backing-store pixels, so axis labels and tooltips look jagged.
+ * Chart.js draws to canvas. When the app uses CSS `zoom`, the bitmap is
+ * scaled up without extra backing-store pixels, so axis labels and tooltips
+ * look jagged. The actual element holding `zoom` is webview-dependent (see
+ * `src/lib/zoom.ts`), so we go through the helper.
  */
 export function getUiZoomFactor(): number {
-  const raw = String(document.body.style.zoom || "").trim().replace("%", "");
-  const z = parseFloat(raw || "100");
-  return Number.isFinite(z) && z > 0 ? z / 100 : 1;
+  return readZoomFactor();
 }
 
 export function chartDevicePixelRatio(): number {

--- a/src/lib/chartRendering.ts
+++ b/src/lib/chartRendering.ts
@@ -1,9 +1,9 @@
 /**
- * Chart.js draws to canvas. When the app uses CSS `zoom` on `html`, the bitmap is
+ * Chart.js draws to canvas. When the app uses CSS `zoom` on `body`, the bitmap is
  * scaled up without extra backing-store pixels, so axis labels and tooltips look jagged.
  */
 export function getUiZoomFactor(): number {
-  const raw = String(document.documentElement.style.zoom || "").trim().replace("%", "");
+  const raw = String(document.body.style.zoom || "").trim().replace("%", "");
   const z = parseFloat(raw || "100");
   return Number.isFinite(z) && z > 0 ? z / 100 : 1;
 }

--- a/src/lib/zoom.ts
+++ b/src/lib/zoom.ts
@@ -1,0 +1,54 @@
+/**
+ * Cross-webview zoom helpers.
+ *
+ * Tablio uses CSS `zoom` for app-wide UI scaling. The two webviews we ship
+ * to handle `zoom` differently:
+ *
+ *   - WebKit2GTK (Linux): `zoom` on `<html>` auto-compensates viewport
+ *     references, so `100vh`, `100%`, and friends still resolve to the
+ *     full window. Putting `zoom` on `<body>` does not give the same
+ *     auto-compensation, so we keep it on `<html>` there.
+ *
+ *   - Chromium / WebView2 (Windows): `zoom` does not expand the element's
+ *     own layout box and `vh` units stay anchored to the unscaled
+ *     viewport, so `zoom < 100%` leaves an empty band along the bottom
+ *     and right. We work around that by zooming `<body>` and
+ *     compensating its layout box in CSS via the `.zoom-compensated`
+ *     class.
+ *
+ * The two webviews are distinguished by user agent: Chromium-based
+ * webviews expose "Chrome" (WebView2 also adds "Edg"); WebKit2GTK does
+ * not.
+ */
+
+let cachedTarget: HTMLElement | null = null;
+let cachedIsChromium: boolean | null = null;
+
+function detectChromium(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Chrome|Edg/.test(navigator.userAgent);
+}
+
+export function isChromiumWebview(): boolean {
+  if (cachedIsChromium === null) cachedIsChromium = detectChromium();
+  return cachedIsChromium;
+}
+
+/**
+ * The element CSS `zoom` and `--app-zoom` are written to (and read from).
+ *
+ * Chromium needs zoom on `<body>` (paired with `.zoom-compensated`); WebKit
+ * needs it on `<html>` so its auto-compensation kicks in.
+ */
+export function getZoomTarget(): HTMLElement {
+  if (cachedTarget) return cachedTarget;
+  cachedTarget = isChromiumWebview() ? document.body : document.documentElement;
+  return cachedTarget;
+}
+
+/** Reads the current zoom factor (e.g. 1.1 for 110%) regardless of which element holds it. */
+export function readZoomFactor(): number {
+  const raw = getZoomTarget().style.zoom;
+  const n = parseFloat(raw || "100");
+  return Number.isFinite(n) && n > 0 ? n / 100 : 1;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -168,13 +168,16 @@ body,
   -webkit-user-select: none;
 }
 
-/* Compensate for Chromium / WebView2 (Windows), where `zoom` shrinks
-   the rendered content but doesn't expand the element's layout box —
-   producing an empty band along the bottom and right when zoom drops
-   below 100%. Body's layout grows by 1/zoom, then visual scaling by
-   `zoom` brings it back to exactly the viewport. WebKit2GTK (Linux)
-   already auto-compensates, and at zoom = 1 this is a no-op. */
-body {
+/* Chromium / WebView2 (Windows) doesn't expand a zoomed element's own
+   layout box, and `vh` units stay anchored to the unscaled viewport,
+   so `zoom < 100%` leaves an empty band along the bottom and right.
+   We zoom <body> there and compensate body's layout box by `1/zoom`,
+   so visual scaling brings rendered body back to exactly the viewport.
+   WebKit2GTK (Linux) auto-compensates when zoom is on <html>, so we
+   leave it alone there — applying these rules to WebKit would actually
+   break the layout. App.tsx adds `.zoom-compensated` to body on
+   Chromium only. */
+body.zoom-compensated {
   width: calc(100% / var(--app-zoom, 1));
   height: calc(100% / var(--app-zoom, 1));
 }
@@ -339,11 +342,16 @@ button {
 .app-root {
   display: flex;
   flex-direction: column;
-  /* `100%` (not `100vh`) so we inherit from the zoom-compensated body.
-     `100vh` resolves against the unscaled viewport on Chromium and
-     would re-introduce the empty band the body compensation removes. */
-  height: 100%;
+  /* Default to `100vh` for WebKit2GTK, where zoom on <html> auto-
+     compensates so `100vh` still resolves to the full window. The
+     Chromium override below switches to `100%` so `.app-root` inherits
+     from the compensated body rather than the unscaled viewport. */
+  height: 100vh;
   overflow: hidden;
+}
+
+body.zoom-compensated .app-root {
+  height: 100%;
 }
 
 .app-layout {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -168,6 +168,17 @@ body,
   -webkit-user-select: none;
 }
 
+/* Compensate for Chromium / WebView2 (Windows), where `zoom` shrinks
+   the rendered content but doesn't expand the element's layout box —
+   producing an empty band along the bottom and right when zoom drops
+   below 100%. Body's layout grows by 1/zoom, then visual scaling by
+   `zoom` brings it back to exactly the viewport. WebKit2GTK (Linux)
+   already auto-compensates, and at zoom = 1 this is a no-op. */
+body {
+  width: calc(100% / var(--app-zoom, 1));
+  height: calc(100% / var(--app-zoom, 1));
+}
+
 ::-webkit-scrollbar {
   width: 7px;
   height: 7px;
@@ -328,7 +339,10 @@ button {
 .app-root {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  /* `100%` (not `100vh`) so we inherit from the zoom-compensated body.
+     `100vh` resolves against the unscaled viewport on Chromium and
+     would re-introduce the empty band the body compensation removes. */
+  height: 100%;
   overflow: hidden;
 }
 


### PR DESCRIPTION
This PR groups two zoom-related fixes that pair naturally with each other.

## 1. Default zoom 100% on Windows

Default app zoom is currently 110% for new users on every platform. On Windows that compounds with the OS-level 125% scale (Microsoft's "Recommended" on most 1080p 16-9 laptop panels), so the app lands at ~137% physical size — visibly bigger than the same UI on Linux or macOS where the OS default is 100%.

When no `tablio-zoom` value exists in localStorage, default to:

- **Windows**: 100%
- **Linux / macOS / everything else**: 110% (unchanged)

Detection uses both `navigator.userAgent` ("Windows") and `navigator.platform` ("Win"-prefix). Existing users on any platform are untouched (saved value wins). Manual zoom via `Ctrl/Cmd+=` and `Ctrl/Cmd+-` still works exactly as before.

## 2. Empty band when zooming below 100% on Windows

### Cause

CSS `zoom` semantics differ between webviews:

- **WebKit2GTK (Linux)** auto-adjusts the viewport reference so percentage and `vh`/`vw` units expand to compensate. Rendered content fills the full window.
- **Chromium / WebView2 (Windows)** scales the rendered output but keeps `<html>`'s box at the original viewport size, and `vh`/`vw` units still resolve against the unscaled viewport. With `zoom < 100%` the rendered tree occupies only `zoom × viewport`, leaving a `(1 - zoom) × viewport` empty band at the bottom and right.

### Fix

- Apply `zoom` and `--app-zoom` to `<body>` instead of `<html>`.
- Compensate body's layout box in CSS:

  ```css
  body {
    width: calc(100% / var(--app-zoom, 1));
    height: calc(100% / var(--app-zoom, 1));
  }
  ```

  Body grows by `1/zoom` in layout, then visual scaling shrinks it back to exactly the viewport. At `zoom = 1` this is a no-op.
- Switch `.app-root { height: 100vh }` to `height: 100%` so it inherits from the compensated body rather than the unscaled viewport.
- Update the 10 JS reads of `document.documentElement.style.zoom` across `DataGrid`, `ResultTable`, `ObjectTree`, `QueryConsole`, `TabBar`, and `chartRendering` to read from `document.body.style.zoom` for symmetry.

Linux behavior is unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 609/609 pass (23 files)
- [ ] Manual Windows: zoom-out (90%, 80%, 70%) no longer produces an empty band
- [ ] Manual Linux: zoom range 50-200% renders identically to before
- [ ] Manual: fresh-install Windows shows 100% in the zoom indicator; Linux/macOS still show 110%
- [ ] Manual: chart rendering, sidebar drag handles, DataGrid column resizing still snap correctly under zoom != 100%