### PR TITLE
fix(sqlite): views with computed columns no longer return NULL (#126)

### DIFF
--- a/src-tauri/src/db/sqlite.rs
+++ b/src-tauri/src/db/sqlite.rs
@@ -102,15 +102,54 @@ fn sqlite_row_to_json_values(
                     serde_json::Value::String(format!("X'{}'", hex_str))
                 })
                 .unwrap_or(serde_json::Value::Null),
-            _ => row
+            "TEXT" => row
                 .try_get::<String, _>(i)
                 .ok()
                 .map(serde_json::Value::String)
                 .unwrap_or(serde_json::Value::Null),
+            // Computed columns (view bodies, SELECT-list expressions
+            // like `strftime() - if(...)`, aggregates) have no declared
+            // type. SQLite gives sqlx a non-static type name and the
+            // earlier branches don't fire. The old fallback tried to
+            // decode the cell as `String` only, which silently failed
+            // for integer / real values and rendered them as NULL —
+            // that's the regression Dialga hit on issue #126 after
+            // v0.4.8 (every cell of his `create view f as select ...`
+            // came back null).
+            //
+            // Probe each concrete sqlx decoder in turn. Order matters:
+            // integer first so a `1+1` cell stays as the number `2`
+            // rather than the string `"2"`; real second so `1.5*2`
+            // stays a number rather than getting truncated to `3` by
+            // i64; string third; explicit null last.
+            _ => decode_dynamic_sqlite_cell(row, i),
         };
         values.push(val);
     }
     values
+}
+
+/// Per-cell decoder for SQLite columns whose declared type isn't one
+/// of the static affinities (`INTEGER` / `REAL` / `TEXT` / `BLOB` /
+/// `BOOLEAN`). The runtime type is inferred from whichever sqlx
+/// decoder accepts the cell first.
+fn decode_dynamic_sqlite_cell(row: &sqlx::sqlite::SqliteRow, i: usize) -> serde_json::Value {
+    if let Ok(Some(n)) = row.try_get::<Option<i64>, _>(i) {
+        return serde_json::Value::Number(n.into());
+    }
+    if let Ok(Some(n)) = row.try_get::<Option<f64>, _>(i) {
+        if let Some(num) = serde_json::Number::from_f64(n) {
+            return serde_json::Value::Number(num);
+        }
+    }
+    if let Ok(Some(s)) = row.try_get::<Option<String>, _>(i) {
+        return serde_json::Value::String(s);
+    }
+    if let Ok(Some(b)) = row.try_get::<Option<Vec<u8>>, _>(i) {
+        let hex: String = b.iter().map(|byte| format!("{:02x}", byte)).collect();
+        return serde_json::Value::String(format!("X'{}'", hex));
+    }
+    serde_json::Value::Null
 }
 
 fn quote_ident(name: &str) -> String {

--- a/src-tauri/tests/sqlite_integration.rs
+++ b/src-tauri/tests/sqlite_integration.rs
@@ -1639,3 +1639,118 @@ async fn sqlite_cancel_query() {
     driver.cancel_query("0").await.unwrap();
     let _ = std::fs::remove_file(&path);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #126 follow-up: views with computed expressions returned NULL
+// for every cell.
+//
+// Reproducer from the user comment on the original issue:
+//
+//   create table income as select current_date as date, 100 as amount;
+//   create view f as select
+//     strftime('%Y',date)-if(cast(strftime('%m',date) as int)<4, 1, 0) year,
+//     round(total(amount),2) as net_income from income group by year;
+//   select * from f;
+//
+// Expected: year = some integer (e.g. 2026), net_income = 100.0
+// Actual on v0.4.8: year = NULL, net_income = NULL.
+//
+// Root cause: `sqlite_row_to_json_values` in src/db/sqlite.rs matches
+// on `col.type_info().name()`. For a view's computed column there's no
+// declared type, so the driver returns whatever sqlite reports
+// per-cell at runtime — which is *not* one of "INTEGER" / "REAL" /
+// "TEXT" / "BLOB" / "BOOLEAN", so the function falls through to the
+// String branch. An integer cell can't be decoded as String, sqlx
+// returns Err, `.ok()` swallows it, and the cell renders as NULL.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn sqlite_view_with_computed_columns_does_not_return_null() {
+    let (driver, path) = create_driver().await;
+
+    driver
+        .execute_query(
+            DB,
+            "create table income as select current_date as date, 100 as amount;",
+        )
+        .await
+        .expect("create table failed");
+
+    driver
+        .execute_query(
+            DB,
+            "create view f as select \
+               strftime('%Y',date)-if(cast(strftime('%m',date) as int)<4, 1, 0) year, \
+               round(total(amount),2) as net_income from income group by year;",
+        )
+        .await
+        .expect("create view failed");
+
+    let result = driver
+        .execute_query(DB, "select * from f;")
+        .await
+        .expect("select from view failed");
+
+    assert_eq!(result.rows.len(), 1, "expected exactly one row");
+    let row = &result.rows[0];
+    assert_eq!(row.len(), 2, "expected exactly two columns");
+
+    // Both columns should have real values, not null. The exact
+    // year depends on the current date and the fiscal-year-style
+    // `if(month < 4, 1, 0)` adjustment, so we don't pin the exact
+    // value; we only assert the cells came back non-null.
+    assert!(
+        !row[0].is_null(),
+        "year column came back NULL — issue #126 reproduction. Driver: {:?}",
+        row[0]
+    );
+    assert!(
+        !row[1].is_null(),
+        "net_income column came back NULL — issue #126 reproduction. Driver: {:?}",
+        row[1]
+    );
+
+    // net_income is round(total(100), 2) on one row, which must be
+    // 100.0 (or the integer 100). Accept either shape; both are
+    // legitimate JSON encodings.
+    let net_income = row[1]
+        .as_f64()
+        .or_else(|| row[1].as_i64().map(|n| n as f64))
+        .unwrap_or_else(|| panic!("net_income not numeric: {:?}", row[1]));
+    assert!(
+        (net_income - 100.0).abs() < 0.001,
+        "net_income = {}, expected 100.0",
+        net_income
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+// Smaller, more targeted version of the same bug for stable regression
+// coverage: any SELECT-only query whose columns are pure expressions
+// (no underlying table) used to surface as NULL because the column
+// type names from sqlx-sqlite don't match the static type strings.
+#[tokio::test]
+async fn sqlite_select_of_pure_expressions_returns_real_values() {
+    let (driver, path) = create_driver().await;
+
+    let result = driver
+        .execute_query(
+            DB,
+            "select 1+1 as sum_val, 1.5*2 as prod_val, 'hi' as label_val;",
+        )
+        .await
+        .expect("select of pure expressions failed");
+
+    assert_eq!(result.rows.len(), 1);
+    let row = &result.rows[0];
+    assert_eq!(row.len(), 3);
+
+    // Three pure expressions — integer, real, text. Before the
+    // type-fallback fix every one of these came back as NULL.
+    assert!(!row[0].is_null(), "1+1 came back NULL: {:?}", row[0]);
+    assert!(!row[1].is_null(), "1.5*2 came back NULL: {:?}", row[1]);
+    assert!(!row[2].is_null(), "'hi' came back NULL: {:?}", row[2]);
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
Follow-up to #126. Dialga reported that v0.4.8 fixed the original \`no such function: if\` error but introduced a new regression — every cell of a view with computed expressions came back NULL.

## Reproducer (from Dialga's comment)

\`\`\`sql
create table income as select current_date as date, 100 as amount;
create view f as select
  strftime('%Y',date)-if(cast(strftime('%m',date) as int)<4, 1, 0) year,
  round(total(amount),2) as net_income from income group by year;
select * from f;
-- Expected: 2026 | 100.0
-- Actual on v0.4.8: NULL | NULL
\`\`\`

## Root cause

\`sqlite_row_to_json_values\` matched on \`col.type_info().name()\` and only handled the static SQLite affinities (\`BOOLEAN\` / \`INTEGER\` / \`REAL\` / \`BLOB\`) plus a \`String\` fallback for everything else.

For **view columns and SELECT-list expressions** (\`strftime() - if(...)\`, aggregates, arithmetic) SQLite reports no declared type — there's no underlying column definition to inherit from. sqlx-sqlite passes that through as a non-static type name, our fallback tried \`try_get::<String>\` on (say) an integer cell, sqlx returned \`Err\`, \`.ok()\` swallowed the error, and the cell rendered as NULL.

## Fix

Route the unknown-type branch through a new \`decode_dynamic_sqlite_cell\` helper that probes each concrete sqlx decoder in turn and returns the first one that decodes the cell:

| Order | Decoder | Why |
|---|---|---|
| 1 | \`Option<i64>\` | Keep \`1+1\` as the number 2 (not the string \`"2"\`). |
| 2 | \`Option<f64>\` | Keep \`1.5*2\` as 3.0 (not truncated to 3 by i64). |
| 3 | \`Option<String>\` | Text cells with no declared affinity. |
| 4 | \`Option<Vec<u8>>\` | Blob cells (rare in expressions but possible via \`x'deadbeef'\`). |
| else | \`null\` | Genuine NULL. |

The four static-type branches in the outer match are unchanged, so every existing path that already worked keeps working — only the dynamic-type fallback is upgraded.

## Tests

Two regression tests in \`sqlite_integration.rs\`:

| Test | What it covers |
|---|---|
| \`sqlite_view_with_computed_columns_does_not_return_null\` | Dialga's exact CREATE/SELECT from the issue; asserts neither computed column comes back NULL and \`net_income\` equals 100.0 |
| \`sqlite_select_of_pure_expressions_returns_real_values\` | Smaller table-less reproducer over integer / real / text expressions in a single SELECT |

Both **failed on master** before the fix (panicked with \`"came back NULL: Null"\`) and **pass after**.

## Verification

- \`cargo test --test sqlite_integration\` — 59/59 pass
- \`cargo test --lib\` — 414/414 pass
- \`cargo clippy --all-targets -- -D warnings\` — clean

## Out of scope

- Honouring SQLite's column-type affinity rules per-cell (the new helper is type-driven, not affinity-driven). If a column has a TEXT affinity but a cell stores integer 42, we'd now return JSON number 42 instead of "42". This is consistent with how the existing static-type branches behave (they trust sqlx's decode), so the dynamic branch shouldn't either.