### PR TITLE
fix(grid): match column names in inline search (#56)

### DIFF
--- a/src/components/DataGrid/DataGrid.test.ts
+++ b/src/components/DataGrid/DataGrid.test.ts
@@ -129,6 +129,15 @@ function buildSearchMatches(
   if (!searchQuery || !columns) return [];
   const q = searchQuery.toLowerCase();
   const matches: SearchMatch[] = [];
+
+  // Column-name matches first (bug #56). Sentinel rowIndex = -1
+  // means "no row — scroll the column into view".
+  for (const col of columns) {
+    if (col.name.toLowerCase().includes(q)) {
+      matches.push({ rowIndex: -1, colId: col.name });
+    }
+  }
+
   for (let r = 0; r < editingRows.length; r++) {
     for (let c = 0; c < editingRows[r].length; c++) {
       const val = editingRows[r][c];
@@ -281,6 +290,75 @@ describe("DataGrid search match building", () => {
     const matches = buildSearchMatches("alice", rows, shortCols);
     expect(matches).toEqual([]);
   });
+
+  // -----------------------------------------------------------------------
+  // Bug #56: the placeholder "Search columns and values..." promised
+  // column-name matching, but the matcher only scanned cell values.
+  // The fix adds column-name matches with a sentinel rowIndex = -1.
+  // -----------------------------------------------------------------------
+
+  it("matches a column name with sentinel rowIndex = -1", () => {
+    const matches = buildSearchMatches("email", [], cols);
+    expect(matches).toEqual([{ rowIndex: -1, colId: "email" }]);
+  });
+
+  it("matches a column name case-insensitively", () => {
+    const matches = buildSearchMatches("EMAIL", [], cols);
+    expect(matches).toEqual([{ rowIndex: -1, colId: "email" }]);
+  });
+
+  it("matches a column name with a partial substring", () => {
+    const matches = buildSearchMatches("nam", [], cols);
+    expect(matches).toEqual([{ rowIndex: -1, colId: "name" }]);
+  });
+
+  it("matches multiple column names", () => {
+    const fanCols = [
+      { name: "user_id" },
+      { name: "user_email" },
+      { name: "created_at" },
+    ];
+    const matches = buildSearchMatches("user", [], fanCols);
+    expect(matches).toEqual([
+      { rowIndex: -1, colId: "user_id" },
+      { rowIndex: -1, colId: "user_email" },
+    ]);
+  });
+
+  it("orders column matches before cell matches", () => {
+    const rows = [[1, "Alice", "alice@test.com"]];
+    // "name" matches the second column name AND no cell values.
+    const matches = buildSearchMatches("name", rows, cols);
+    expect(matches[0]).toEqual({ rowIndex: -1, colId: "name" });
+  });
+
+  it("finds both a column-name and a cell-value match in the same query", () => {
+    // Search query simultaneously matches the `email` column name
+    // AND the `alice@test.com` cell value. We surface both.
+    const rows = [[1, "Alice", "alice@test.com"]];
+    const matches = buildSearchMatches("email", rows, cols);
+    expect(matches).toEqual([
+      { rowIndex: -1, colId: "email" },
+      // No row-cell match here — neither "Alice" nor
+      // "alice@test.com" contains the substring "email".
+    ]);
+
+    // Now a query that hits both: "alice" matches the cell values
+    // but not the column names (cols = id / name / email).
+    const cellOnly = buildSearchMatches("alice", rows, cols);
+    expect(cellOnly).toEqual([
+      { rowIndex: 0, colId: "name" },
+      { rowIndex: 0, colId: "email" },
+    ]);
+
+    // And a query that hits BOTH a column name (`name`) and cell
+    // values that happen to contain it (`my_name_is_alice`).
+    const both = buildSearchMatches("name", [[1, "my_name_is_alice", "x"]], cols);
+    expect(both).toEqual([
+      { rowIndex: -1, colId: "name" },
+      { rowIndex: 0, colId: "name" },
+    ]);
+  });
 });
 
 describe("DataGrid search navigation index", () => {
@@ -385,6 +463,17 @@ describe("DataGrid cell search class rules", () => {
     it("returns false when colField is undefined", () => {
       const current = { rowIndex: 0, colId: "id" };
       expect(isCellSearchCurrent(current, 0, undefined)).toBe(false);
+    });
+
+    it("never matches a cell when the current match is a column-only sentinel (#56)", () => {
+      // After bug #56's fix, column-name matches use `rowIndex = -1`.
+      // No data cell has rowIndex = -1, so the cell-search-current
+      // class rule must never light up while the user navigates to
+      // a column match — the visual feedback for that path is
+      // `ensureColumnVisible` + `setFocusedCell`, not a cell tint.
+      const colMatch = { rowIndex: -1, colId: "email" };
+      expect(isCellSearchCurrent(colMatch, 0, "email")).toBe(false);
+      expect(isCellSearchCurrent(colMatch, 5, "email")).toBe(false);
     });
   });
 });

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -381,6 +381,19 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     if (!searchQuery || !data) return [];
     const q = searchQuery.toLowerCase();
     const matches: { rowIndex: number; colId: string }[] = [];
+
+    // Column-name matches come first. The search bar's placeholder
+    // promises "Search columns and values..."; without this loop
+    // (bug #56), typing a column name returned zero results despite
+    // the copy. We emit a sentinel match with `rowIndex = -1` that
+    // `navigateToMatch` interprets as "no row — just scroll the
+    // column into view".
+    for (const col of data.columns) {
+      if (col.name.toLowerCase().includes(q)) {
+        matches.push({ rowIndex: -1, colId: col.name });
+      }
+    }
+
     for (let r = 0; r < editingRows.length; r++) {
       for (let c = 0; c < editingRows[r].length; c++) {
         const val = editingRows[r][c];
@@ -402,10 +415,24 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     searchCurrentRef.current = match;
     const api = gridApiRef.current;
     if (!api) return;
-    api.ensureIndexVisible(match.rowIndex, "middle");
-    api.ensureColumnVisible(match.colId);
+
+    if (match.rowIndex < 0) {
+      // Column-name match (bug #56 sentinel). There's no row to
+      // scroll to — just bring the column into view and focus its
+      // first data row so the user sees a clear "this is the column
+      // you were searching for" cell outline. ag-grid's
+      // `headerClass` isn't reactive without a custom header
+      // component, so we rely on cell focus for the visual cue.
+      api.ensureColumnVisible(match.colId);
+      if (editingRows.length > 0) {
+        api.setFocusedCell(0, match.colId);
+      }
+    } else {
+      api.ensureIndexVisible(match.rowIndex, "middle");
+      api.ensureColumnVisible(match.colId);
+    }
     api.refreshCells({ force: true });
-  }, [searchMatches]);
+  }, [searchMatches, editingRows.length]);
 
   useEffect(() => {
     if (searchMatches.length > 0) {


### PR DESCRIPTION
Closes #56.

## Summary

The data grid's inline search bar promises *"Search columns and values..."* but the matcher only scanned cell values, so typing a column name returned zero results — exactly the opposite of what the placeholder copy says.

## Fix

Two surgical changes in \`DataGrid.tsx\`:

1. **\`searchMatches\` scans column headers first**, before the row/cell loop. Column matches carry a sentinel \`rowIndex = -1\` so the navigation handler can distinguish them from row/cell matches without changing the \`SearchMatch\` shape.
2. **\`navigateToMatch\` handles the sentinel**: instead of \`ensureIndexVisible\` (no row to scroll to), it calls \`ensureColumnVisible\` + \`setFocusedCell(0, colId)\`. The user gets a standard ag-grid cell-focus outline on the column they searched for — a clear visual cue that doesn't require a custom header component or per-frame \`refreshHeader\` calls.

Cell-value matches are unchanged. The shared search counter, Enter / Shift+Enter navigation, and per-cell highlight all keep working because they read from the same \`searchMatches\` array; only the column-only branch diverges in \`navigateToMatch\`.

## Tests

6 new cases in \`DataGrid.test.ts\` for the column-name path:

| Case | Asserts |
|---|---|
| matches a column name with sentinel \`rowIndex = -1\` | the sentinel shape itself |
| case-insensitive column match | \`"EMAIL"\` matches \`email\` |
| partial column substring | \`"nam"\` matches \`name\` |
| multiple column matches | \`"user"\` matches \`user_id\` and \`user_email\`, but not \`created_at\` |
| ordering | column matches come before cell matches in the result array |
| mixed query (column AND cell hits) | both surface, in the right order |

Plus a guard in \`isCellSearchCurrent\` that proves no data cell ever lights up the per-cell highlight while the user is navigating to a column match (because no cell has \`rowIndex = -1\`).

## Verification

- \`vitest src/components/DataGrid/DataGrid.test.ts\` — 133 / 133 pass
- \`npm test\` — 616 / 616 pass
- \`tsc --noEmit\` — clean

## Acceptance criteria

- [x] Typing a column name in the grid search bar finds and focuses that column
- [x] Typing a cell value continues to work exactly as today
- [x] Match navigation (Enter / next / previous) handles both cell-value and column-name matches
- [x] Tests in \`DataGrid.test.ts\` cover the column-name match path
- [x] No regression in the existing inline search test cases

## Out of scope (per the issue)

- The \`ColumnOrganizer\` column search (separate purpose: show / hide / reorder).
- Multi-token / regex search.