### PR TITLE
ci: serialise MSSQL tests and add test-mssql to ci-required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,9 +571,19 @@ jobs:
       - name: Run MSSQL integration tests with coverage
         env:
           TEST_MSSQL_URL: "mssql://SA:Str0ng_Passw0rd!@localhost:1433/testdb"
+        # `--test-threads=1` serialises the integration suite so concurrent
+        # `CREATE TABLE` / `DROP TABLE` calls don't deadlock on SQL
+        # Server's system-catalog locks (error 1205 "Transaction was
+        # deadlocked on lock resources with another process and has
+        # been chosen as the deadlock victim"). The deadlock victim is
+        # a perfectly legitimate transient SQL-Server outcome and the
+        # docs recommend rerunning; serialising the suite makes it
+        # never happen in the first place. Trade-off: ~2 minutes
+        # longer wall-clock time. Same pattern as `test-ssh-tunnel`.
         run: |
           cargo llvm-cov --manifest-path src-tauri/Cargo.toml --test mssql_integration \
-            --lcov --output-path "${{ github.workspace }}/lcov-mssql.info"
+            --lcov --output-path "${{ github.workspace }}/lcov-mssql.info" \
+            -- --test-threads=1
 
       - name: Upload coverage
         if: always()
@@ -1045,6 +1055,7 @@ jobs:
       - test-postgres
       - test-mysql
       - test-mariadb
+      - test-mssql
       - test-cockroachdb
       - test-tidb
       - test-sqlite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,11 @@ jobs:
       - name: Run MSSQL integration tests
         env:
           TEST_MSSQL_URL: "mssql://SA:Str0ng_Passw0rd!@localhost:1433/testdb"
-        run: cargo test --manifest-path src-tauri/Cargo.toml --test mssql_integration
+        # `--test-threads=1` serialises the integration suite so
+        # concurrent CREATE TABLE / DROP TABLE calls don't deadlock
+        # on SQL Server's system-catalog locks (error 1205). See
+        # the matching comment in `.github/workflows/ci.yml`.
+        run: cargo test --manifest-path src-tauri/Cargo.toml --test mssql_integration -- --test-threads=1
 
   test-cockroachdb:
     name: CockroachDB


### PR DESCRIPTION
## Summary

Two tightly-related fixes to the SQL Server CI lane.

### 1. Flake: \`mssql_create_table_and_list_tables\` hits SQL Server 1205

Recent CI runs (e.g. PR #137 [run 26024328939](https://github.com/dasunNimantha/tablio/actions/runs/26024328939)) intermittently fail with:

\`\`\`
thread 'mssql_create_table_and_list_tables' panicked at tests/mssql_integration.rs:176:56:
Token error: 'Transaction was deadlocked on lock resources with another
process and has been chosen as the deadlock victim. Rerun the transaction.'
(code: 1205, state: 56, class: 13)
\`\`\`

This is a SQL Server system-catalog deadlock caused by parallel test threads running concurrent DDL (\`CREATE TABLE\` / \`DROP TABLE\`) against the same database. The deadlock victim is a perfectly legitimate transient SQL-Server outcome — the docs explicitly say "rerun the transaction" — but Rust's test runner panics on the first \`.unwrap()\` of the underlying tiberius error and never retries.

Fix: \`--test-threads=1\` to serialise the integration suite so concurrent DDL is structurally impossible. Same pattern \`test-ssh-tunnel\` already uses. Trade-off: ~2 minutes longer wall-clock time. Applied to both \`ci.yml\` and \`release.yml\`.

### 2. \`ci-required\` was missing \`test-mssql\`

While investigating the flake we noticed \`test-mssql\` was never in \`ci-required\`'s \`needs:\` list, which is why this MSSQL failure didn't gate PR #137. The aggregator's whole purpose is to be the single required status check that branch protection enforces; missing a test job there means that job's failures pass silently. Added \`test-mssql\` to the list so future MSSQL failures actually block merging.

The \`--test-threads=1\` change alone wouldn't have surfaced this gap — only adding MSSQL to \`ci-required\` will. Doing both at once catches both the flake and the structural reason nobody noticed the flake earlier.

## Test plan

- [ ] CI: every \`test-mssql\` run on this PR passes (proves the flake is gone)
- [ ] CI Required: now includes \`test-mssql\` in its required-job summary
- [ ] Branch protection: confirm a deliberately-broken MSSQL change would now block the PR (manual smoke once merged)

## Notes

A future, more surgical alternative would be to add a 1205-aware retry helper in the MSSQL driver. That conflates retry policy with test isolation, and \`--test-threads=1\` matches an existing precedent in this repo — so we ship the simpler fix now.