### PR TITLE
feat(grid): press Down on the last row to add a new pending row (#64)

### DIFF
--- a/src/components/DataGrid/DataGrid.test.ts
+++ b/src/components/DataGrid/DataGrid.test.ts
@@ -1004,3 +1004,118 @@ describe("Delete button label", () => {
     expect(deleteButtonLabel(100)).toBe("Delete 100 rows");
   });
 });
+
+// -----------------------------------------------------------------------
+// Feature #64: pressing Down on the last data row creates a new pending
+// row, spreadsheet-style. The logic lives inside an `onCellKeyDown`
+// callback in DataGrid.tsx; we mirror its decision-making here as a pure
+// function so we can exercise every branch without spinning up ag-grid.
+// -----------------------------------------------------------------------
+
+interface DownAddRowInput {
+  key: string;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  rowPinned: "top" | "bottom" | null;
+  rowIndex: number;
+  lastDataRowIndex: number; // = agRowData.length - 1
+  editingCellsCount: number;
+  hasColumns: boolean;
+  hasEditableColumn: boolean;
+}
+
+/**
+ * Returns true when a keydown event should be handled as "add a new
+ * pending row". Mirrors the conditions inside
+ * `DataGrid.tsx::handleCellKeyDown` exactly.
+ */
+function shouldAddRowOnDown(input: DownAddRowInput): boolean {
+  if (input.key !== "ArrowDown") return false;
+  if (input.shiftKey || input.ctrlKey || input.metaKey || input.altKey)
+    return false;
+  if (input.rowPinned !== null) return false;
+  if (input.lastDataRowIndex < 0) return false;
+  if (input.rowIndex !== input.lastDataRowIndex) return false;
+  if (input.editingCellsCount > 0) return false;
+  if (!input.hasColumns) return false;
+  if (!input.hasEditableColumn) return false;
+  return true;
+}
+
+const baseInput: DownAddRowInput = {
+  key: "ArrowDown",
+  shiftKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  rowPinned: null,
+  rowIndex: 4,
+  lastDataRowIndex: 4,
+  editingCellsCount: 0,
+  hasColumns: true,
+  hasEditableColumn: true,
+};
+
+describe("Down-on-last-row creates a new pending row (#64)", () => {
+  it("fires on the last data row with a plain ArrowDown", () => {
+    expect(shouldAddRowOnDown(baseInput)).toBe(true);
+  });
+
+  it("does not fire for any key other than ArrowDown", () => {
+    for (const key of ["ArrowUp", "ArrowLeft", "ArrowRight", "Enter", "Tab", "PageDown", "End"]) {
+      expect(shouldAddRowOnDown({ ...baseInput, key })).toBe(false);
+    }
+  });
+
+  it("does not fire when a modifier is held (selection extension, page nav, etc.)", () => {
+    expect(shouldAddRowOnDown({ ...baseInput, shiftKey: true })).toBe(false);
+    expect(shouldAddRowOnDown({ ...baseInput, ctrlKey: true })).toBe(false);
+    expect(shouldAddRowOnDown({ ...baseInput, metaKey: true })).toBe(false);
+    expect(shouldAddRowOnDown({ ...baseInput, altKey: true })).toBe(false);
+  });
+
+  it("does not fire when the user is not on the last data row", () => {
+    expect(shouldAddRowOnDown({ ...baseInput, rowIndex: 0 })).toBe(false);
+    expect(shouldAddRowOnDown({ ...baseInput, rowIndex: 3 })).toBe(false);
+  });
+
+  it("does not fire when focus is on a pinned-top row (i.e. an in-progress insert)", () => {
+    // Pinned-top is where the new rows ALREADY go after we add
+    // them. Chaining Down there would create rows indefinitely
+    // before the user has typed anything.
+    expect(shouldAddRowOnDown({ ...baseInput, rowPinned: "top" })).toBe(false);
+  });
+
+  it("does not fire when there are no data rows at all", () => {
+    expect(shouldAddRowOnDown({ ...baseInput, rowIndex: -1, lastDataRowIndex: -1 })).toBe(false);
+  });
+
+  it("does not fire while a cell is being edited", () => {
+    // ag-grid forwards keydown to the cell editor while editing.
+    // We must not mutate the row set out from under the editor.
+    expect(shouldAddRowOnDown({ ...baseInput, editingCellsCount: 1 })).toBe(false);
+  });
+
+  it("does not fire when the table has no columns", () => {
+    expect(shouldAddRowOnDown({ ...baseInput, hasColumns: false })).toBe(false);
+  });
+
+  it("does not fire when every column is auto-generated (degenerate case)", () => {
+    // e.g. a table whose only column is a serial PK. There's no
+    // editable column to focus, so the shortcut would land the
+    // user on a non-editable cell.
+    expect(shouldAddRowOnDown({ ...baseInput, hasEditableColumn: false })).toBe(false);
+  });
+
+  it("repeated Down keystrokes only fire while still on the last row", () => {
+    // After the first Down adds a row and moves focus to the
+    // pinned-top area, the next Down arrives with rowPinned="top"
+    // and so the guard above blocks chained creation.
+    expect(shouldAddRowOnDown(baseInput)).toBe(true);
+    expect(
+      shouldAddRowOnDown({ ...baseInput, rowPinned: "top", rowIndex: 0 })
+    ).toBe(false);
+  });
+});

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -46,7 +46,7 @@ import {
   Terminal,
 } from "lucide-react";
 import { save } from "@tauri-apps/plugin-dialog";
-import { AllCommunityModule, themeQuartz, type ColDef, type CellClickedEvent, type CellContextMenuEvent, type GridApi, type GridReadyEvent, type IHeaderParams, type SelectionChangedEvent } from "ag-grid-community";
+import { AllCommunityModule, themeQuartz, type ColDef, type CellClickedEvent, type CellContextMenuEvent, type CellKeyDownEvent, type GridApi, type GridReadyEvent, type IHeaderParams, type SelectionChangedEvent } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 import "./DataGrid.css";
 import "./ag-grid-theme.css";
@@ -627,6 +627,54 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     }));
     setTimeout(() => gridApiRef.current?.ensureIndexVisible(0, "top"), 0);
   };
+
+  // Spreadsheet-style "Down on last row → add new pending row"
+  // (feature #64). The newly-added row goes into the pinned-top
+  // area, same as the toolbar "Add Row" button, so users can save
+  // a batch of inserts in one transaction. We move focus straight
+  // to the first editable cell of the new row so the user can
+  // type immediately without reaching for the mouse.
+  const handleCellKeyDown = useCallback((event: CellKeyDownEvent) => {
+    const ev = event.event as KeyboardEvent | null;
+    if (!ev || ev.key !== "ArrowDown") return;
+    // Modified Down is reserved for selection extension / page nav;
+    // don't hijack those.
+    if (ev.shiftKey || ev.ctrlKey || ev.metaKey || ev.altKey) return;
+
+    // Only react when focus is on an existing data row at the very
+    // bottom of the main grid. The pinned-top area holds in-progress
+    // inserts; chaining Down there would create rows indefinitely.
+    if (event.rowPinned) return;
+    const lastIdx = agRowData.length - 1;
+    if (lastIdx < 0 || event.rowIndex !== lastIdx) return;
+
+    // ag-grid forwards keydown to the cell editor while a cell is
+    // being edited; we don't want to mutate the row set out from
+    // under the editor.
+    const api = event.api;
+    if (api.getEditingCells().length > 0) return;
+
+    if (!data) return;
+    // First non-auto-generated column is the first cell the user
+    // can actually type into. If every column is auto-generated
+    // (a degenerate case but possible for tables with only a
+    // serial PK), there's nothing to focus, so we don't trigger
+    // the shortcut.
+    const firstEditable = data.columns.find((c) => !c.is_auto_generated);
+    if (!firstEditable) return;
+
+    ev.preventDefault();
+
+    // The new pinned row's index = current count of pinned rows
+    // (we're appending). We capture this *before* `handleAddRow`
+    // mutates state so we can target it from a setTimeout that
+    // runs after the next render pass.
+    const newPinnedIdx = pinnedTopRows.length;
+    handleAddRow();
+    setTimeout(() => {
+      gridApiRef.current?.setFocusedCell(newPinnedIdx, firstEditable.name, "top");
+    }, 0);
+  }, [agRowData.length, pinnedTopRows.length, data, handleAddRow]);
 
   const handleDeleteRow = (rowIndex: number) => {
     const pkKey = getPkKey(rowIndex);
@@ -1258,6 +1306,7 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
           onGridReady={onGridReady}
           onCellClicked={onCellClicked}
           onCellContextMenu={onCellContextMenu}
+          onCellKeyDown={handleCellKeyDown}
           onSortChanged={onSortChanged}
           onSelectionChanged={onSelectionChanged}
           rowSelection={{ mode: "multiRow", checkboxes: false, headerCheckbox: false, enableClickSelection: false }}


### PR DESCRIPTION
Closes #64.

## Summary

In a spreadsheet, pressing Down on the last row creates a new empty row. The data grid should support the same shortcut so users don't have to click "Add Row" in the toolbar.

## Fix

A new \`onCellKeyDown\` handler on the grid (\`handleCellKeyDown\` in \`DataGrid.tsx\`):

- **Only plain ArrowDown** triggers — Shift / Ctrl / Cmd / Alt + Down keep their existing meanings (selection extension, page nav, etc.)
- **Only when focus is on the last data row** in the main (non-pinned) area. Pinned-top is where in-progress inserts already live; chaining Down there would create unlimited empty rows.
- **No-op while a cell is being edited** — ag-grid forwards keydown to the editor in that case
- **No-op when no editable columns exist** (degenerate: every column is auto-generated, e.g. a serial-PK-only table)

When all guards pass, it calls the existing \`handleAddRow\` (same single-transaction save path the toolbar uses) and then \`setFocusedCell\` onto the new pinned row's first editable column so the user can type immediately.

## Tests

10 new cases in \`DataGrid.test.ts\` covering each guard branch via a pure \`shouldAddRowOnDown\` function that mirrors the in-component decision logic — no ag-grid needed in the test loop.

| Case | Asserts |
|---|---|
| fires on last data row with plain ArrowDown | the happy path |
| does not fire for other keys | every non-ArrowDown key |
| does not fire when a modifier is held | Shift / Ctrl / Cmd / Alt |
| does not fire on non-last rows | rowIndex 0 and rowIndex 3 |
| does not fire on pinned-top rows | the "chained creation" guard |
| does not fire with no data rows | empty table case |
| does not fire while editing | ag-grid editor pass-through |
| does not fire with no columns | empty schema case |
| does not fire when every column is auto-generated | degenerate-table case |
| repeated Down only fires while still on last row | proves repeated keystrokes can't chain rows |

## Acceptance criteria

- [x] Pressing Down on the last data row adds a new pending row and focuses its first editable cell
- [x] Repeated Down keystrokes do not create multiple empty rows in a single press
- [x] No-op for tables without editable columns or while the user is actively editing
- [x] The new row appears in the existing pending-row area and saves through the existing transaction path
- [x] Component test covers the Down-on-last-row path

## Notes

- There's no explicit "read-only" prop on the data grid today, so we follow the same UX as the existing toolbar "Add Row" button: always available; save-time errors surface naturally if the underlying table doesn't support inserts.
- Out of scope per the issue: bulk row creation (Down + N), auto-saving the row before it has values.

## Verification

- \`vitest src/components/DataGrid/DataGrid.test.ts\` — 136 / 136 pass
- \`tsc --noEmit\` — clean
- \`npm test\` — full frontend suite green