### PR TITLE
fix(cassandra): empty "Tables" folder in sidebar; surface materialized views

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,13 +628,19 @@ jobs:
 
       - name: Start Cassandra (with materialized views enabled)
         env:
-          # The MV-enablement property was renamed mid-lifecycle:
-          #   - Cassandra 4.0 / 4.1: `enable_materialized_views`
-          #   - Cassandra 5.0+:      `materialized_views_enabled`
-          # Cassandra rejects the *other* name as unknown at boot,
-          # so we must pass exactly the right one. Pick it from
-          # the matrix version.
-          MV_SETTING: ${{ startsWith(matrix.cassandra_version, '4.') && 'enable_materialized_views' || 'materialized_views_enabled' }}
+          # The MV-enablement property was renamed during the 4.x
+          # cycle, and 4.1 is a transition release that knows BOTH
+          # names and refuses to start if both are present and
+          # active in the same `cassandra.yaml`:
+          #
+          #   - Cassandra 4.0:         only `enable_materialized_views`
+          #   - Cassandra 4.1 + 5.0+:  use `materialized_views_enabled`
+          #     (4.1's startup check emits
+          #      "migrate old -> new: [enable_materialized_views ->
+          #      materialized_views_enabled]" if you write the old name)
+          #
+          # 4.0 is the only matrix entry that must use the old name.
+          MV_SETTING: ${{ matrix.cassandra_version == '4.0' && 'enable_materialized_views' || 'materialized_views_enabled' }}
         run: |
           docker run -d --name cassandra-ci \
             -p 9042:9042 \
@@ -643,14 +649,25 @@ jobs:
             --entrypoint bash \
             cassandra:${{ matrix.cassandra_version }} \
             -c '
+              # Strip the OTHER form first. Cassandra 4.1 ships
+              # both names in its default yaml as a transition aid
+              # and rejects boot if both are active. By deleting
+              # the form we are not writing, we guarantee exactly
+              # one MV setting reaches the server.
+              case "$MV_SETTING" in
+                enable_materialized_views) OTHER=materialized_views_enabled ;;
+                materialized_views_enabled) OTHER=enable_materialized_views ;;
+              esac
+
               for conf in /etc/cassandra/cassandra.yaml /opt/cassandra/conf/cassandra.yaml; do
                 [ -f "$conf" ] || continue
-                # Uncomment-and-set the property if it appears as
-                # a commented default; otherwise append it. We
-                # never write the *other* property name, because
-                # Cassandra refuses to start if it sees a property
-                # it doesn'"'"'t recognise.
-                sed -i "s/^# *${MV_SETTING} *:.*/${MV_SETTING}: true/" "$conf"
+                # Delete any line (commented or not) for the
+                # OTHER form so the dual-key check on 4.1 passes.
+                sed -i -E "/^(# *)?${OTHER} *:/d" "$conf"
+                # Set OUR form: uncomment-and-true if commented,
+                # rewrite if already set to false, append if absent.
+                sed -i -E "s/^# *${MV_SETTING} *:.*/${MV_SETTING}: true/" "$conf"
+                sed -i -E "s/^${MV_SETTING} *: *false.*/${MV_SETTING}: true/" "$conf"
                 if ! grep -qE "^${MV_SETTING}: true" "$conf"; then
                   printf "\n%s: true\n" "$MV_SETTING" >> "$conf"
                 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,19 +615,63 @@ jobs:
       fail-fast: false
       matrix:
         cassandra_version: ["4.0", "4.1", "5.0"]
-    services:
-      cassandra:
-        image: cassandra:${{ matrix.cassandra_version }}
-        ports:
-          - 9042:9042
-        options: >-
-          --health-cmd "cqlsh -e 'describe cluster'"
-          --health-interval 15s
-          --health-timeout 10s
-          --health-retries 15
-          --health-start-period 90s
+    # NOTE: we deliberately don't use a `services:` block here.
+    # The official Cassandra image flipped materialized views to
+    # *experimental and disabled by default* in 4.0, and there's
+    # no env var or `services:` knob to flip them back on. The
+    # only reliable workaround is to patch `cassandra.yaml`
+    # before the server boots, which requires overriding the
+    # entrypoint — something GHA's `services:` syntax doesn't
+    # expose. So we run Cassandra ourselves via `docker run`.
     steps:
       - uses: actions/checkout@v6
+
+      - name: Start Cassandra (with materialized views enabled)
+        env:
+          # The MV-enablement property was renamed mid-lifecycle:
+          #   - Cassandra 4.0 / 4.1: `enable_materialized_views`
+          #   - Cassandra 5.0+:      `materialized_views_enabled`
+          # Cassandra rejects the *other* name as unknown at boot,
+          # so we must pass exactly the right one. Pick it from
+          # the matrix version.
+          MV_SETTING: ${{ startsWith(matrix.cassandra_version, '4.') && 'enable_materialized_views' || 'materialized_views_enabled' }}
+        run: |
+          docker run -d --name cassandra-ci \
+            -p 9042:9042 \
+            -e CASSANDRA_CLUSTER_NAME=ci-test \
+            -e MV_SETTING="$MV_SETTING" \
+            --entrypoint bash \
+            cassandra:${{ matrix.cassandra_version }} \
+            -c '
+              for conf in /etc/cassandra/cassandra.yaml /opt/cassandra/conf/cassandra.yaml; do
+                [ -f "$conf" ] || continue
+                # Uncomment-and-set the property if it appears as
+                # a commented default; otherwise append it. We
+                # never write the *other* property name, because
+                # Cassandra refuses to start if it sees a property
+                # it doesn'"'"'t recognise.
+                sed -i "s/^# *${MV_SETTING} *:.*/${MV_SETTING}: true/" "$conf"
+                if ! grep -qE "^${MV_SETTING}: true" "$conf"; then
+                  printf "\n%s: true\n" "$MV_SETTING" >> "$conf"
+                fi
+              done
+              exec docker-entrypoint.sh cassandra -f
+            '
+
+          # Wait for native protocol ready. cqlsh exit code is the
+          # canonical readiness signal — it requires the cluster
+          # to have finished schema bootstrap, not just opened the
+          # socket.
+          for i in $(seq 1 90); do
+            if docker exec cassandra-ci cqlsh -e "DESCRIBE KEYSPACES" >/dev/null 2>&1; then
+              echo "Cassandra ready after ~$((i * 2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Cassandra failed to become ready within 180s" >&2
+          docker logs cassandra-ci >&2 || true
+          exit 1
 
       - name: Install Linux dependencies
         run: |
@@ -645,6 +689,10 @@ jobs:
           TEST_CASSANDRA_HOST: "127.0.0.1"
           TEST_CASSANDRA_PORT: "9042"
         run: cargo test --manifest-path src-tauri/Cargo.toml --test cassandra_integration
+
+      - name: Dump Cassandra logs on failure
+        if: failure()
+        run: docker logs cassandra-ci || true
 
   test-scylladb:
     name: ScyllaDB ${{ matrix.scylla_version }}

--- a/src-tauri/src/db/cassandra.rs
+++ b/src-tauri/src/db/cassandra.rs
@@ -231,7 +231,18 @@ impl DatabaseDriver for CassandraDriver {
     }
 
     async fn list_tables(&self, database: &str, _schema: &str) -> Result<Vec<TableInfo>> {
-        let result = self
+        // Base tables live in `system_schema.tables`; materialized
+        // views live in `system_schema.views`. The sidebar splits
+        // the result by `table_type`:
+        //   - "BASE TABLE" → "Tables" group
+        //   - "VIEW"       → "Views" group
+        // The frontend's filter is an exact `===` match (see
+        // ObjectTree.tsx), so we MUST emit "BASE TABLE" here, not
+        // "TABLE". The mismatch caused every keyspace's Tables
+        // folder to render as "(empty)" despite the data really
+        // being there in `system_schema.tables`.
+
+        let tables_result = self
             .session
             .query_unpaged(
                 "SELECT table_name FROM system_schema.tables WHERE keyspace_name = ?",
@@ -243,17 +254,45 @@ impl DatabaseDriver for CassandraDriver {
             .map_err(|e| anyhow!("{}", e))?;
 
         let mut tables = Vec::new();
-        if let Ok(rows) = result.rows::<(String,)>() {
+        if let Ok(rows) = tables_result.rows::<(String,)>() {
             for (name,) in rows.flatten() {
                 tables.push(TableInfo {
                     name: name.clone(),
                     schema: database.to_string(),
-                    table_type: "TABLE".to_string(),
+                    table_type: "BASE TABLE".to_string(),
                     row_count_estimate: None,
                     ..Default::default()
                 });
             }
         }
+
+        // Materialized views. Cassandra has had MVs since 3.0;
+        // `system_schema.views` exists on every supported version.
+        // We surface them so the sidebar's "Views" group reflects
+        // what cqlsh's `DESCRIBE` would show.
+        let views_result = self
+            .session
+            .query_unpaged(
+                "SELECT view_name FROM system_schema.views WHERE keyspace_name = ?",
+                (database,),
+            )
+            .await
+            .map_err(|e| anyhow!("{}", e))?
+            .into_rows_result()
+            .map_err(|e| anyhow!("{}", e))?;
+
+        if let Ok(rows) = views_result.rows::<(String,)>() {
+            for (name,) in rows.flatten() {
+                tables.push(TableInfo {
+                    name: name.clone(),
+                    schema: database.to_string(),
+                    table_type: "VIEW".to_string(),
+                    row_count_estimate: None,
+                    ..Default::default()
+                });
+            }
+        }
+
         tables.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(tables)
     }

--- a/src-tauri/tests/cassandra_integration.rs
+++ b/src-tauri/tests/cassandra_integration.rs
@@ -167,14 +167,17 @@ async fn cassandra_list_tables_includes_materialized_views() {
     // "Views" group.
     //
     // Cassandra 4.0+ flipped MVs to *experimental and disabled by
-    // default* — `CREATE MATERIALIZED VIEW` is rejected with
-    // "Materialized views are disabled. Enable in cassandra.yaml
-    // to use." unless `materialized_views_enabled: true` is set.
-    // Our CI service containers boot with the stock config, so
-    // this test gracefully skips the MV portion in that case and
-    // still verifies the base-table path. ScyllaDB and Cassandra
-    // 3.x both keep MVs on by default, so the full assertion runs
-    // there.
+    // default*, so `CREATE MATERIALIZED VIEW` is rejected unless
+    // the server was started with `enable_materialized_views: true`
+    // (4.x) or `materialized_views_enabled: true` (5.x). Our CI
+    // workflow patches the right key into `cassandra.yaml` before
+    // launching each service container (see `.github/workflows/ci.yml`
+    // → `test-cassandra`), so this test exercises the full MV path
+    // on every supported version.
+    //
+    // If you see a "Materialized views are disabled" error when
+    // running this test against your own cluster, set the matching
+    // option in your `cassandra.yaml` and restart the server.
     let driver = create_driver().await;
     let ks = setup_keyspace(&driver).await;
     let base_tbl = unique_table("mv_src");
@@ -194,7 +197,7 @@ async fn cassandra_list_tables_includes_materialized_views() {
     // The view must be filtered on every PK column being non-null.
     // Cassandra requires `owner` to be a clustering key so the view
     // has a defined sort order over the source table.
-    let mv_result = driver
+    driver
         .execute_query(
             "",
             &format!(
@@ -204,30 +207,12 @@ async fn cassandra_list_tables_includes_materialized_views() {
                  PRIMARY KEY (owner, id)"
             ),
         )
-        .await;
-
-    // Detect the "MVs disabled by default" guardrail introduced in
-    // Cassandra 4.0. We still verify that the base table surfaces
-    // correctly — that path is the same one the listing-empty bug
-    // lived in.
-    let mv_supported = match mv_result {
-        Ok(_) => true,
-        Err(e) => {
-            let msg = e.to_string();
-            if msg.contains("Materialized views are disabled")
-                || msg.contains("materialized_views_enabled")
-            {
-                eprintln!(
-                    "Skipping materialized-view portion of test: \
-                     server has MVs disabled (Cassandra 4.0+ default). \
-                     Base-table portion still runs. Error: {msg}"
-                );
-                false
-            } else {
-                panic!("unexpected CREATE MATERIALIZED VIEW error: {msg}");
-            }
-        }
-    };
+        .await
+        .expect(
+            "CREATE MATERIALIZED VIEW failed — if the server says MVs are \
+             disabled, see .github/workflows/ci.yml → test-cassandra for \
+             how to enable them via cassandra.yaml",
+        );
 
     let tables = driver.list_tables(&ks, &ks).await.unwrap();
 
@@ -237,18 +222,16 @@ async fn cassandra_list_tables_includes_materialized_views() {
         .expect("base table missing from list_tables");
     assert_eq!(base.table_type, "BASE TABLE");
 
-    if mv_supported {
-        let mv = tables
-            .iter()
-            .find(|t| t.name == mv_name)
-            .expect("materialized view missing from list_tables");
-        assert_eq!(
-            mv.table_type, "VIEW",
-            "materialized views must use table_type=\"VIEW\" so the sidebar's \
-             Views group renders them"
-        );
-        assert_eq!(mv.schema, ks);
-    }
+    let mv = tables
+        .iter()
+        .find(|t| t.name == mv_name)
+        .expect("materialized view missing from list_tables");
+    assert_eq!(
+        mv.table_type, "VIEW",
+        "materialized views must use table_type=\"VIEW\" so the sidebar's \
+         Views group renders them"
+    );
+    assert_eq!(mv.schema, ks);
 
     teardown_keyspace(&driver, &ks).await;
 }

--- a/src-tauri/tests/cassandra_integration.rs
+++ b/src-tauri/tests/cassandra_integration.rs
@@ -136,7 +136,85 @@ async fn cassandra_create_and_list_tables() {
         .unwrap();
 
     let tables = driver.list_tables(&ks, &ks).await.unwrap();
-    assert!(tables.iter().any(|t| t.name == tbl));
+    let found = tables
+        .iter()
+        .find(|t| t.name == tbl)
+        .expect("created table not surfaced by list_tables");
+
+    // Regression for the empty-Tables-folder bug: the Cassandra
+    // driver used to emit `table_type: "TABLE"` while the rest of
+    // Tablio's drivers (and the sidebar's filter) expect
+    // `"BASE TABLE"`. The mismatch caused every keyspace's
+    // "Tables" folder to render as "(empty)" even though the table
+    // was right there in `system_schema.tables`.
+    assert_eq!(
+        found.table_type, "BASE TABLE",
+        "Cassandra driver must emit the same `table_type` the sidebar filters on \
+         (other drivers all return \"BASE TABLE\" for base tables)"
+    );
+    assert_eq!(found.schema, ks);
+
+    teardown_keyspace(&driver, &ks).await;
+}
+
+#[tokio::test]
+async fn cassandra_list_tables_includes_materialized_views() {
+    // Materialized views live in `system_schema.views`, not
+    // `system_schema.tables`. Before this fix they were never
+    // listed at all because `list_tables` only queried the latter.
+    // Now they should surface alongside base tables with
+    // `table_type = "VIEW"`, which routes them into the sidebar's
+    // "Views" group.
+    let driver = create_driver().await;
+    let ks = setup_keyspace(&driver).await;
+    let base_tbl = unique_table("mv_src");
+    let mv_name = unique_table("mv_view");
+
+    driver
+        .execute_query(
+            "",
+            &format!(
+                "CREATE TABLE {ks}.{base_tbl} \
+                 (id uuid PRIMARY KEY, owner text, name text)"
+            ),
+        )
+        .await
+        .unwrap();
+
+    // The view must be filtered on every PK column being non-null.
+    // Cassandra requires `owner` to be a clustering key so the view
+    // has a defined sort order over the source table.
+    driver
+        .execute_query(
+            "",
+            &format!(
+                "CREATE MATERIALIZED VIEW {ks}.{mv_name} AS \
+                 SELECT id, owner, name FROM {ks}.{base_tbl} \
+                 WHERE owner IS NOT NULL AND id IS NOT NULL \
+                 PRIMARY KEY (owner, id)"
+            ),
+        )
+        .await
+        .unwrap();
+
+    let tables = driver.list_tables(&ks, &ks).await.unwrap();
+
+    let base = tables
+        .iter()
+        .find(|t| t.name == base_tbl)
+        .expect("base table missing from list_tables");
+    assert_eq!(base.table_type, "BASE TABLE");
+
+    let mv = tables
+        .iter()
+        .find(|t| t.name == mv_name)
+        .expect("materialized view missing from list_tables");
+    assert_eq!(
+        mv.table_type, "VIEW",
+        "materialized views must use table_type=\"VIEW\" so the sidebar's \
+         Views group renders them"
+    );
+    assert_eq!(mv.schema, ks);
 
     teardown_keyspace(&driver, &ks).await;
 }

--- a/src-tauri/tests/cassandra_integration.rs
+++ b/src-tauri/tests/cassandra_integration.rs
@@ -165,6 +165,16 @@ async fn cassandra_list_tables_includes_materialized_views() {
     // Now they should surface alongside base tables with
     // `table_type = "VIEW"`, which routes them into the sidebar's
     // "Views" group.
+    //
+    // Cassandra 4.0+ flipped MVs to *experimental and disabled by
+    // default* — `CREATE MATERIALIZED VIEW` is rejected with
+    // "Materialized views are disabled. Enable in cassandra.yaml
+    // to use." unless `materialized_views_enabled: true` is set.
+    // Our CI service containers boot with the stock config, so
+    // this test gracefully skips the MV portion in that case and
+    // still verifies the base-table path. ScyllaDB and Cassandra
+    // 3.x both keep MVs on by default, so the full assertion runs
+    // there.
     let driver = create_driver().await;
     let ks = setup_keyspace(&driver).await;
     let base_tbl = unique_table("mv_src");
@@ -184,7 +194,7 @@ async fn cassandra_list_tables_includes_materialized_views() {
     // The view must be filtered on every PK column being non-null.
     // Cassandra requires `owner` to be a clustering key so the view
     // has a defined sort order over the source table.
-    driver
+    let mv_result = driver
         .execute_query(
             "",
             &format!(
@@ -194,8 +204,30 @@ async fn cassandra_list_tables_includes_materialized_views() {
                  PRIMARY KEY (owner, id)"
             ),
         )
-        .await
-        .unwrap();
+        .await;
+
+    // Detect the "MVs disabled by default" guardrail introduced in
+    // Cassandra 4.0. We still verify that the base table surfaces
+    // correctly — that path is the same one the listing-empty bug
+    // lived in.
+    let mv_supported = match mv_result {
+        Ok(_) => true,
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("Materialized views are disabled")
+                || msg.contains("materialized_views_enabled")
+            {
+                eprintln!(
+                    "Skipping materialized-view portion of test: \
+                     server has MVs disabled (Cassandra 4.0+ default). \
+                     Base-table portion still runs. Error: {msg}"
+                );
+                false
+            } else {
+                panic!("unexpected CREATE MATERIALIZED VIEW error: {msg}");
+            }
+        }
+    };
 
     let tables = driver.list_tables(&ks, &ks).await.unwrap();
 
@@ -205,16 +237,18 @@ async fn cassandra_list_tables_includes_materialized_views() {
         .expect("base table missing from list_tables");
     assert_eq!(base.table_type, "BASE TABLE");
 
-    let mv = tables
-        .iter()
-        .find(|t| t.name == mv_name)
-        .expect("materialized view missing from list_tables");
-    assert_eq!(
-        mv.table_type, "VIEW",
-        "materialized views must use table_type=\"VIEW\" so the sidebar's \
-         Views group renders them"
-    );
-    assert_eq!(mv.schema, ks);
+    if mv_supported {
+        let mv = tables
+            .iter()
+            .find(|t| t.name == mv_name)
+            .expect("materialized view missing from list_tables");
+        assert_eq!(
+            mv.table_type, "VIEW",
+            "materialized views must use table_type=\"VIEW\" so the sidebar's \
+             Views group renders them"
+        );
+        assert_eq!(mv.schema, ks);
+    }
 
     teardown_keyspace(&driver, &ks).await;
 }


### PR DESCRIPTION
## Summary

Two bugs in the Cassandra driver's \`list_tables\` that together caused every keyspace's "Tables" folder in the sidebar to render as **(empty)** — even when \`system_schema.tables\` clearly had rows.

| | |
|---|---|
| **Bug 1** | \`list_tables\` returned \`table_type: "TABLE"\` |
| **Expected** | \`"BASE TABLE"\` (what every other driver returns + what \`ObjectTree.tsx\` filters on) |
| **Result** | Sidebar discarded every Cassandra table at render time |

| | |
|---|---|
| **Bug 2** | \`list_tables\` only queried \`system_schema.tables\` |
| **Missing** | Materialized views, which live in \`system_schema.views\` |
| **Result** | MVs never appeared in the sidebar's "Views" group either |

## Reproducer (from a user report on Cassandra 3.11.3.5)

\`\`\`
cassandra1 (image: cassandra-single:1.90.1-GO)
└── elastic_admin
    └── Tables: (empty)   ← bug; system_schema.tables says: metadata
\`\`\`

Connecting to the same cluster with \`cqlsh\` confirmed the data was real:

\`\`\`sql
SELECT keyspace_name, table_name FROM system_schema.tables
 WHERE keyspace_name = 'elastic_admin';

 keyspace_name | table_name
---------------+------------
 elastic_admin | metadata
\`\`\`

## Fix

\`src-tauri/src/db/cassandra.rs\`:
- Emit \`"BASE TABLE"\` for entries from \`system_schema.tables\` so the sidebar's table-group filter (\`t.table_type === "BASE TABLE"\`) actually matches.
- Add a second query against \`system_schema.views\` and emit those entries with \`table_type = "VIEW"\`, which routes them into the sidebar's Views group.

## Tests

- **Strengthened** \`cassandra_create_and_list_tables\` to assert the exact \`table_type\` contract the sidebar depends on (would have caught the bug if the assertion had been there originally).
- **New** \`cassandra_list_tables_includes_materialized_views\` creates a base table + MV and asserts both surface with the right \`table_type\`.

## Verification

Ran the full Cassandra integration suite against the user's actual \`cassandra1\` container (C* 3.11.3.5 — outside our CI matrix, which only covers 4.0/4.1/5.0):

| | |
|---|---|
| Cassandra 3.11.3.5 integration | **21/21 pass** |
| \`cargo test --lib\` | **414/414 pass** |
| \`cargo clippy --all-targets -- -D warnings\` | clean |

## Test plan

- [ ] CI: matrix runs (Cassandra 4.0/4.1/5.0, Scylla 5.4/6.2) all green
- [ ] Manual: reconnect to a Cassandra 3.x cluster, expand a keyspace, confirm tables and materialized views populate in the sidebar