### PR TITLE
feat(table-view): move Query button to header (next to Data/Schema toggle)

### DIFF
--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -43,7 +43,6 @@ import {
   ExternalLink,
   Shuffle,
   Trash2,
-  Terminal,
 } from "lucide-react";
 import { save } from "@tauri-apps/plugin-dialog";
 import { AllCommunityModule, themeQuartz, type ColDef, type CellClickedEvent, type CellContextMenuEvent, type CellKeyDownEvent, type GridApi, type GridReadyEvent, type IHeaderParams, type SelectionChangedEvent } from "ag-grid-community";
@@ -1025,20 +1024,9 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
     addToast(`Opened ${fk.referenced_table} — filter by ${fk.referenced_column} = ${JSON.stringify(cellValue)}`);
   }, [connectionId, database, schema, connections, openTab, addToast]);
 
-  const handleOpenQuery = useCallback(() => {
-    const conn = connections.find((c) => c.id === connectionId);
-    const tabId = `query:${connectionId}:${database}:${table}:${Date.now()}`;
-    const tab: TabInfo = {
-      id: tabId,
-      type: "query",
-      title: `Query - ${table}`,
-      connectionId,
-      connectionColor: conn?.color || "#6398ff",
-      database,
-      schema: "",
-    };
-    openTab(tab);
-  }, [connectionId, database, table, connections, openTab]);
+  // `handleOpenQuery` used to live here; it now lives on TableView's
+  // header so the "Query" button is reachable from both Data and Schema
+  // modes (the DataGrid toolbar isn't rendered in Schema mode).
 
   const handleExplainResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -1153,13 +1141,6 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
               </div>
             )}
           </div>
-          <button
-            className="btn-ghost"
-            onClick={handleOpenQuery}
-            title="Open SQL query console for this database"
-          >
-            <Terminal size={14} /> Query
-          </button>
           {data && (
             <ColumnOrganizer
               columns={data.columns}

--- a/src/components/TableView/TableView.css
+++ b/src/components/TableView/TableView.css
@@ -90,6 +90,39 @@
 }
 
 /* ------------------------------------------------------------------ */
+/* Standalone Query button. Lives in the same header row as the         */
+/* Data/Schema toggle, sized to match the segmented control's buttons   */
+/* so the right edge of the header doesn't look unbalanced.             */
+/* ------------------------------------------------------------------ */
+
+.tv-query-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  height: 32px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+
+.tv-query-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border-color: color-mix(in srgb, var(--text-muted) 25%, var(--border));
+}
+
+.tv-query-btn:active {
+  background: var(--bg-secondary);
+}
+
+/* ------------------------------------------------------------------ */
 /* Mode switch (Data / Schema)                                         */
 /* ------------------------------------------------------------------ */
 

--- a/src/components/TableView/TableView.tsx
+++ b/src/components/TableView/TableView.tsx
@@ -4,6 +4,7 @@ import {
   AlertCircle,
   Table2,
   Layers,
+  Terminal,
 } from "lucide-react";
 import {
   api,
@@ -14,7 +15,7 @@ import {
   TriggerInfo,
   TableInfo as TableInfoType,
 } from "../../lib/tauri";
-import { useTabStore } from "../../stores/tabStore";
+import { useTabStore, TabInfo } from "../../stores/tabStore";
 import { DataGrid } from "../DataGrid/DataGrid";
 import { SchemaPage } from "./SchemaPage";
 import {
@@ -59,6 +60,25 @@ export function TableView({
   initialSubTab,
 }: Props) {
   const setTabSubTab = useTabStore((s) => s.setTabSubTab);
+  const openTab = useTabStore((s) => s.openTab);
+
+  // Opening a SQL query console scoped to this table used to live
+  // inside the DataGrid toolbar, but it's a "view-level" affordance —
+  // equally useful from the Schema tab where the toolbar isn't
+  // rendered. Lifting it to the TableView header makes it available
+  // in both modes from the same spot, next to the Data/Schema toggle.
+  const handleOpenQuery = useCallback(() => {
+    const tab: TabInfo = {
+      id: `query:${connectionId}:${database}:${table}:${Date.now()}`,
+      type: "query",
+      title: `Query - ${table}`,
+      connectionId,
+      connectionColor,
+      database,
+      schema: "",
+    };
+    openTab(tab);
+  }, [connectionId, connectionColor, database, table, openTab]);
 
   const initialParsed = useMemo(() => parseSubTab(initialSubTab), [initialSubTab]);
   const [mode, setMode] = useState<TableMode>(initialParsed.mode);
@@ -170,6 +190,14 @@ export function TableView({
         </div>
 
         <div className="tv-header-right">
+          <button
+            className="tv-query-btn btn-ghost"
+            onClick={handleOpenQuery}
+            title="Open SQL query console for this database"
+          >
+            <Terminal size={13} aria-hidden="true" />
+            <span>Query</span>
+          </button>
           <div className="tv-mode-switch" role="tablist" aria-label="View mode">
             <button
               role="tab"


### PR DESCRIPTION
## Summary

The "Query" button used to live inside the DataGrid toolbar, which meant it was only reachable while the **Data** tab was active. On the **Schema** tab the DataGrid toolbar isn't rendered, so users had to flip back to Data just to spawn a query console for the same table.

This PR moves the button to the TableView header, next to the Data/Schema segmented control, so it's a view-level affordance reachable from both modes.

## Before / After

| | |
|---|---|
| Before | Query button was the 4th item in the DataGrid toolbar, only visible in Data mode |
| After | Query button sits in the top-right header next to the Data/Schema toggle, visible from both modes |

## Changes

- **`TableView.tsx`**
  - New `handleOpenQuery` (identical semantics — same tab id format, same title, same color). Uses the existing `connectionColor` prop, so no new store dependency.
  - New `.tv-query-btn` rendered immediately before the Data/Schema segmented control in `tv-header-right`.
- **`TableView.css`**
  - `.tv-query-btn` styled to match the segmented-control buttons (32px height, same font weight, same letter-spacing) so the right side of the header reads as one cohesive cluster instead of two disconnected affordances.
- **`DataGrid.tsx`**
  - Removed the now-redundant Query button + \`handleOpenQuery\`.
  - Dropped the \`Terminal\` icon import (no remaining users).

## Verification

- \`npm test\` — 630 / 630 pass
- \`tsc --noEmit\` — clean
- Tab spawn semantics unchanged: same tab id format (\`query:<conn>:<db>:<table>:<ts>\`), same \`Query - <table>\` title, same tooltip copy.

## Out of scope

- Keyboard shortcut for the new button (could be a follow-up).
- Right-click context menu on the button (e.g. "Open in new tab"). The existing left-click behaviour is unchanged from the previous toolbar location.