### PR TITLE
Revert: column-name match in grid search (#56 / PR #139)

### DIFF
--- a/src/components/DataGrid/DataGrid.test.ts
+++ b/src/components/DataGrid/DataGrid.test.ts
@@ -129,15 +129,6 @@ function buildSearchMatches(
   if (!searchQuery || !columns) return [];
   const q = searchQuery.toLowerCase();
   const matches: SearchMatch[] = [];
-
-  // Column-name matches first (bug #56). Sentinel rowIndex = -1
-  // means "no row — scroll the column into view".
-  for (const col of columns) {
-    if (col.name.toLowerCase().includes(q)) {
-      matches.push({ rowIndex: -1, colId: col.name });
-    }
-  }
-
   for (let r = 0; r < editingRows.length; r++) {
     for (let c = 0; c < editingRows[r].length; c++) {
       const val = editingRows[r][c];
@@ -290,75 +281,6 @@ describe("DataGrid search match building", () => {
     const matches = buildSearchMatches("alice", rows, shortCols);
     expect(matches).toEqual([]);
   });
-
-  // -----------------------------------------------------------------------
-  // Bug #56: the placeholder "Search columns and values..." promised
-  // column-name matching, but the matcher only scanned cell values.
-  // The fix adds column-name matches with a sentinel rowIndex = -1.
-  // -----------------------------------------------------------------------
-
-  it("matches a column name with sentinel rowIndex = -1", () => {
-    const matches = buildSearchMatches("email", [], cols);
-    expect(matches).toEqual([{ rowIndex: -1, colId: "email" }]);
-  });
-
-  it("matches a column name case-insensitively", () => {
-    const matches = buildSearchMatches("EMAIL", [], cols);
-    expect(matches).toEqual([{ rowIndex: -1, colId: "email" }]);
-  });
-
-  it("matches a column name with a partial substring", () => {
-    const matches = buildSearchMatches("nam", [], cols);
-    expect(matches).toEqual([{ rowIndex: -1, colId: "name" }]);
-  });
-
-  it("matches multiple column names", () => {
-    const fanCols = [
-      { name: "user_id" },
-      { name: "user_email" },
-      { name: "created_at" },
-    ];
-    const matches = buildSearchMatches("user", [], fanCols);
-    expect(matches).toEqual([
-      { rowIndex: -1, colId: "user_id" },
-      { rowIndex: -1, colId: "user_email" },
-    ]);
-  });
-
-  it("orders column matches before cell matches", () => {
-    const rows = [[1, "Alice", "alice@test.com"]];
-    // "name" matches the second column name AND no cell values.
-    const matches = buildSearchMatches("name", rows, cols);
-    expect(matches[0]).toEqual({ rowIndex: -1, colId: "name" });
-  });
-
-  it("finds both a column-name and a cell-value match in the same query", () => {
-    // Search query simultaneously matches the `email` column name
-    // AND the `alice@test.com` cell value. We surface both.
-    const rows = [[1, "Alice", "alice@test.com"]];
-    const matches = buildSearchMatches("email", rows, cols);
-    expect(matches).toEqual([
-      { rowIndex: -1, colId: "email" },
-      // No row-cell match here — neither "Alice" nor
-      // "alice@test.com" contains the substring "email".
-    ]);
-
-    // Now a query that hits both: "alice" matches the cell values
-    // but not the column names (cols = id / name / email).
-    const cellOnly = buildSearchMatches("alice", rows, cols);
-    expect(cellOnly).toEqual([
-      { rowIndex: 0, colId: "name" },
-      { rowIndex: 0, colId: "email" },
-    ]);
-
-    // And a query that hits BOTH a column name (`name`) and cell
-    // values that happen to contain it (`my_name_is_alice`).
-    const both = buildSearchMatches("name", [[1, "my_name_is_alice", "x"]], cols);
-    expect(both).toEqual([
-      { rowIndex: -1, colId: "name" },
-      { rowIndex: 0, colId: "name" },
-    ]);
-  });
 });
 
 describe("DataGrid search navigation index", () => {
@@ -463,17 +385,6 @@ describe("DataGrid cell search class rules", () => {
     it("returns false when colField is undefined", () => {
       const current = { rowIndex: 0, colId: "id" };
       expect(isCellSearchCurrent(current, 0, undefined)).toBe(false);
-    });
-
-    it("never matches a cell when the current match is a column-only sentinel (#56)", () => {
-      // After bug #56's fix, column-name matches use `rowIndex = -1`.
-      // No data cell has rowIndex = -1, so the cell-search-current
-      // class rule must never light up while the user navigates to
-      // a column match — the visual feedback for that path is
-      // `ensureColumnVisible` + `setFocusedCell`, not a cell tint.
-      const colMatch = { rowIndex: -1, colId: "email" };
-      expect(isCellSearchCurrent(colMatch, 0, "email")).toBe(false);
-      expect(isCellSearchCurrent(colMatch, 5, "email")).toBe(false);
     });
   });
 });

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -381,19 +381,6 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     if (!searchQuery || !data) return [];
     const q = searchQuery.toLowerCase();
     const matches: { rowIndex: number; colId: string }[] = [];
-
-    // Column-name matches come first. The search bar's placeholder
-    // promises "Search columns and values..."; without this loop
-    // (bug #56), typing a column name returned zero results despite
-    // the copy. We emit a sentinel match with `rowIndex = -1` that
-    // `navigateToMatch` interprets as "no row — just scroll the
-    // column into view".
-    for (const col of data.columns) {
-      if (col.name.toLowerCase().includes(q)) {
-        matches.push({ rowIndex: -1, colId: col.name });
-      }
-    }
-
     for (let r = 0; r < editingRows.length; r++) {
       for (let c = 0; c < editingRows[r].length; c++) {
         const val = editingRows[r][c];
@@ -415,24 +402,10 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     searchCurrentRef.current = match;
     const api = gridApiRef.current;
     if (!api) return;
-
-    if (match.rowIndex < 0) {
-      // Column-name match (bug #56 sentinel). There's no row to
-      // scroll to — just bring the column into view and focus its
-      // first data row so the user sees a clear "this is the column
-      // you were searching for" cell outline. ag-grid's
-      // `headerClass` isn't reactive without a custom header
-      // component, so we rely on cell focus for the visual cue.
-      api.ensureColumnVisible(match.colId);
-      if (editingRows.length > 0) {
-        api.setFocusedCell(0, match.colId);
-      }
-    } else {
-      api.ensureIndexVisible(match.rowIndex, "middle");
-      api.ensureColumnVisible(match.colId);
-    }
+    api.ensureIndexVisible(match.rowIndex, "middle");
+    api.ensureColumnVisible(match.colId);
     api.refreshCells({ force: true });
-  }, [searchMatches, editingRows.length]);
+  }, [searchMatches]);
 
   useEffect(() => {
     if (searchMatches.length > 0) {


### PR DESCRIPTION
Reverts #139 in full.

## Why

Two follow-up bugs surfaced after PR #139 shipped:

1. The auto-navigate-to-first-match \`useEffect\` ran on every keystroke and called \`api.setFocusedCell\` for column-only matches — that stole keyboard focus from the search input on every letter typed. PR #142 was the in-flight fix.
2. After PR #142 dropped \`setFocusedCell\` to keep focus in the input, the matched column scrolled into view but there was no visual cue showing *which* column matched. PR #142 added a header tint + column stripe to compensate.

Net effect: this turned out to be more delicate than the original "add a column-name match" patch deserved — the placeholder originally said \`"Search columns and values..."\` and the matcher only scanned values, so the natural alternative (the issue's "Option 2") is simply to update the placeholder text instead of growing the matcher.

After discussion, we're going with the lighter fix:

- Revert PR #139 entirely
- Close PR #142 unmerged (no longer needed)
- Follow-up: a one-line placeholder change so the copy matches the behaviour (\`"Search columns and values..."\` → \`"Search values..."\`)

The \`ColumnOrganizer\` ("Columns" dropdown in the data grid toolbar) already has a real column-name search, so the discoverability story for finding a column by name isn't lost.

## What's reverted

\`src/components/DataGrid/DataGrid.tsx\`:
- The column-header loop in \`searchMatches\` (sentinel \`rowIndex = -1\`)
- The column-only branch in \`navigateToMatch\`

\`src/components/DataGrid/DataGrid.test.ts\`:
- The 7 column-name match cases
- The "isCellSearchCurrent never matches a cell for column-only sentinel" guard

Nothing else has to change because PR #142's improvements (header tint, focus-loss test guards) only existed to support PR #139's feature and were never merged.

## Verification

- \`vitest src/components/DataGrid/DataGrid.test.ts\` — 136 / 136 pass (back from 147 after removing the 11 column-name cases, as expected)
- \`tsc --noEmit\` — clean