### PR TITLE
fix(zoom): stop shrinking body below viewport on Chromium zoom-in (Windows)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -168,18 +168,25 @@ body,
   -webkit-user-select: none;
 }
 
-/* Chromium / WebView2 (Windows) doesn't expand a zoomed element's own
-   layout box, and `vh` units stay anchored to the unscaled viewport,
-   so `zoom < 100%` leaves an empty band along the bottom and right.
-   We zoom <body> there and compensate body's layout box by `1/zoom`,
-   so visual scaling brings rendered body back to exactly the viewport.
-   WebKit2GTK (Linux) auto-compensates when zoom is on <html>, so we
-   leave it alone there — applying these rules to WebKit would actually
-   break the layout. App.tsx adds `.zoom-compensated` to body on
-   Chromium only. */
+/* Chromium / WebView2 (Windows) doesn't grow body's own layout box
+   when `zoom` is applied to it — only its descendants get scaled,
+   `vh` units stay anchored to the unscaled viewport, and `100%` on
+   body keeps resolving against html's CSS dimensions. So `zoom < 100%`
+   leaves an empty band along the bottom and right (body painted
+   smaller than viewport).
+   At `zoom < 100%` we expand body by `1/zoom` so the painted box
+   covers the viewport. At `zoom >= 100%` we *don't* shrink body
+   (which would re-introduce the same band on the other side); we
+   pin it to 100% and let zoomed-up descendants overflow body's box,
+   which is clipped by `body { overflow: hidden }`. `max()` covers
+   both regimes in one rule.
+   WebKit2GTK (Linux) auto-compensates when zoom is on <html>, so
+   we leave it alone there — applying these rules to WebKit would
+   actually break the layout. App.tsx adds `.zoom-compensated` to
+   body on Chromium only. */
 body.zoom-compensated {
-  width: calc(100% / var(--app-zoom, 1));
-  height: calc(100% / var(--app-zoom, 1));
+  width: max(100%, calc(100% / var(--app-zoom, 1)));
+  height: max(100%, calc(100% / var(--app-zoom, 1)));
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

At any zoom > 100% on Windows, the app left an empty band along the bottom (and a thin one on the right). The band's height is `(zoom − 1) / zoom` of the viewport (~16.7% at 120%, ~33.3% at 150%) — exactly what we'd expect if body's painted box is being held to `100% / zoom` of html instead of being grown back to viewport size.

The v0.4.x compensation (`body { width: 100% / zoom; height: 100% / zoom }`) was tuned for zoom-OUT, where body needs to be *larger* than the viewport so that visual scaling brings the painted box back to viewport size. WebView2/Chromium's `zoom` doesn't grow the zoomed element's own layout box — only its descendants — so on zoom-IN the same formula instead pushes body *below* viewport size, producing the empty band.

Fix: clamp the compensation with `max(100%, …)` so body never shrinks below 100% of html.

| zoom | `100% / zoom` | `max(100%, …)` | result                           |
| ---- | ------------- | -------------- | -------------------------------- |
| 0.5  | 200%          | 200%           | body grown, clipped to viewport  |
| 1.0  | 100%          | 100%           | identity                         |
| 1.2  | 83.3%         | 100%           | body pinned to viewport          |
| 1.5  | 66.6%         | 100%           | body pinned to viewport          |

At zoom > 1, descendants render larger than body's box and get clipped by `body { overflow: hidden }`. That matches the expected "see less, bigger" semantics of zoom-in instead of leaking html's background through.

WebKit2GTK is unaffected — `.zoom-compensated` is only added to body on Chromium (see `App.tsx` + `src/lib/zoom.ts`).

## Test plan

- [ ] Linux (WebKit2GTK): zoom 50%, 100%, 110%, 150% all fill the viewport (regression check).
- [ ] Windows (WebView2): zoom 50%, 100%, 110%, 120%, 150% all fill the viewport (no empty band on the bottom or right).
- [ ] On Windows at zoom 150%, the status bar stays at the bottom of the visible window.
- [ ] `npx tsc --noEmit` clean.
- [ ] `npm run test` clean (609/609 currently).