### PR TITLE
ci: aggregate backend coverage across every engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,61 +122,99 @@ jobs:
       - name: Clippy
         run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
 
-  # Backend code coverage via cargo-llvm-cov. Scoped to the lib + the SQLite
-  # integration suite (the only one that doesn't need an external service);
-  # the per-engine integration jobs cover the driver-specific paths and
-  # could feed lcov into a merge step in a follow-up. Coverage is a signal,
-  # not a gate — no thresholds today.
+  # Backend coverage aggregator. Each per-engine `test-*` job runs its
+  # integration suite under `cargo-llvm-cov` and uploads a per-job
+  # `lcov-<engine>[-version].info` artifact. This job collects every
+  # one of those, merges them into a single `lcov.info` with the `lcov`
+  # CLI, and writes a summary table to the PR's job summary.
+  #
+  # Per-line hit counts get summed when the same line is covered by
+  # multiple engines (e.g. the `pg_common` module is exercised by both
+  # `test-postgres` and `test-cockroachdb`). For *line* coverage that's
+  # exactly what we want — once-covered stays once-covered, and the
+  # totals reflect the union of every engine's exercised paths.
+  #
+  # Coverage is a signal, not a gate — no thresholds today.
   coverage-backend:
     name: Backend Coverage
-    needs: [changes]
-    if: needs.changes.outputs.backend == 'true'
+    needs:
+      - changes
+      - test-postgres
+      - test-mysql
+      - test-mariadb
+      - test-cockroachdb
+      - test-tidb
+      - test-sqlite
+      - test-mssql
+      - test-cassandra
+      - test-scylladb
+      - test-ssh-tunnel
+    # `always()` lets the aggregator still run and publish a partial
+    # report even when one engine job fails or is cancelled. The
+    # `ci-required` aggregator job is what gates the PR, not this one.
+    if: ${{ always() && needs.changes.outputs.backend == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Linux dependencies
+      - name: Install lcov
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
+          sudo apt-get install -y lcov
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Download all per-engine coverage artifacts
+        uses: actions/download-artifact@v6
         with:
-          components: llvm-tools-preview
+          pattern: lcov-*
+          path: lcov-parts
+          merge-multiple: true
 
-      - uses: swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
-
-      # Single coverage run; emit lcov for the artifact, then re-render the
-      # already-collected profraw data as a summary table for the PR job
-      # summary. `report` does not re-execute tests.
-      - name: Run coverage (lib + sqlite)
+      - name: Merge lcov tracefiles
+        id: merge
         run: |
-          cargo llvm-cov --manifest-path src-tauri/Cargo.toml \
-            --lib --test sqlite_integration \
-            --no-report
-          cargo llvm-cov --manifest-path src-tauri/Cargo.toml report \
-            --lcov --output-path lcov.info
+          shopt -s nullglob
+          parts=(lcov-parts/lcov-*.info)
+          if [ ${#parts[@]} -eq 0 ]; then
+            echo "::warning::No per-engine lcov artifacts were found"
+            echo "found=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Found ${#parts[@]} per-engine lcov files:"
+          printf '  %s\n' "${parts[@]}"
+
+          # `lcov --add-tracefile a --add-tracefile b ...` accumulates
+          # hits across files. We pass every part exactly once so the
+          # merged totals reflect the union of engines' coverage.
+          args=()
+          for p in "${parts[@]}"; do
+            args+=(--add-tracefile "$p")
+          done
+          # `--ignore-errors inconsistent` tolerates the small line-
+          # number drift that happens between engines if one build's
+          # source map disagrees with another's (e.g. a comment-only
+          # change between cache invalidations). Without it lcov
+          # bails on the first mismatched file.
+          lcov --ignore-errors inconsistent,empty "${args[@]}" --output-file lcov.info
+          echo "found=${#parts[@]}" >> "$GITHUB_OUTPUT"
 
       - name: Coverage summary
-        if: always()
+        if: ${{ always() && steps.merge.outputs.found != '0' }}
         run: |
+          # lcov's `--summary` writes overall totals plus per-line /
+          # per-function / per-branch percentages to stderr; redirect
+          # to stdout so it lands in the step summary.
           {
-            echo "## Backend coverage (cargo-llvm-cov, lib + sqlite)"
+            echo "## Backend coverage (cargo-llvm-cov, all engines)"
+            echo
+            echo "Merged from ${{ steps.merge.outputs.found }} per-engine lcov files."
             echo
             echo '```'
-            cargo llvm-cov --manifest-path src-tauri/Cargo.toml report \
-              --summary-only 2>/dev/null || echo "(no coverage data collected)"
+            lcov --summary lcov.info 2>&1 || echo "(no coverage data collected)"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload backend coverage
-        if: always()
+      - name: Upload merged backend coverage
+        if: ${{ always() && steps.merge.outputs.found != '0' }}
         uses: actions/upload-artifact@v7
         with:
           name: coverage-backend
@@ -216,17 +254,38 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      - name: Run unit + Postgres integration tests
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run unit + Postgres integration tests with coverage
         env:
           TEST_POSTGRES_URL: "postgres://test:test@localhost:5432/testdb"
         run: |
-          cargo test --manifest-path src-tauri/Cargo.toml --lib
-          cargo test --manifest-path src-tauri/Cargo.toml --test postgres_integration
+          # The Postgres job is also where the lib unit tests run
+          # under coverage. `--no-report` accumulates profraw data;
+          # the final `report` invocation emits a single combined
+          # lcov for this matrix entry.
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --lib --no-report
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test postgres_integration --no-report
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml report \
+            --lcov --output-path "${{ github.workspace }}/lcov-postgres-${{ matrix.pg_version }}.info"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-postgres-${{ matrix.pg_version }}
+          path: lcov-postgres-${{ matrix.pg_version }}.info
+          retention-days: 1
+          if-no-files-found: ignore
 
   test-mysql:
     name: MySQL ${{ matrix.mysql_version }}
@@ -261,15 +320,32 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      - name: Run MySQL integration tests
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run MySQL integration tests with coverage
         env:
           TEST_MYSQL_URL: "mysql://root:test@localhost:3306/testdb"
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test mysql_integration
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test mysql_integration \
+            --lcov --output-path "${{ github.workspace }}/lcov-mysql-${{ matrix.mysql_version }}.info"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-mysql-${{ matrix.mysql_version }}
+          path: lcov-mysql-${{ matrix.mysql_version }}.info
+          retention-days: 1
+          if-no-files-found: ignore
 
   test-mariadb:
     name: MariaDB ${{ matrix.mariadb_version }}
@@ -304,15 +380,32 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      - name: Run MariaDB integration tests
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run MariaDB integration tests with coverage
         env:
           TEST_MARIADB_URL: "mysql://root:test@localhost:3306/testdb"
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test mariadb_integration
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test mariadb_integration \
+            --lcov --output-path "${{ github.workspace }}/lcov-mariadb-${{ matrix.mariadb_version }}.info"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-mariadb-${{ matrix.mariadb_version }}
+          path: lcov-mariadb-${{ matrix.mariadb_version }}.info
+          retention-days: 1
+          if-no-files-found: ignore
 
   test-cockroachdb:
     name: CockroachDB
@@ -339,15 +432,32 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      - name: Run CockroachDB integration tests
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run CockroachDB integration tests with coverage
         env:
           TEST_COCKROACHDB_URL: "postgres://root@localhost:26257/testdb?sslmode=disable"
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test cockroachdb_integration
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test cockroachdb_integration \
+            --lcov --output-path "${{ github.workspace }}/lcov-cockroachdb.info"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-cockroachdb
+          path: lcov-cockroachdb.info
+          retention-days: 1
+          if-no-files-found: ignore
 
   test-tidb:
     name: TiDB
@@ -374,15 +484,32 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      - name: Run TiDB integration tests
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run TiDB integration tests with coverage
         env:
           TEST_TIDB_URL: "mysql://root@localhost:4000/testdb"
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test tidb_integration
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test tidb_integration \
+            --lcov --output-path "${{ github.workspace }}/lcov-tidb.info"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-tidb
+          path: lcov-tidb.info
+          retention-days: 1
+          if-no-files-found: ignore
 
   # SQL Server is wired into PR CI (not just release.yml) because the new
   # get_query_stats DMV-backed implementation needs continuous coverage.
@@ -430,15 +557,32 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      - name: Run MSSQL integration tests
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run MSSQL integration tests with coverage
         env:
           TEST_MSSQL_URL: "mssql://SA:Str0ng_Passw0rd!@localhost:1433/testdb"
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test mssql_integration
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test mssql_integration \
+            --lcov --output-path "${{ github.workspace }}/lcov-mssql.info"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-mssql
+          path: lcov-mssql.info
+          retention-days: 1
+          if-no-files-found: ignore
 
   test-sqlite:
     name: SQLite
@@ -454,13 +598,30 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      - name: Run SQLite integration tests
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test sqlite_integration
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run SQLite integration tests with coverage
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test sqlite_integration \
+            --lcov --output-path "${{ github.workspace }}/lcov-sqlite.info"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-sqlite
+          path: lcov-sqlite.info
+          retention-days: 1
+          if-no-files-found: ignore
 
   # Stand up an OpenSSH bastion in front of a Postgres instance so the
   # russh-based SSH tunnel can be exercised end-to-end. The bastion uses
@@ -562,10 +723,16 @@ jobs:
           pg_dump --version
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
 
       - name: Start ssh-agent and load test key
         id: sshagent
@@ -582,7 +749,7 @@ jobs:
           echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
           echo "TEST_SSH_AGENT_AVAILABLE=1" >> "$GITHUB_ENV"
 
-      - name: Run SSH tunnel integration tests
+      - name: Run SSH tunnel integration tests with coverage
         env:
           TEST_SSH_HOST: 127.0.0.1
           TEST_SSH_PORT: "2222"
@@ -600,7 +767,20 @@ jobs:
           TEST_SSH_KEY_PATH: ${{ steps.sshkey.outputs.key_path }}
           # `SSH_AUTH_SOCK` and `TEST_SSH_AGENT_AVAILABLE` come in via
           # $GITHUB_ENV from the previous step.
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test ssh_tunnel_integration -- --test-threads=1
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml \
+            --test ssh_tunnel_integration \
+            --lcov --output-path "${{ github.workspace }}/lcov-ssh-tunnel.info" \
+            -- --test-threads=1
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-ssh-tunnel
+          path: lcov-ssh-tunnel.info
+          retention-days: 1
+          if-no-files-found: ignore
 
       - name: Dump bastion logs on failure
         if: failure()
@@ -696,16 +876,33 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      - name: Run Cassandra integration tests
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run Cassandra integration tests with coverage
         env:
           TEST_CASSANDRA_HOST: "127.0.0.1"
           TEST_CASSANDRA_PORT: "9042"
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test cassandra_integration
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test cassandra_integration \
+            --lcov --output-path "${{ github.workspace }}/lcov-cassandra-${{ matrix.cassandra_version }}.info"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-cassandra-${{ matrix.cassandra_version }}
+          path: lcov-cassandra-${{ matrix.cassandra_version }}.info
+          retention-days: 1
+          if-no-files-found: ignore
 
       - name: Dump Cassandra logs on failure
         if: failure()
@@ -740,16 +937,33 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev librsvg2-dev libayatana-appindicator3-dev patchelf
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
 
-      - name: Run ScyllaDB integration tests
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Run ScyllaDB integration tests with coverage
         env:
           TEST_CASSANDRA_HOST: "127.0.0.1"
           TEST_CASSANDRA_PORT: "9042"
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test cassandra_integration
+        run: |
+          cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test cassandra_integration \
+            --lcov --output-path "${{ github.workspace }}/lcov-scylladb-${{ matrix.scylla_version }}.info"
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov-scylladb-${{ matrix.scylla_version }}
+          path: lcov-scylladb-${{ matrix.scylla_version }}.info
+          retention-days: 1
+          if-no-files-found: ignore
 
   test-e2e:
     name: E2E Tests


### PR DESCRIPTION
## Summary

The \`Backend Coverage\` job today reports ~44% line coverage because it runs \`cargo llvm-cov\` against just \`--lib + --test sqlite_integration\`. Every per-engine integration job runs in parallel with its own service container and never feeds its data back. The original job's comment explicitly called this out as deferred work:

> "the per-engine integration jobs cover the driver-specific paths and could feed lcov into a merge step in a follow-up"

This PR is that follow-up.

## Approach

**Each per-engine \`test-*\` job** now runs its integration suite under \`cargo-llvm-cov\` and uploads its own \`lcov-<engine>[-version].info\` artifact:

- \`test-postgres\` (matrix: 14/15/16/17/18) — also runs \`--lib\` under coverage, since lib unit tests already live in this job
- \`test-mysql\` (matrix: 8.0/8.4)
- \`test-mariadb\` (matrix: 10.11/11.4)
- \`test-cockroachdb\`
- \`test-tidb\`
- \`test-sqlite\`
- \`test-mssql\`
- \`test-cassandra\` (matrix: 4.0/4.1/5.0)
- \`test-scylladb\` (matrix: 5.4/6.2)
- \`test-ssh-tunnel\`

**The \`Backend Coverage\` aggregator job** now:
- Depends on all 10 per-engine jobs
- Downloads every \`lcov-*\` artifact with \`actions/download-artifact\` (\`pattern: lcov-*\`, \`merge-multiple: true\`)
- Merges them with \`lcov --add-tracefile ... --output-file lcov.info\`. Per-line hit counts are summed across engines, so the union of every exercised path lands in one tracefile.
- Writes a summary table to \`\$GITHUB_STEP_SUMMARY\` and uploads the merged \`lcov.info\`

The aggregator runs with \`if: always()\` and is **not** in \`ci-required\`'s needs list, so coverage stays a signal — a partial or missing report can never block merging.

## What it costs

Adding instrumentation rebuilds each engine's test binary with \`RUSTFLAGS="-C instrument-coverage"\`, which invalidates the swatinem cache. Expect each per-engine job to add roughly 2-4 minutes of wall-clock time. The jobs run in parallel so total CI duration shouldn't move much.

## What it doesn't change

- \`ci-required\` still depends on the same test jobs as before (the aggregator was already excluded from required checks).
- No new thresholds — coverage remains a signal, not a gate.
- The frontend \`Frontend Coverage\` job is unchanged.

## Test plan

- [ ] CI: every \`test-*\` job runs green with the new coverage step
- [ ] \`Backend Coverage\` job: produces a merged \`lcov.info\` and the PR job summary shows a unified coverage table
- [ ] Final coverage % is meaningfully higher than the previous ~44% (target: 70%+ after merging all engines)
- [ ] Failure mode: if one engine job fails, the aggregator still produces a partial report for the engines that succeeded