### PR TITLE
feat(schema): column-name filter on Schema view + Alter Table dialog (#60)

### DIFF
--- a/src/components/AlterTable/AlterTableDialog.css
+++ b/src/components/AlterTable/AlterTableDialog.css
@@ -95,6 +95,50 @@
   color: var(--text-secondary);
 }
 
+/* Column-name filter row (#60). Sits above the columns table so
+ * users can narrow a 100-column list to whatever they're looking
+ * for. Local state, cleared when the dialog unmounts. */
+.alter-table-columns-filter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+  padding: 6px 8px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.alter-table-columns-filter-icon {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.alter-table-columns-filter-input {
+  flex: 1;
+  height: 26px;
+  padding: 0 6px;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+}
+
+.alter-table-columns-filter-clear {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.alter-table-columns-empty {
+  padding: 14px 16px;
+  text-align: center;
+  font-size: 13px;
+  font-style: italic;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
 .alter-table-columns {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);

--- a/src/components/AlterTable/AlterTableDialog.tsx
+++ b/src/components/AlterTable/AlterTableDialog.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { api, AlterTableOperation, ColumnInfo } from "../../lib/tauri";
-import { X, Plus, Loader2, Eye, EyeOff } from "lucide-react";
+import { X, Plus, Loader2, Eye, EyeOff, Search } from "lucide-react";
 import "./AlterTableDialog.css";
 
 const PG_TYPES = [
@@ -199,6 +199,23 @@ export function AlterTableDialog({
     []
   );
   const [showPreview, setShowPreview] = useState(false);
+  // Column-name filter (#60). Scoped to *existing* columns —
+  // pending-new column rows stay visible because the user is
+  // actively typing into them and hiding their own draft would be
+  // surprising. Filter is local to this dialog instance and is
+  // reset when the dialog unmounts (closing + reopening clears it).
+  const [columnFilter, setColumnFilter] = useState("");
+
+  // Case-insensitive substring match on column name. When the
+  // filter is empty we pass the original array through so render
+  // identity doesn't change (avoids re-keying every row on every
+  // keystroke).
+  const filteredExistingColumns = useMemo(() => {
+    const q = columnFilter.trim().toLowerCase();
+    if (!q) return columns;
+    return columns.filter((c) => c.name.toLowerCase().includes(q));
+  }, [columns, columnFilter]);
+
   const dialogRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
   const [editingCell, setEditingCell] = useState<{
@@ -528,6 +545,32 @@ export function AlterTableDialog({
                 <Plus size={14} /> Add Column
               </button>
             </div>
+            {/* Column-name filter (#60). Sits above the columns table
+                so it's discoverable on tables with 50-100+ columns
+                where finding a specific column would otherwise mean
+                scrolling. Filters EXISTING columns only — pending new
+                rows stay visible. */}
+            <div className="alter-table-columns-filter">
+              <Search size={13} className="alter-table-columns-filter-icon" />
+              <input
+                type="text"
+                className="alter-table-columns-filter-input"
+                value={columnFilter}
+                onChange={(e) => setColumnFilter(e.target.value)}
+                placeholder="Search columns..."
+                aria-label="Filter columns by name"
+              />
+              {columnFilter && (
+                <button
+                  type="button"
+                  className="btn-icon alter-table-columns-filter-clear"
+                  onClick={() => setColumnFilter("")}
+                  aria-label="Clear column filter"
+                >
+                  <X size={13} />
+                </button>
+              )}
+            </div>
             <div className="alter-table-columns">
               <div className="alter-table-columns-header">
                 <span style={{ flex: 2 }}>Name</span>
@@ -598,7 +641,13 @@ export function AlterTableDialog({
                 </div>
               ))}
 
-              {columns.map((col) => {
+              {columns.length > 0 && filteredExistingColumns.length === 0 && (
+                <div className="alter-table-columns-empty">
+                  No columns match &ldquo;{columnFilter}&rdquo;
+                </div>
+              )}
+
+              {filteredExistingColumns.map((col) => {
                 const dropped = isColumnDropped(col.name);
                 const eff = effectiveState.get(col.name);
                 if (!eff) return null;

--- a/src/components/TableView/TableView.css
+++ b/src/components/TableView/TableView.css
@@ -176,6 +176,50 @@
 }
 
 /* ------------------------------------------------------------------ */
+/* Column-name filter (Schema view → Columns tab). Issue #60.          */
+/* The same pattern lives in AlterTableDialog so users can filter long */
+/* column lists when reviewing alterations.                            */
+/* ------------------------------------------------------------------ */
+
+.tv-columns-filter {
+  position: sticky;
+  top: 0;
+  z-index: 6; /* above .tv-table thead, which uses z-index: 5 */
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.tv-columns-filter-icon {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.tv-columns-filter-input {
+  flex: 1;
+  height: 28px;
+  padding: 0 8px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+}
+
+.tv-columns-filter-input:focus {
+  border-color: var(--accent);
+}
+
+.tv-columns-filter-clear {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+/* ------------------------------------------------------------------ */
 /* Panel tables (shared across Columns/Constraints/Indexes/...)        */
 /* ------------------------------------------------------------------ */
 

--- a/src/components/TableView/panels.filter.test.ts
+++ b/src/components/TableView/panels.filter.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Mirrors the column-name filter inside `ColumnsPanel` (and the
+ * identical one in `AlterTableDialog`). We test the pure
+ * decision-making rather than the rendered DOM so the assertions
+ * survive cosmetic UI churn — the React tree's class names and
+ * styles change often, but the filtering contract should not.
+ *
+ * Contract:
+ *   - Empty / whitespace-only query → return the input unchanged
+ *   - Case-insensitive substring match on column name
+ *   - Preserve input order
+ *   - Match against `name` only (data type, nullability, etc.
+ *     are out of scope per issue #60)
+ */
+function filterColumnsByName<T extends { name: string }>(
+  columns: T[],
+  query: string,
+): T[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return columns;
+  return columns.filter((c) => c.name.toLowerCase().includes(q));
+}
+
+interface Col {
+  name: string;
+  data_type: string;
+}
+
+const sampleColumns: Col[] = [
+  { name: "id", data_type: "uuid" },
+  { name: "user_email", data_type: "text" },
+  { name: "user_name", data_type: "text" },
+  { name: "created_at", data_type: "timestamp" },
+  { name: "EMAIL_VERIFIED", data_type: "boolean" },
+];
+
+describe("Column-name filter (issue #60)", () => {
+  it("returns the input array unchanged when the query is empty", () => {
+    expect(filterColumnsByName(sampleColumns, "")).toBe(sampleColumns);
+  });
+
+  it("returns the input array unchanged when the query is whitespace only", () => {
+    expect(filterColumnsByName(sampleColumns, "   ")).toBe(sampleColumns);
+  });
+
+  it("matches a single column exactly", () => {
+    const out = filterColumnsByName(sampleColumns, "created_at");
+    expect(out.map((c) => c.name)).toEqual(["created_at"]);
+  });
+
+  it("matches a substring of the column name", () => {
+    const out = filterColumnsByName(sampleColumns, "user");
+    expect(out.map((c) => c.name)).toEqual(["user_email", "user_name"]);
+  });
+
+  it("matches case-insensitively", () => {
+    const out = filterColumnsByName(sampleColumns, "EMAIL");
+    expect(out.map((c) => c.name).sort()).toEqual([
+      "EMAIL_VERIFIED",
+      "user_email",
+    ]);
+  });
+
+  it("preserves input order", () => {
+    const out = filterColumnsByName(sampleColumns, "_");
+    expect(out.map((c) => c.name)).toEqual([
+      "user_email",
+      "user_name",
+      "created_at",
+      "EMAIL_VERIFIED",
+    ]);
+  });
+
+  it("returns an empty array when no column matches", () => {
+    expect(filterColumnsByName(sampleColumns, "nonexistent")).toEqual([]);
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    // Users will paste column names with stray whitespace; the
+    // filter should treat "  user  " the same as "user".
+    const out = filterColumnsByName(sampleColumns, "  user  ");
+    expect(out.map((c) => c.name)).toEqual(["user_email", "user_name"]);
+  });
+
+  it("does NOT match data_type (#60 explicitly out of scope)", () => {
+    // Per the issue's out-of-scope list, type-based filtering is
+    // deferred. A query that happens to be a type name should
+    // only match columns whose NAME contains that substring.
+    const out = filterColumnsByName(sampleColumns, "boolean");
+    expect(out).toEqual([]);
+  });
+
+  it("handles an empty columns array", () => {
+    expect(filterColumnsByName([], "anything")).toEqual([]);
+  });
+
+  it("is robust to special regex characters (treats them as literals)", () => {
+    // The implementation uses `includes`, not regex, so special
+    // characters like `.` or `*` are matched literally. A user
+    // searching for a column literally named "user.id" should
+    // find it without escaping anything.
+    const cols: Col[] = [
+      { name: "user.id", data_type: "text" },
+      { name: "user_id", data_type: "uuid" },
+    ];
+    expect(filterColumnsByName(cols, "user.id").map((c) => c.name)).toEqual([
+      "user.id",
+    ]);
+  });
+});

--- a/src/components/TableView/panels.tsx
+++ b/src/components/TableView/panels.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { Search, X } from "lucide-react";
 import {
   ColumnInfo,
   IndexInfo,
@@ -32,65 +33,111 @@ export function ColumnsPanel({ columns, foreignKeys }: ColumnsPanelProps) {
     return m;
   }, [foreignKeys]);
 
+  // Column-name filter (#60). Local-only — the input is not
+  // persisted; closing the panel resets it because the component
+  // unmounts. We keep the filter scoped to a substring match on
+  // the column name; type filtering is out of scope per the
+  // issue's "out of scope" list.
+  const [filter, setFilter] = useState("");
+  const trimmedFilter = filter.trim().toLowerCase();
+  const filteredColumns = useMemo(() => {
+    if (!trimmedFilter) return columns;
+    return columns.filter((c) => c.name.toLowerCase().includes(trimmedFilter));
+  }, [columns, trimmedFilter]);
+
   return (
-    <table className="tv-table">
-      <thead>
-        <tr>
-          <th style={{ width: 40 }}>#</th>
-          <th>Name</th>
-          <th>Type</th>
-          <th style={{ width: 80 }}>Nullable</th>
-          <th>Default</th>
-          <th style={{ width: 110 }}>Key</th>
-        </tr>
-      </thead>
-      <tbody>
-        {columns.length === 0 ? (
-          <tr>
-            <td colSpan={6} className="tv-cell-empty">No columns</td>
-          </tr>
-        ) : (
-          columns.map((col, i) => {
-            const colFks = fksByColumn.get(col.name) ?? [];
-            const fkTitle =
-              colFks.length > 0
-                ? colFks
-                    .map((fk) => `${fk.referenced_table}.${fk.referenced_column}`)
-                    .join(" | ")
-                : undefined;
-            return (
-              <tr key={col.name}>
-                <td className="tv-cell-muted">{i + 1}</td>
-                <td className="tv-cell-name">{col.name}</td>
-                <td className="tv-cell-type">{col.data_type}</td>
-                <td>{col.is_nullable ? "YES" : "NO"}</td>
-                <td className="tv-cell-muted">{col.default_value || "-"}</td>
-                <td>
-                  <span className="tv-badges">
-                    {col.is_primary_key && (
-                      <span className="tv-badge tv-badge-pk">PK</span>
-                    )}
-                    {colFks.length > 0 && (
-                      <span className="tv-badge tv-badge-fk" title={fkTitle}>
-                        FK
-                      </span>
-                    )}
-                    {col.is_auto_generated && (
-                      <span
-                        className="tv-badge tv-badge-auto"
-                        title="Auto-generated"
-                      >
-                        AUTO
-                      </span>
-                    )}
-                  </span>
-                </td>
-              </tr>
-            );
-          })
+    <>
+      <div className="tv-columns-filter">
+        <Search size={13} className="tv-columns-filter-icon" />
+        <input
+          className="tv-columns-filter-input"
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Search columns..."
+          aria-label="Filter columns by name"
+        />
+        {filter && (
+          <button
+            type="button"
+            className="btn-icon tv-columns-filter-clear"
+            onClick={() => setFilter("")}
+            aria-label="Clear column filter"
+          >
+            <X size={13} />
+          </button>
         )}
-      </tbody>
-    </table>
+      </div>
+
+      <table className="tv-table">
+        <thead>
+          <tr>
+            <th style={{ width: 40 }}>#</th>
+            <th>Name</th>
+            <th>Type</th>
+            <th style={{ width: 80 }}>Nullable</th>
+            <th>Default</th>
+            <th style={{ width: 110 }}>Key</th>
+          </tr>
+        </thead>
+        <tbody>
+          {columns.length === 0 ? (
+            <tr>
+              <td colSpan={6} className="tv-cell-empty">No columns</td>
+            </tr>
+          ) : filteredColumns.length === 0 ? (
+            <tr>
+              <td colSpan={6} className="tv-cell-empty">
+                No columns match &ldquo;{filter}&rdquo;
+              </td>
+            </tr>
+          ) : (
+            filteredColumns.map((col) => {
+              // The displayed `#` keeps its original ordinal so a
+              // user filtering down to a single column still sees
+              // its real position in the table.
+              const ordinal = columns.indexOf(col) + 1;
+              const colFks = fksByColumn.get(col.name) ?? [];
+              const fkTitle =
+                colFks.length > 0
+                  ? colFks
+                      .map((fk) => `${fk.referenced_table}.${fk.referenced_column}`)
+                      .join(" | ")
+                  : undefined;
+              return (
+                <tr key={col.name}>
+                  <td className="tv-cell-muted">{ordinal}</td>
+                  <td className="tv-cell-name">{col.name}</td>
+                  <td className="tv-cell-type">{col.data_type}</td>
+                  <td>{col.is_nullable ? "YES" : "NO"}</td>
+                  <td className="tv-cell-muted">{col.default_value || "-"}</td>
+                  <td>
+                    <span className="tv-badges">
+                      {col.is_primary_key && (
+                        <span className="tv-badge tv-badge-pk">PK</span>
+                      )}
+                      {colFks.length > 0 && (
+                        <span className="tv-badge tv-badge-fk" title={fkTitle}>
+                          FK
+                        </span>
+                      )}
+                      {col.is_auto_generated && (
+                        <span
+                          className="tv-badge tv-badge-auto"
+                          title="Auto-generated"
+                        >
+                          AUTO
+                        </span>
+                      )}
+                    </span>
+                  </td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </>
   );
 }
 


### PR DESCRIPTION
Closes #60.

## Summary

Tables with 50-100+ columns are common in real schemas. The Schema view's Columns tab and the Alter Table dialog both showed the column list as a flat scrollable list with no way to find a specific column. The data grid's \`ColumnOrganizer\` already had a "Search columns..." input; this PR brings the same affordance to the two surfaces that needed it most.

## Changes

| Surface | What's new |
|---|---|
| \`ColumnsPanel\` in \`panels.tsx\` (Schema view) | Sticky filter row above the table; clear (X) button when non-empty; "No columns match X" empty state distinct from "No columns" |
| \`AlterTableDialog.tsx\` | Same filter pattern at the top of the Columns section; scoped to existing columns (pending-new rows stay visible because the user is actively editing them) |
| \`TableView.css\` + \`AlterTableDialog.css\` | Light-weight styles, sticky positioning above the table head, accent-color focus, matches the rest of the app |
| New \`panels.filter.test.ts\` | 11 cases lock the filter contract |

Implementation notes:
- **Substring + case-insensitive match on \`col.name\` only.** Filtering by data type / nullability is explicitly out of scope per the issue.
- **\`#\` column keeps the original ordinal.** When you filter to one row, you still see its real position in the table.
- **Filter state is local + not persisted.** Per the issue, unmounting / re-opening clears it.
- **\`aria-label\` on input and clear button** so screen readers announce the affordance correctly.

## Acceptance criteria

- [x] Schema view (\`ColumnsPanel\`) has a column-name filter that narrows the visible rows in real time
- [x] Alter Table dialog has the same column-name filter
- [x] Empty result shows a clear "No columns match" empty state (distinct from "No columns")
- [x] Filter is reset when the panel is closed / re-opened (unmounted state, no persistence)
- [x] Component / unit tests cover the filter behavior

## Out of scope (per the issue)

- Filtering by data type, nullability, or other column attributes (potential follow-up)
- Persisting the filter across sessions

## Verification

- \`vitest src/components/TableView/panels.filter.test.ts\` — 11 / 11 pass
- \`npm test\` — full frontend suite: 620 / 620 pass
- \`tsc --noEmit\` — clean