### PR TITLE
feat(grid): multi-column sort end-to-end (#57)

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -21,7 +21,7 @@ pub async fn export_table_data(
             &request.table,
             0,
             1_000_000,
-            None,
+            Vec::new(),
             request.filter,
         )
         .await
@@ -68,7 +68,7 @@ pub async fn export_table_to_file(
             &request.table,
             0,
             1_000_000,
-            None,
+            Vec::new(),
             request.filter,
         )
         .await

--- a/src-tauri/src/db/cassandra.rs
+++ b/src-tauri/src/db/cassandra.rs
@@ -413,7 +413,7 @@ impl DatabaseDriver for CassandraDriver {
         table: &str,
         offset: u64,
         limit: u64,
-        sort: Option<SortSpec>,
+        sort: Vec<SortSpec>,
         filter: Option<String>,
     ) -> Result<TableData> {
         let columns = self.list_columns(database, database, table).await?;
@@ -464,15 +464,32 @@ impl DatabaseDriver for CassandraDriver {
 
         let mut cql = format!("SELECT * FROM {}{}", qualified, where_clause);
 
-        if let Some(ref s) = sort {
-            cql.push_str(&format!(
-                " ORDER BY {} {}",
-                quote_ident(&s.column),
-                match s.direction {
-                    SortDirection::Asc => "ASC",
-                    SortDirection::Desc => "DESC",
-                }
-            ));
+        if !sort.is_empty() {
+            // CQL `ORDER BY` is only valid on a partition's
+            // clustering columns and only in the table's defined
+            // clustering order (or its strict reverse). Tablio
+            // can't statically know which columns are clustering
+            // keys at this layer, so we just pass the user-picked
+            // sort vec through and let the Cassandra server be
+            // the gatekeeper: legal orderings work, illegal ones
+            // surface as an execution error. Multi-column sort
+            // (issue #57) follows the same rule — typically only
+            // useful when the user is sorting by the clustering
+            // columns in clustering order.
+            let parts: Vec<String> = sort
+                .iter()
+                .map(|s| {
+                    format!(
+                        "{} {}",
+                        quote_ident(&s.column),
+                        match s.direction {
+                            SortDirection::Asc => "ASC",
+                            SortDirection::Desc => "DESC",
+                        }
+                    )
+                })
+                .collect();
+            cql.push_str(&format!(" ORDER BY {}", parts.join(", ")));
         }
 
         // Saturating add prevents an integer overflow if the caller

--- a/src-tauri/src/db/cockroachdb.rs
+++ b/src-tauri/src/db/cockroachdb.rs
@@ -316,7 +316,7 @@ impl DatabaseDriver for CockroachdbDriver {
         table: &str,
         offset: u64,
         limit: u64,
-        sort: Option<SortSpec>,
+        sort: Vec<SortSpec>,
         filter: Option<String>,
     ) -> Result<TableData> {
         let pool = self.get_pool(database).await?;

--- a/src-tauri/src/db/mariadb.rs
+++ b/src-tauri/src/db/mariadb.rs
@@ -181,7 +181,7 @@ impl DatabaseDriver for MariadbDriver {
         table: &str,
         offset: u64,
         limit: u64,
-        sort: Option<SortSpec>,
+        sort: Vec<SortSpec>,
         filter: Option<String>,
     ) -> Result<TableData> {
         let columns = self.list_columns(database, database, table).await?;

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -63,6 +63,18 @@ pub trait DatabaseDriver: Send + Sync {
         schema: &str,
         table: &str,
     ) -> Result<TableStats>;
+    /// Fetch a window of rows from `table`, ordered by the given
+    /// list of `sort` specs (empty list = driver's default
+    /// ordering, typically the primary-key columns).
+    ///
+    /// `sort` is a `Vec` rather than `Option<SortSpec>` so the
+    /// data grid's Shift+click multi-column sort actually reaches
+    /// the database — see issue #57. Drivers compose the SQL
+    /// `ORDER BY` clause by walking the vec in order and
+    /// joining with `, `; if the engine can't honour every entry
+    /// (e.g. Cassandra's clustering-key constraint), it falls
+    /// back to whatever it can and the server surfaces the
+    /// limitation as an execution error.
     async fn fetch_rows(
         &self,
         database: &str,
@@ -70,7 +82,7 @@ pub trait DatabaseDriver: Send + Sync {
         table: &str,
         offset: u64,
         limit: u64,
-        sort: Option<SortSpec>,
+        sort: Vec<SortSpec>,
         filter: Option<String>,
     ) -> Result<TableData>;
     async fn execute_query(&self, database: &str, sql: &str) -> Result<QueryResult>;

--- a/src-tauri/src/db/mssql.rs
+++ b/src-tauri/src/db/mssql.rs
@@ -807,7 +807,7 @@ impl DatabaseDriver for MssqlDriver {
         table: &str,
         offset: u64,
         limit: u64,
-        sort: Option<SortSpec>,
+        sort: Vec<SortSpec>,
         filter: Option<String>,
     ) -> Result<TableData> {
         let columns = self.list_columns(database, schema, table).await?;
@@ -820,15 +820,27 @@ impl DatabaseDriver for MssqlDriver {
             .filter(|c| c.is_primary_key)
             .map(|c| c.name.clone())
             .collect();
-        let order = if let Some(s) = sort {
-            format!(
-                "{} {}",
-                bracket(&s.column),
-                match s.direction {
-                    SortDirection::Asc => "ASC",
-                    SortDirection::Desc => "DESC",
-                }
-            )
+        // ORDER BY is mandatory for `OFFSET ... FETCH NEXT` on
+        // SQL Server, so unlike pg/my we always end up with a
+        // non-empty clause. Three-step ladder:
+        //   1. multi-column user sort (issue #57)
+        //   2. PK columns
+        //   3. first column of the table (last-resort
+        //      deterministic ordering)
+        let order = if !sort.is_empty() {
+            sort.iter()
+                .map(|s| {
+                    format!(
+                        "{} {}",
+                        bracket(&s.column),
+                        match s.direction {
+                            SortDirection::Asc => "ASC",
+                            SortDirection::Desc => "DESC",
+                        }
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
         } else if pk_cols.is_empty() {
             bracket(&columns[0].name).to_string()
         } else {

--- a/src-tauri/src/db/mysql.rs
+++ b/src-tauri/src/db/mysql.rs
@@ -187,7 +187,7 @@ impl DatabaseDriver for MysqlDriver {
         table: &str,
         offset: u64,
         limit: u64,
-        sort: Option<SortSpec>,
+        sort: Vec<SortSpec>,
         filter: Option<String>,
     ) -> Result<TableData> {
         let columns = self.list_columns(database, database, table).await?;

--- a/src-tauri/src/db/mysql_common.rs
+++ b/src-tauri/src/db/mysql_common.rs
@@ -555,7 +555,7 @@ pub async fn my_fetch_rows_impl(
     table: &str,
     offset: u64,
     limit: u64,
-    sort: Option<SortSpec>,
+    sort: Vec<SortSpec>,
     filter: Option<String>,
 ) -> Result<TableData> {
     if let Some(ref f) = filter {
@@ -572,26 +572,34 @@ pub async fn my_fetch_rows_impl(
         .map(|f| format!("WHERE {}", f))
         .unwrap_or_default();
 
-    let order_clause = sort
-        .map(|s| {
-            let dir = match s.direction {
-                SortDirection::Asc => "ASC",
-                SortDirection::Desc => "DESC",
-            };
-            format!("ORDER BY {} {}", quote_ident(&s.column), dir)
-        })
-        .unwrap_or_else(|| {
-            let pk_cols: Vec<String> = columns
-                .iter()
-                .filter(|c| c.is_primary_key)
-                .map(|c| quote_ident(&c.name))
-                .collect();
-            if pk_cols.is_empty() {
-                String::new()
-            } else {
-                format!("ORDER BY {}", pk_cols.join(", "))
-            }
-        });
+    let order_clause = if !sort.is_empty() {
+        // Multi-column sort (issue #57): compose every requested
+        // sort in priority order, comma-separated.
+        let parts: Vec<String> = sort
+            .iter()
+            .map(|s| {
+                let dir = match s.direction {
+                    SortDirection::Asc => "ASC",
+                    SortDirection::Desc => "DESC",
+                };
+                format!("{} {}", quote_ident(&s.column), dir)
+            })
+            .collect();
+        format!("ORDER BY {}", parts.join(", "))
+    } else {
+        // No explicit sort — fall back to the PK columns for
+        // stable pagination.
+        let pk_cols: Vec<String> = columns
+            .iter()
+            .filter(|c| c.is_primary_key)
+            .map(|c| quote_ident(&c.name))
+            .collect();
+        if pk_cols.is_empty() {
+            String::new()
+        } else {
+            format!("ORDER BY {}", pk_cols.join(", "))
+        }
+    };
 
     let count_sql = format!(
         "SELECT COUNT(*) as cnt FROM {}.{} {}",

--- a/src-tauri/src/db/pg_common.rs
+++ b/src-tauri/src/db/pg_common.rs
@@ -918,7 +918,7 @@ pub async fn pg_fetch_rows_impl(
     table: &str,
     offset: u64,
     limit: u64,
-    sort: Option<SortSpec>,
+    sort: Vec<SortSpec>,
     filter: Option<String>,
 ) -> Result<TableData> {
     if let Some(ref f) = filter {
@@ -935,26 +935,36 @@ pub async fn pg_fetch_rows_impl(
         .map(|f| format!("WHERE {}", f))
         .unwrap_or_default();
 
-    let order_clause = sort
-        .map(|s| {
-            let dir = match s.direction {
-                SortDirection::Asc => "ASC",
-                SortDirection::Desc => "DESC",
-            };
-            format!("ORDER BY {} {}", quote_ident(&s.column), dir)
-        })
-        .unwrap_or_else(|| {
-            let pk_cols: Vec<String> = columns
-                .iter()
-                .filter(|c| c.is_primary_key)
-                .map(|c| quote_ident(&c.name))
-                .collect();
-            if pk_cols.is_empty() {
-                String::new()
-            } else {
-                format!("ORDER BY {}", pk_cols.join(", "))
-            }
-        });
+    let order_clause = if !sort.is_empty() {
+        // Multi-column sort (issue #57): compose every requested
+        // sort in priority order, comma-separated.
+        let parts: Vec<String> = sort
+            .iter()
+            .map(|s| {
+                let dir = match s.direction {
+                    SortDirection::Asc => "ASC",
+                    SortDirection::Desc => "DESC",
+                };
+                format!("{} {}", quote_ident(&s.column), dir)
+            })
+            .collect();
+        format!("ORDER BY {}", parts.join(", "))
+    } else {
+        // No explicit sort — order by the PK columns so pagination
+        // is stable. Empty if the table has no PK at all (offset
+        // pagination on an unordered set is the caller's problem
+        // in that case).
+        let pk_cols: Vec<String> = columns
+            .iter()
+            .filter(|c| c.is_primary_key)
+            .map(|c| quote_ident(&c.name))
+            .collect();
+        if pk_cols.is_empty() {
+            String::new()
+        } else {
+            format!("ORDER BY {}", pk_cols.join(", "))
+        }
+    };
 
     let count_sql = format!(
         "SELECT COUNT(*) as cnt FROM {}.{} {}",

--- a/src-tauri/src/db/postgres.rs
+++ b/src-tauri/src/db/postgres.rs
@@ -316,7 +316,7 @@ impl DatabaseDriver for PostgresDriver {
         table: &str,
         offset: u64,
         limit: u64,
-        sort: Option<SortSpec>,
+        sort: Vec<SortSpec>,
         filter: Option<String>,
     ) -> Result<TableData> {
         let pool = self.get_pool(database).await?;

--- a/src-tauri/src/db/sqlite.rs
+++ b/src-tauri/src/db/sqlite.rs
@@ -404,7 +404,7 @@ impl DatabaseDriver for SqliteDriver {
         table: &str,
         offset: u64,
         limit: u64,
-        sort: Option<SortSpec>,
+        sort: Vec<SortSpec>,
         filter: Option<String>,
     ) -> Result<TableData> {
         if let Some(ref f) = filter {
@@ -423,26 +423,32 @@ impl DatabaseDriver for SqliteDriver {
             .map(|f| format!("WHERE {}", f))
             .unwrap_or_default();
 
-        let order_clause = sort
-            .map(|s| {
-                let dir = match s.direction {
-                    SortDirection::Asc => "ASC",
-                    SortDirection::Desc => "DESC",
-                };
-                format!("ORDER BY {} {}", quote_ident(&s.column), dir)
-            })
-            .unwrap_or_else(|| {
-                let pk_cols: Vec<String> = columns
-                    .iter()
-                    .filter(|c| c.is_primary_key)
-                    .map(|c| quote_ident(&c.name))
-                    .collect();
-                if pk_cols.is_empty() {
-                    String::new()
-                } else {
-                    format!("ORDER BY {}", pk_cols.join(", "))
-                }
-            });
+        let order_clause = if !sort.is_empty() {
+            // Multi-column sort (issue #57).
+            let parts: Vec<String> = sort
+                .iter()
+                .map(|s| {
+                    let dir = match s.direction {
+                        SortDirection::Asc => "ASC",
+                        SortDirection::Desc => "DESC",
+                    };
+                    format!("{} {}", quote_ident(&s.column), dir)
+                })
+                .collect();
+            format!("ORDER BY {}", parts.join(", "))
+        } else {
+            // PK fallback for stable pagination.
+            let pk_cols: Vec<String> = columns
+                .iter()
+                .filter(|c| c.is_primary_key)
+                .map(|c| quote_ident(&c.name))
+                .collect();
+            if pk_cols.is_empty() {
+                String::new()
+            } else {
+                format!("ORDER BY {}", pk_cols.join(", "))
+            }
+        };
 
         let count_sql = format!(
             "SELECT COUNT(*) as cnt FROM {} {}",

--- a/src-tauri/src/db/tidb.rs
+++ b/src-tauri/src/db/tidb.rs
@@ -182,7 +182,7 @@ impl DatabaseDriver for TidbDriver {
         table: &str,
         offset: u64,
         limit: u64,
-        sort: Option<SortSpec>,
+        sort: Vec<SortSpec>,
         filter: Option<String>,
     ) -> Result<TableData> {
         let columns = self.list_columns(database, database, table).await?;

--- a/src-tauri/src/models/types.rs
+++ b/src-tauri/src/models/types.rs
@@ -222,7 +222,19 @@ pub struct FetchRowsRequest {
     pub table: String,
     pub offset: u64,
     pub limit: u64,
-    pub sort: Option<SortSpec>,
+    /// Ordered list of sort specifications applied to the result.
+    ///
+    /// The frontend's data grid lets users Shift+click multiple
+    /// column headers to build a multi-level sort; the list is in
+    /// priority order (index 0 is the primary sort, index 1 the
+    /// secondary, etc.). An empty vec means "no sort" — drivers
+    /// then fall back to ordering by the table's primary-key
+    /// columns so pagination stays stable.
+    ///
+    /// `#[serde(default)]` keeps the wire shape backwards
+    /// compatible: a missing field deserialises to `Vec::new()`.
+    #[serde(default)]
+    pub sort: Vec<SortSpec>,
     pub filter: Option<String>,
 }
 

--- a/src-tauri/tests/cassandra_integration.rs
+++ b/src-tauri/tests/cassandra_integration.rs
@@ -458,14 +458,14 @@ async fn cassandra_fetch_rows() {
     }
 
     let data = driver
-        .fetch_rows(&ks, &ks, &tbl, 0, 3, None, None)
+        .fetch_rows(&ks, &ks, &tbl, 0, 3, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows.len(), 3);
     assert_eq!(data.columns.len(), 3);
 
     let data_all = driver
-        .fetch_rows(&ks, &ks, &tbl, 0, 100, None, None)
+        .fetch_rows(&ks, &ks, &tbl, 0, 100, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data_all.rows.len(), 5);

--- a/src-tauri/tests/cockroachdb_integration.rs
+++ b/src-tauri/tests/cockroachdb_integration.rs
@@ -348,7 +348,7 @@ async fn crdb_fetch_rows_empty_table() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -387,7 +387,7 @@ async fn crdb_fetch_rows_with_data() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -425,14 +425,14 @@ async fn crdb_fetch_rows_pagination() {
         .unwrap();
 
     let page1 = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 5, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page1.rows.len(), 5);
     assert_eq!(page1.total_rows, 10);
 
     let page2 = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 5, 5, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 5, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page2.rows.len(), 5);
@@ -475,10 +475,10 @@ async fn crdb_fetch_rows_sort() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Asc,
-            }),
+            }],
             None,
         )
         .await
@@ -518,7 +518,15 @@ async fn crdb_fetch_rows_filter() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, Some("\"val\" > 15".into()))
+        .fetch_rows(
+            &db,
+            SCHEMA,
+            &tbl,
+            0,
+            50,
+            Vec::new(),
+            Some("\"val\" > 15".into()),
+        )
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -555,7 +563,7 @@ async fn crdb_fetch_rows_null_values() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::Value::Null);
@@ -601,7 +609,7 @@ async fn crdb_fetch_rows_various_data_types() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -765,7 +773,7 @@ async fn crdb_apply_changes_insert() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -816,7 +824,7 @@ async fn crdb_apply_changes_update() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!("new"));
@@ -866,7 +874,7 @@ async fn crdb_apply_changes_delete() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1077,7 +1085,7 @@ async fn crdb_truncate_table() {
 
     driver.truncate_table(&db, SCHEMA, &tbl).await.unwrap();
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -1320,7 +1328,7 @@ async fn crdb_no_db_fetch_rows_on_specific_database() {
 
     let driver = crdb_driver_no_db!();
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);

--- a/src-tauri/tests/mariadb_integration.rs
+++ b/src-tauri/tests/mariadb_integration.rs
@@ -456,7 +456,7 @@ async fn mariadb_fetch_rows_empty_table() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -495,7 +495,7 @@ async fn mariadb_fetch_rows_with_data() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -526,14 +526,14 @@ async fn mariadb_fetch_rows_pagination() {
         .unwrap();
 
     let page1 = driver
-        .fetch_rows(&db, &db, &tbl, 0, 5, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page1.rows.len(), 5);
     assert_eq!(page1.total_rows, 10);
 
     let page2 = driver
-        .fetch_rows(&db, &db, &tbl, 5, 5, None, None)
+        .fetch_rows(&db, &db, &tbl, 5, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page2.rows.len(), 5);
@@ -570,10 +570,10 @@ async fn mariadb_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Asc,
-            }),
+            }],
             None,
         )
         .await
@@ -588,10 +588,10 @@ async fn mariadb_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Desc,
-            }),
+            }],
             None,
         )
         .await
@@ -625,7 +625,7 @@ async fn mariadb_fetch_rows_filter() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, Some("`val` > 15".into()))
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), Some("`val` > 15".into()))
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -657,7 +657,7 @@ async fn mariadb_fetch_rows_null_values() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -701,7 +701,7 @@ async fn mariadb_fetch_rows_various_data_types() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -842,7 +842,7 @@ async fn mariadb_apply_changes_insert() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -887,7 +887,7 @@ async fn mariadb_apply_changes_update() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!("new"));
@@ -931,7 +931,7 @@ async fn mariadb_apply_changes_delete() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1119,7 +1119,7 @@ async fn mariadb_alter_table_set_default() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!(5));
@@ -1184,7 +1184,7 @@ async fn mariadb_truncate_table() {
 
     driver.truncate_table(&db, &db, &tbl).await.unwrap();
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -1251,7 +1251,7 @@ async fn mariadb_import_data() {
     assert_eq!(n, 2);
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -1404,7 +1404,7 @@ async fn mariadb_no_db_fetch_rows_on_specific_database() {
 
     let driver = mariadb_driver_no_db!();
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);

--- a/src-tauri/tests/mssql_integration.rs
+++ b/src-tauri/tests/mssql_integration.rs
@@ -581,7 +581,7 @@ async fn mssql_fetch_rows_empty_table() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -628,7 +628,7 @@ async fn mssql_fetch_rows_with_data() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -669,14 +669,14 @@ async fn mssql_fetch_rows_pagination() {
         .unwrap();
 
     let page1 = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 5, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page1.rows.len(), 5);
     assert_eq!(page1.total_rows, 10);
 
     let page2 = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 5, 5, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 5, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page2.rows.len(), 5);
@@ -724,10 +724,10 @@ async fn mssql_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Asc,
-            }),
+            }],
             None,
         )
         .await
@@ -743,16 +743,103 @@ async fn mssql_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Desc,
-            }),
+            }],
             None,
         )
         .await
         .unwrap();
     assert_eq!(desc.rows[0][name_idx], serde_json::json!("c"));
     assert_eq!(desc.rows[2][name_idx], serde_json::json!("a"));
+
+    driver
+        .drop_object(&db, SCHEMA, &tbl, "TABLE")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn mssql_fetch_rows_multi_column_sort() {
+    // Multi-column sort (issue #57) end-to-end on SQL Server.
+    // Uses bracket-quoted identifiers and the `OFFSET … FETCH
+    // NEXT` paging that requires a non-empty ORDER BY.
+    let (driver, db) = mssql_driver!();
+    let tbl = unique_table("ms_multi_sort");
+    driver
+        .execute_query(
+            &db,
+            &format!(
+                "CREATE TABLE {}.{} (id INT PRIMARY KEY, dept NVARCHAR(32), salary INT)",
+                SCHEMA, tbl,
+            ),
+        )
+        .await
+        .unwrap();
+    driver
+        .execute_query(
+            &db,
+            &format!(
+                "INSERT INTO {}.{} VALUES \
+                 (1,'eng',100),(2,'sales',90),(3,'eng',200),(4,'sales',70),(5,'eng',150)",
+                SCHEMA, tbl,
+            ),
+        )
+        .await
+        .unwrap();
+
+    let rows = driver
+        .fetch_rows(
+            &db,
+            SCHEMA,
+            &tbl,
+            0,
+            10,
+            vec![
+                SortSpec {
+                    column: "dept".into(),
+                    direction: SortDirection::Asc,
+                },
+                SortSpec {
+                    column: "salary".into(),
+                    direction: SortDirection::Desc,
+                },
+            ],
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(rows.rows.len(), 5);
+    let dept_idx = rows.columns.iter().position(|c| c.name == "dept").unwrap();
+    let salary_idx = rows
+        .columns
+        .iter()
+        .position(|c| c.name == "salary")
+        .unwrap();
+    let depts: Vec<_> = rows.rows.iter().map(|r| r[dept_idx].clone()).collect();
+    let salaries: Vec<_> = rows.rows.iter().map(|r| r[salary_idx].clone()).collect();
+    assert_eq!(
+        depts,
+        vec![
+            serde_json::json!("eng"),
+            serde_json::json!("eng"),
+            serde_json::json!("eng"),
+            serde_json::json!("sales"),
+            serde_json::json!("sales"),
+        ],
+    );
+    assert_eq!(
+        salaries,
+        vec![
+            serde_json::json!(200),
+            serde_json::json!(150),
+            serde_json::json!(100),
+            serde_json::json!(90),
+            serde_json::json!(70),
+        ],
+    );
 
     driver
         .drop_object(&db, SCHEMA, &tbl, "TABLE")
@@ -785,7 +872,15 @@ async fn mssql_fetch_rows_filter() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, Some("[val] > 15".into()))
+        .fetch_rows(
+            &db,
+            SCHEMA,
+            &tbl,
+            0,
+            50,
+            Vec::new(),
+            Some("[val] > 15".into()),
+        )
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -825,7 +920,7 @@ async fn mssql_fetch_rows_null_values() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -879,7 +974,7 @@ async fn mssql_fetch_rows_various_data_types() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1072,7 +1167,7 @@ async fn mssql_apply_changes_insert() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1130,7 +1225,7 @@ async fn mssql_apply_changes_update() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     let val_idx = data.columns.iter().position(|c| c.name == "val").unwrap();
@@ -1183,7 +1278,7 @@ async fn mssql_apply_changes_delete() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1248,7 +1343,7 @@ async fn mssql_apply_changes_batch_insert_update_delete() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 3);
@@ -1466,7 +1561,7 @@ async fn mssql_truncate_table() {
 
     driver.truncate_table(&db, SCHEMA, &tbl).await.unwrap();
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -1574,7 +1669,7 @@ async fn mssql_import_data() {
     assert_eq!(imported, 3);
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 3);
@@ -1608,7 +1703,7 @@ async fn mssql_import_data_large_batch() {
     assert_eq!(imported, 100);
 
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 1, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 1, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 100);
@@ -1827,7 +1922,7 @@ async fn mssql_no_db_fetch_rows_on_specific_database() {
 
     let driver = mssql_driver_no_db!();
     let data = driver
-        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);

--- a/src-tauri/tests/mysql_integration.rs
+++ b/src-tauri/tests/mysql_integration.rs
@@ -474,7 +474,7 @@ async fn mysql_fetch_rows_empty_table() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -514,7 +514,7 @@ async fn mysql_fetch_rows_with_data() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -546,14 +546,14 @@ async fn mysql_fetch_rows_pagination() {
         .unwrap();
 
     let page1 = driver
-        .fetch_rows(&db, &db, &tbl, 0, 5, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page1.rows.len(), 5);
     assert_eq!(page1.total_rows, 10);
 
     let page2 = driver
-        .fetch_rows(&db, &db, &tbl, 5, 5, None, None)
+        .fetch_rows(&db, &db, &tbl, 5, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page2.rows.len(), 5);
@@ -591,10 +591,10 @@ async fn mysql_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Asc,
-            }),
+            }],
             None,
         )
         .await
@@ -609,16 +609,98 @@ async fn mysql_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Desc,
-            }),
+            }],
             None,
         )
         .await
         .unwrap();
     assert_eq!(desc.rows[0][1], serde_json::json!("c"));
     assert_eq!(desc.rows[2][1], serde_json::json!("a"));
+
+    driver.drop_object(&db, &db, &tbl, "TABLE").await.unwrap();
+}
+
+#[tokio::test]
+async fn mysql_fetch_rows_multi_column_sort() {
+    // Multi-column sort (issue #57) end-to-end on MySQL.
+    let (driver, db) = mysql_driver!();
+    let tbl = unique_table("multi_sort");
+    driver
+        .execute_query(
+            &db,
+            &format!(
+                "CREATE TABLE `{}` (id INT PRIMARY KEY, dept VARCHAR(32), salary INT) ENGINE=InnoDB",
+                tbl,
+            ),
+        )
+        .await
+        .unwrap();
+    driver
+        .execute_query(
+            &db,
+            &format!(
+                "INSERT INTO `{}` VALUES \
+                 (1,'eng',100),(2,'sales',90),(3,'eng',200),(4,'sales',70),(5,'eng',150)",
+                tbl,
+            ),
+        )
+        .await
+        .unwrap();
+
+    let rows = driver
+        .fetch_rows(
+            &db,
+            &db,
+            &tbl,
+            0,
+            10,
+            vec![
+                SortSpec {
+                    column: "dept".into(),
+                    direction: SortDirection::Asc,
+                },
+                SortSpec {
+                    column: "salary".into(),
+                    direction: SortDirection::Desc,
+                },
+            ],
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(rows.rows.len(), 5);
+    let dept_idx = rows.columns.iter().position(|c| c.name == "dept").unwrap();
+    let salary_idx = rows
+        .columns
+        .iter()
+        .position(|c| c.name == "salary")
+        .unwrap();
+    let depts: Vec<_> = rows.rows.iter().map(|r| r[dept_idx].clone()).collect();
+    let salaries: Vec<_> = rows.rows.iter().map(|r| r[salary_idx].clone()).collect();
+    assert_eq!(
+        depts,
+        vec![
+            serde_json::json!("eng"),
+            serde_json::json!("eng"),
+            serde_json::json!("eng"),
+            serde_json::json!("sales"),
+            serde_json::json!("sales"),
+        ],
+    );
+    assert_eq!(
+        salaries,
+        vec![
+            serde_json::json!(200),
+            serde_json::json!(150),
+            serde_json::json!(100),
+            serde_json::json!(90),
+            serde_json::json!(70),
+        ],
+    );
 
     driver.drop_object(&db, &db, &tbl, "TABLE").await.unwrap();
 }
@@ -647,7 +729,7 @@ async fn mysql_fetch_rows_filter() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, Some("`val` > 15".into()))
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), Some("`val` > 15".into()))
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -676,7 +758,7 @@ async fn mysql_fetch_rows_unsafe_filter_rejected() {
             &tbl,
             0,
             50,
-            None,
+            Vec::new(),
             Some("1=1; DROP TABLE x".into()),
         )
         .await;
@@ -709,7 +791,7 @@ async fn mysql_fetch_rows_null_values() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -753,7 +835,7 @@ async fn mysql_fetch_rows_various_data_types() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -915,7 +997,7 @@ async fn mysql_apply_changes_insert() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -961,7 +1043,7 @@ async fn mysql_apply_changes_update() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!("new"));
@@ -1006,7 +1088,7 @@ async fn mysql_apply_changes_delete() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1064,7 +1146,7 @@ async fn mysql_apply_changes_batch() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -1202,7 +1284,7 @@ async fn mysql_truncate_table() {
 
     driver.truncate_table(&db, &db, &tbl).await.unwrap();
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -1263,7 +1345,7 @@ async fn mysql_import_data() {
     assert_eq!(n, 2);
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -1291,7 +1373,7 @@ async fn mysql_import_data_large_batch() {
     assert_eq!(n, 600);
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 1, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 1, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 600);
@@ -1480,7 +1562,7 @@ async fn mysql_alter_table_set_default() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!(5));
@@ -1728,7 +1810,7 @@ async fn mysql_no_db_fetch_rows_on_specific_database() {
 
     let driver = mysql_driver_no_db!();
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -1864,7 +1946,7 @@ async fn million_row_paginate() {
     loop {
         let t = std::time::Instant::now();
         let data = driver
-            .fetch_rows(&db, &db, &table, offset, PAGE, None, None)
+            .fetch_rows(&db, &db, &table, offset, PAGE, Vec::new(), None)
             .await
             .expect("fetch_rows page");
         let elapsed = t.elapsed().as_millis();

--- a/src-tauri/tests/postgres_integration.rs
+++ b/src-tauri/tests/postgres_integration.rs
@@ -763,7 +763,7 @@ async fn pg_fetch_rows_empty_table() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -803,7 +803,7 @@ async fn pg_fetch_rows_with_data() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -840,7 +840,7 @@ async fn pg_fetch_rows_pagination() {
         .unwrap();
 
     let page1 = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 5, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page1.rows.len(), 5);
@@ -848,7 +848,7 @@ async fn pg_fetch_rows_pagination() {
     assert_eq!(page1.rows[0][0], serde_json::json!(1));
 
     let page2 = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 5, 5, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 5, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page2.rows.len(), 5);
@@ -890,10 +890,10 @@ async fn pg_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Asc,
-            }),
+            }],
             None,
         )
         .await
@@ -908,16 +908,101 @@ async fn pg_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Desc,
-            }),
+            }],
             None,
         )
         .await
         .unwrap();
     assert_eq!(desc.rows[0][1], serde_json::json!("c"));
     assert_eq!(desc.rows[2][1], serde_json::json!("a"));
+
+    driver.drop_object(DB, SCHEMA, &tbl, "TABLE").await.unwrap();
+}
+
+// Multi-column sort end-to-end (issue #57). Before the fix the
+// driver only used `sort[0]` so multi-sort UI didn't reach the
+// database — verified here on Postgres.
+#[tokio::test]
+async fn pg_fetch_rows_multi_column_sort() {
+    let driver = pg_driver!();
+    let tbl = unique_table("pg_multi_sort");
+
+    driver
+        .execute_query(
+            DB,
+            &format!(
+                "CREATE TABLE {}.\"{}\" (id INT PRIMARY KEY, dept TEXT, salary INT)",
+                SCHEMA, tbl,
+            ),
+        )
+        .await
+        .unwrap();
+    driver
+        .execute_query(
+            DB,
+            &format!(
+                "INSERT INTO {}.\"{}\" VALUES \
+                 (1,'eng',100),(2,'sales',90),(3,'eng',200),(4,'sales',70),(5,'eng',150)",
+                SCHEMA, tbl,
+            ),
+        )
+        .await
+        .unwrap();
+
+    let rows = driver
+        .fetch_rows(
+            DB,
+            SCHEMA,
+            &tbl,
+            0,
+            10,
+            vec![
+                SortSpec {
+                    column: "dept".into(),
+                    direction: SortDirection::Asc,
+                },
+                SortSpec {
+                    column: "salary".into(),
+                    direction: SortDirection::Desc,
+                },
+            ],
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(rows.rows.len(), 5);
+    let dept_idx = rows.columns.iter().position(|c| c.name == "dept").unwrap();
+    let salary_idx = rows
+        .columns
+        .iter()
+        .position(|c| c.name == "salary")
+        .unwrap();
+    let depts: Vec<_> = rows.rows.iter().map(|r| r[dept_idx].clone()).collect();
+    let salaries: Vec<_> = rows.rows.iter().map(|r| r[salary_idx].clone()).collect();
+    assert_eq!(
+        depts,
+        vec![
+            serde_json::json!("eng"),
+            serde_json::json!("eng"),
+            serde_json::json!("eng"),
+            serde_json::json!("sales"),
+            serde_json::json!("sales"),
+        ],
+    );
+    assert_eq!(
+        salaries,
+        vec![
+            serde_json::json!(200),
+            serde_json::json!(150),
+            serde_json::json!(100),
+            serde_json::json!(90),
+            serde_json::json!(70),
+        ],
+    );
 
     driver.drop_object(DB, SCHEMA, &tbl, "TABLE").await.unwrap();
 }
@@ -949,7 +1034,15 @@ async fn pg_fetch_rows_filter() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, Some("\"val\" > 15".into()))
+        .fetch_rows(
+            DB,
+            SCHEMA,
+            &tbl,
+            0,
+            50,
+            Vec::new(),
+            Some("\"val\" > 15".into()),
+        )
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -977,7 +1070,7 @@ async fn pg_fetch_rows_unsafe_filter_rejected() {
             &tbl,
             0,
             50,
-            None,
+            Vec::new(),
             Some("1=1; DROP TABLE x".into()),
         )
         .await;
@@ -1013,7 +1106,7 @@ async fn pg_fetch_rows_null_values() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -1060,7 +1153,7 @@ async fn pg_fetch_rows_various_data_types() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1249,7 +1342,7 @@ async fn pg_apply_changes_insert() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1299,7 +1392,7 @@ async fn pg_apply_changes_update() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!("new"));
@@ -1347,7 +1440,7 @@ async fn pg_apply_changes_delete() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1407,7 +1500,7 @@ async fn pg_apply_changes_batch_insert_update_delete() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 3);
@@ -1683,7 +1776,7 @@ async fn pg_truncate_table() {
 
     driver.truncate_table(DB, SCHEMA, &tbl).await.unwrap();
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -1777,7 +1870,7 @@ async fn pg_import_data() {
     assert_eq!(imported, 3);
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 3);
@@ -1808,7 +1901,7 @@ async fn pg_import_data_large_batch() {
     assert_eq!(imported, 600);
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 1, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 1, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 600);
@@ -1985,7 +2078,7 @@ async fn pg_alter_table_set_default() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!(5));
@@ -2129,7 +2222,7 @@ async fn pg_no_db_fetch_rows_on_specific_database() {
 
     let driver = pg_driver_no_db!();
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -2176,7 +2269,7 @@ async fn pg_no_db_apply_changes_on_specific_database() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -2348,7 +2441,7 @@ async fn million_row_paginate() {
     loop {
         let t = std::time::Instant::now();
         let data = driver
-            .fetch_rows(DB, SCHEMA, &table, offset, PAGE, None, None)
+            .fetch_rows(DB, SCHEMA, &table, offset, PAGE, Vec::new(), None)
             .await
             .expect("fetch_rows page");
         let elapsed = t.elapsed().as_millis();
@@ -2587,7 +2680,7 @@ async fn pg_xlsx_round_trip_preserves_types() {
     assert_eq!(inserted, 2);
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .expect("fetch");
     assert_eq!(data.total_rows, 2);

--- a/src-tauri/tests/sqlite_integration.rs
+++ b/src-tauri/tests/sqlite_integration.rs
@@ -466,7 +466,7 @@ async fn sqlite_fetch_rows_empty_table() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -507,7 +507,7 @@ async fn sqlite_fetch_rows_with_data() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -540,14 +540,14 @@ async fn sqlite_fetch_rows_pagination() {
         .unwrap();
 
     let page1 = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 5, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page1.rows.len(), 5);
     assert_eq!(page1.total_rows, 10);
 
     let page2 = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 5, 5, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 5, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page2.rows.len(), 5);
@@ -586,10 +586,10 @@ async fn sqlite_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Asc,
-            }),
+            }],
             None,
         )
         .await
@@ -604,16 +604,102 @@ async fn sqlite_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Desc,
-            }),
+            }],
             None,
         )
         .await
         .unwrap();
     assert_eq!(desc.rows[0][1], serde_json::json!("c"));
     assert_eq!(desc.rows[2][1], serde_json::json!("a"));
+
+    driver.drop_object(DB, SCHEMA, &tbl, "TABLE").await.unwrap();
+    let _ = std::fs::remove_file(&path);
+}
+
+// Multi-column sort end-to-end (issue #57). Before the fix the
+// driver could only accept a single SortSpec; ag-grid would
+// display "1", "2" priority badges in the header but the backend
+// ORDER BY only honoured the primary column.
+#[tokio::test]
+async fn sqlite_fetch_rows_multi_column_sort() {
+    let (driver, path) = create_driver().await;
+    let tbl = unique_table("multi_sort");
+
+    driver
+        .execute_query(
+            DB,
+            &format!(
+                "CREATE TABLE \"{}\" (id INTEGER PRIMARY KEY, dept TEXT, salary INTEGER)",
+                tbl
+            ),
+        )
+        .await
+        .unwrap();
+    // Deliberately interleave dept/salary so single-column sort
+    // can't accidentally produce the multi-sort order. Expected
+    // ORDER BY dept ASC, salary DESC:
+    //   eng/200, eng/150, eng/100, sales/90, sales/70
+    driver
+        .execute_query(
+            DB,
+            &format!(
+                "INSERT INTO \"{}\" VALUES \
+                 (1,'eng',100),(2,'sales',90),(3,'eng',200), \
+                 (4,'sales',70),(5,'eng',150)",
+                tbl
+            ),
+        )
+        .await
+        .unwrap();
+
+    let rows = driver
+        .fetch_rows(
+            DB,
+            SCHEMA,
+            &tbl,
+            0,
+            10,
+            vec![
+                SortSpec {
+                    column: "dept".into(),
+                    direction: SortDirection::Asc,
+                },
+                SortSpec {
+                    column: "salary".into(),
+                    direction: SortDirection::Desc,
+                },
+            ],
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(rows.rows.len(), 5);
+    let depts: Vec<_> = rows.rows.iter().map(|r| r[1].clone()).collect();
+    let salaries: Vec<_> = rows.rows.iter().map(|r| r[2].clone()).collect();
+    assert_eq!(
+        depts,
+        vec![
+            serde_json::json!("eng"),
+            serde_json::json!("eng"),
+            serde_json::json!("eng"),
+            serde_json::json!("sales"),
+            serde_json::json!("sales"),
+        ],
+    );
+    assert_eq!(
+        salaries,
+        vec![
+            serde_json::json!(200),
+            serde_json::json!(150),
+            serde_json::json!(100),
+            serde_json::json!(90),
+            serde_json::json!(70),
+        ],
+    );
 
     driver.drop_object(DB, SCHEMA, &tbl, "TABLE").await.unwrap();
     let _ = std::fs::remove_file(&path);
@@ -643,7 +729,15 @@ async fn sqlite_fetch_rows_filter() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, Some("\"val\" > 15".into()))
+        .fetch_rows(
+            DB,
+            SCHEMA,
+            &tbl,
+            0,
+            50,
+            Vec::new(),
+            Some("\"val\" > 15".into()),
+        )
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -672,7 +766,7 @@ async fn sqlite_fetch_rows_unsafe_filter_rejected() {
             &tbl,
             0,
             50,
-            None,
+            Vec::new(),
             Some("1=1; DROP TABLE x".into()),
         )
         .await;
@@ -706,7 +800,7 @@ async fn sqlite_fetch_rows_null_values() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -749,7 +843,7 @@ async fn sqlite_fetch_rows_various_data_types() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -910,7 +1004,7 @@ async fn sqlite_apply_changes_insert() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -958,7 +1052,7 @@ async fn sqlite_apply_changes_update() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!("new"));
@@ -1004,7 +1098,7 @@ async fn sqlite_apply_changes_delete() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1062,7 +1156,7 @@ async fn sqlite_apply_changes_batch() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -1392,7 +1486,7 @@ async fn sqlite_truncate_table() {
 
     driver.truncate_table(DB, SCHEMA, &tbl).await.unwrap();
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -1488,7 +1582,7 @@ async fn sqlite_import_data() {
     assert_eq!(n, 2);
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -1519,7 +1613,7 @@ async fn sqlite_import_data_large_batch() {
     assert_eq!(n, 55);
 
     let data = driver
-        .fetch_rows(DB, SCHEMA, &tbl, 0, 200, None, None)
+        .fetch_rows(DB, SCHEMA, &tbl, 0, 200, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 55);

--- a/src-tauri/tests/tidb_integration.rs
+++ b/src-tauri/tests/tidb_integration.rs
@@ -393,7 +393,7 @@ async fn tidb_fetch_rows_empty_table() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -432,7 +432,7 @@ async fn tidb_fetch_rows_with_data() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -460,14 +460,14 @@ async fn tidb_fetch_rows_pagination() {
         .unwrap();
 
     let page1 = driver
-        .fetch_rows(&db, &db, &tbl, 0, 5, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page1.rows.len(), 5);
     assert_eq!(page1.total_rows, 10);
 
     let page2 = driver
-        .fetch_rows(&db, &db, &tbl, 5, 5, None, None)
+        .fetch_rows(&db, &db, &tbl, 5, 5, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(page2.rows.len(), 5);
@@ -504,10 +504,10 @@ async fn tidb_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Asc,
-            }),
+            }],
             None,
         )
         .await
@@ -522,10 +522,10 @@ async fn tidb_fetch_rows_sort_asc_desc() {
             &tbl,
             0,
             10,
-            Some(SortSpec {
+            vec![SortSpec {
                 column: "name".into(),
                 direction: SortDirection::Desc,
-            }),
+            }],
             None,
         )
         .await
@@ -559,7 +559,7 @@ async fn tidb_fetch_rows_filter() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, Some("`val` > 15".into()))
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), Some("`val` > 15".into()))
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);
@@ -590,7 +590,7 @@ async fn tidb_fetch_rows_null_values() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::Value::Null);
@@ -633,7 +633,7 @@ async fn tidb_fetch_rows_various_data_types() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -768,7 +768,7 @@ async fn tidb_apply_changes_insert() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -813,7 +813,7 @@ async fn tidb_apply_changes_update() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!("new"));
@@ -854,7 +854,7 @@ async fn tidb_apply_changes_delete() {
     driver.apply_changes(&changes).await.unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 1);
@@ -1036,7 +1036,7 @@ async fn tidb_alter_table_set_default() {
         .unwrap();
 
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 10, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 10, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.rows[0][1], serde_json::json!(5));
@@ -1095,7 +1095,7 @@ async fn tidb_truncate_table() {
 
     driver.truncate_table(&db, &db, &tbl).await.unwrap();
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 0);
@@ -1305,7 +1305,7 @@ async fn tidb_no_db_fetch_rows_on_specific_database() {
 
     let driver = tidb_driver_no_db!();
     let data = driver
-        .fetch_rows(&db, &db, &tbl, 0, 50, None, None)
+        .fetch_rows(&db, &db, &tbl, 0, 50, Vec::new(), None)
         .await
         .unwrap();
     assert_eq!(data.total_rows, 2);

--- a/src/components/DataGrid/DataGrid.test.ts
+++ b/src/components/DataGrid/DataGrid.test.ts
@@ -1119,3 +1119,114 @@ describe("Down-on-last-row creates a new pending row (#64)", () => {
     ).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Multi-column sort emission (issue #57). The DataGrid's `onSortChanged`
+// reads ag-grid's column state, filters to the sorted columns, sorts them
+// by `sortIndex` (the priority order from Shift+click), then maps each
+// entry to `{ column, direction }`. Before the fix this code took only
+// `sortModel[0]` and emitted a single `SortSpec | null` — the grid lit
+// up multi-sort indicators in the header but the backend ORDER BY only
+// used the primary column.
+//
+// Lock the new contract here as a pure function so a regression can't
+// silently re-truncate the model.
+// ---------------------------------------------------------------------------
+
+interface SortSpec {
+  column: string;
+  direction: "asc" | "desc";
+}
+
+interface AgColumnState {
+  colId: string;
+  sort: "asc" | "desc" | null | undefined;
+  sortIndex?: number | null;
+}
+
+/** Mirrors the body of `onSortChanged` in DataGrid.tsx. */
+function emitSortModel(columnState: AgColumnState[]): SortSpec[] {
+  const sortModel = columnState
+    .filter((c) => c.sort)
+    .sort((a, b) => (a.sortIndex ?? 0) - (b.sortIndex ?? 0));
+  return sortModel.map((c) => ({
+    column: c.colId,
+    direction: c.sort as "asc" | "desc",
+  }));
+}
+
+describe("DataGrid multi-column sort emission (issue #57)", () => {
+  it("emits an empty array when no column is sorted", () => {
+    expect(
+      emitSortModel([
+        { colId: "id", sort: null },
+        { colId: "name", sort: null },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("emits a single entry when one column is sorted", () => {
+    expect(
+      emitSortModel([
+        { colId: "id", sort: null },
+        { colId: "name", sort: "asc", sortIndex: 0 },
+      ]),
+    ).toEqual([{ column: "name", direction: "asc" }]);
+  });
+
+  it("emits the full model in priority order on Shift+click", () => {
+    // Multi-sort: dept (primary, asc), salary (secondary, desc).
+    // ag-grid emits the column state in the grid's display order
+    // (which is independent of sort priority); the handler must
+    // re-sort by `sortIndex` so the ORDER BY clause is emitted in
+    // the priority the user picked.
+    const state: AgColumnState[] = [
+      { colId: "id", sort: null },
+      { colId: "salary", sort: "desc", sortIndex: 1 },
+      { colId: "dept", sort: "asc", sortIndex: 0 },
+    ];
+    expect(emitSortModel(state)).toEqual([
+      { column: "dept", direction: "asc" },
+      { column: "salary", direction: "desc" },
+    ]);
+  });
+
+  it("handles a three-column sort", () => {
+    const state: AgColumnState[] = [
+      { colId: "country", sort: "asc", sortIndex: 0 },
+      { colId: "city", sort: "asc", sortIndex: 1 },
+      { colId: "name", sort: "desc", sortIndex: 2 },
+      { colId: "id", sort: null },
+    ];
+    expect(emitSortModel(state).map((s) => s.column)).toEqual([
+      "country",
+      "city",
+      "name",
+    ]);
+  });
+
+  it("treats sortIndex undefined as 0 for stable ordering", () => {
+    // Older ag-grid versions sometimes emit `sortIndex: undefined`
+    // for the single-sort case. Both columns get treated as
+    // priority 0; the filter step still drops the un-sorted one
+    // so the output is the one with `sort` truthy.
+    const state: AgColumnState[] = [
+      { colId: "x", sort: null },
+      { colId: "y", sort: "asc" },
+    ];
+    expect(emitSortModel(state)).toEqual([
+      { column: "y", direction: "asc" },
+    ]);
+  });
+
+  it("does NOT truncate the sort model to its first entry", () => {
+    // Explicit guard against the original bug: before the fix the
+    // handler did `sortModel[0]` and emitted a single SortSpec.
+    // This assertion would fail if anyone re-introduces that.
+    const state: AgColumnState[] = [
+      { colId: "a", sort: "asc", sortIndex: 0 },
+      { colId: "b", sort: "desc", sortIndex: 1 },
+    ];
+    expect(emitSortModel(state).length).toBe(2);
+  });
+});

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -52,12 +52,26 @@ import "./ag-grid-theme.css";
 
 function DataTypeHeader(props: IHeaderParams & { dataType?: string; isPk?: boolean; fk?: ForeignKeyInfo }) {
   const [sortState, setSortState] = useState<"asc" | "desc" | null>(null);
+  // Priority position of this column inside ag-grid's multi-sort
+  // model: 0 = primary, 1 = secondary, etc. `null` when this
+  // column isn't sorted. We render a small numeric badge next to
+  // the direction arrow when sortIndex >= 1 so users can tell
+  // which column drives the primary sort — before issue #57 the
+  // server only honoured the first sort silently. (When only one
+  // column is sorted, `sortIndex` is 0 and we hide the badge to
+  // keep the header clean for the common single-sort case.)
+  const [sortIndex, setSortIndex] = useState<number | null>(null);
 
   useEffect(() => {
     const listener = () => {
       if (props.column.isSortAscending()) setSortState("asc");
       else if (props.column.isSortDescending()) setSortState("desc");
       else setSortState(null);
+      // ag-grid types `getSortIndex` as `number | null | undefined`;
+      // normalise to `number | null` so the render side has one
+      // shape to check.
+      const idx = props.column.getSortIndex?.();
+      setSortIndex(idx == null ? null : idx);
     };
     props.column.addEventListener("sortChanged", listener);
     listener();
@@ -83,6 +97,14 @@ function DataTypeHeader(props: IHeaderParams & { dataType?: string; isPk?: boole
                 ? <><line x1="12" y1="19" x2="12" y2="5" /><polyline points="5 12 12 5 19 12" /></>
                 : <><line x1="12" y1="5" x2="12" y2="19" /><polyline points="5 12 12 19 19 12" /></>}
             </svg>
+          )}
+          {sortState && sortIndex !== null && sortIndex > 0 && (
+            <span
+              className="ag-custom-sort-priority"
+              title={`Sort priority ${sortIndex + 1}`}
+            >
+              {sortIndex + 1}
+            </span>
           )}
         </span>
         {props.dataType && (
@@ -164,7 +186,10 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(0);
-  const [sort, setSort] = useState<SortSpec | null>(null);
+  // Multi-column sort (issue #57). The array is in priority order:
+  // index 0 is the primary sort, index 1 the secondary, etc.
+  // Empty = no user-picked sort (driver falls back to PK ordering).
+  const [sort, setSort] = useState<SortSpec[]>([]);
   const [saving, setSaving] = useState(false);
   const [showFilter, setShowFilter] = useState(false);
   const [activeFilter, setActiveFilter] = useState<string | null>(null);
@@ -875,16 +900,29 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
 
   const onSortChanged = useCallback(() => {
     if (!gridApiRef.current) return;
+    // ag-grid's multi-column sort model (Shift+click to add) is
+    // exposed via `getColumnState()`; we sort by `sortIndex` to
+    // preserve priority order. Before issue #57's fix this handler
+    // truncated `sortModel` to its first entry and emitted a
+    // single-column `SortSpec` — the grid lit up multiple sort
+    // arrows, but the backend ORDER BY only used the primary.
     const sortModel = gridApiRef.current.getColumnState()
       .filter((c) => c.sort)
       .sort((a, b) => (a.sortIndex ?? 0) - (b.sortIndex ?? 0));
-    const next: SortSpec | null = sortModel.length === 0
-      ? null
-      : { column: sortModel[0].colId, direction: sortModel[0].sort as "asc" | "desc" };
+    const next: SortSpec[] = sortModel.map((c) => ({
+      column: c.colId,
+      direction: c.sort as "asc" | "desc",
+    }));
     setSort((prev) => {
+      // Cheap structural equality check — avoids spuriously
+      // bumping `filterLoading` (and re-fetching) when ag-grid
+      // emits a sortChanged event with the same effective model
+      // (e.g. on a no-op click or after a tab regains focus).
       const same =
-        (prev === null && next === null) ||
-        (prev !== null && next !== null && prev.column === next.column && prev.direction === next.direction);
+        prev.length === next.length &&
+        prev.every((p, i) =>
+          p.column === next[i].column && p.direction === next[i].direction,
+        );
       if (!same) setFilterLoading(true);
       return next;
     });
@@ -903,8 +941,14 @@ export function DataGrid({ connectionId, database, schema, table, hideTitle = fa
       const dbType = connections.find((c) => c.id === connectionId)?.db_type;
       let sql = `SELECT * FROM ${quoteQualified(dbType, schema, table)}`;
       if (activeFilter) sql += ` WHERE ${activeFilter}`;
-      if (sort) {
-        sql += ` ORDER BY ${quoteIdent(dbType, sort.column)} ${sort.direction}`;
+      if (sort.length > 0) {
+        // Multi-column sort (issue #57): mirror what the driver
+        // emits server-side so the EXPLAIN plan reflects the same
+        // ORDER BY the row fetch is about to issue.
+        const orderBy = sort
+          .map((s) => `${quoteIdent(dbType, s.column)} ${s.direction}`)
+          .join(", ");
+        sql += ` ORDER BY ${orderBy}`;
       } else if (dbType === "mssql") {
         // MSSQL's `OFFSET ... ROWS FETCH NEXT ... ROWS ONLY` syntax
         // requires an `ORDER BY`. Use a NULL-sort sentinel so the

--- a/src/components/DataGrid/ag-grid-theme.css
+++ b/src/components/DataGrid/ag-grid-theme.css
@@ -217,6 +217,24 @@
   margin-left: 2px;
 }
 
+/* Sort-priority badge — only rendered on secondary+ columns when
+ * a multi-column sort is active (issue #57). The primary column
+ * stays badge-free; the badge's presence on column B implicitly
+ * tells the user that some other (un-badged) column is the
+ * primary sort. Sized to match the PK / FK badges so the cluster
+ * to the left of the column name reads as one consistent strip. */
+.ag-grid-wrapper .ag-custom-sort-priority {
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--accent);
+  background: var(--accent-muted);
+  padding: 1px 5px;
+  border-radius: 3px;
+  letter-spacing: 0.03em;
+  flex-shrink: 0;
+  margin-left: 2px;
+}
+
 /* Boolean checkbox styling */
 .ag-grid-wrapper .ag-checkbox-input-wrapper {
   width: 16px;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -313,7 +313,14 @@ export interface FetchRowsRequest {
   table: string;
   offset: number;
   limit: number;
-  sort: SortSpec | null;
+  /**
+   * Ordered list of sort specs (primary sort first). Empty means
+   * "use the driver's default ordering" — typically the primary-
+   * key columns so pagination stays stable. The data grid builds
+   * this from ag-grid's multi-column sort model (Shift+click). See
+   * issue #57.
+   */
+  sort: SortSpec[];
   filter: string | null;
 }
 


### PR DESCRIPTION
Closes #57.

## Summary

The data grid's header has accepted Shift+click since day one — the custom \`DataTypeHeader\` already passes \`e.shiftKey\` into ag-grid's \`progressSort\`, so the grid internally tracked an ordered multi-column sort model. The frontend handler then truncated that model to its first entry and emitted a single \`SortSpec | null\`; the backend's \`Option<SortSpec>\` matched; every driver composed a single-column \`ORDER BY\`; only the primary sort actually reached the database. Users saw arrows on multiple headers but got rows ordered by only one column.

This PR replaces the single-sort contract end-to-end and renders a small priority badge so the multi-sort state is visible from the header alone.

## Visible behaviour change

| Before | After |
|---|---|
| Shift+click columns A and B → arrows on both, rows sorted only by A | Shift+click columns A and B → arrows on both; B has a small priority badge \"2\"; rows actually sorted by A then B |

## Backend

| File | Change |
|---|---|
| \`models/types.rs\` | \`FetchRowsRequest.sort: Option<SortSpec>\` → \`Vec<SortSpec>\` with \`#[serde(default)]\` (omitted field deserialises to empty vec — backwards compatible) |
| \`db/mod.rs\` | \`DatabaseDriver::fetch_rows\` signature updated to match |
| \`commands/data.rs\`, \`commands/export.rs\` | Threaded through |
| \`db/pg_common.rs\` | ORDER BY now walks the vec in priority order and joins with \`, \` (covers postgres, cockroachdb via delegation) |
| \`db/mysql_common.rs\` | Same (covers mysql, mariadb, tidb) |
| \`db/sqlite.rs\` | Same |
| \`db/mssql.rs\` | Same, preserving the bespoke 3-step fallback ladder (user sort → PK → first column) — \`ORDER BY\` is mandatory for \`OFFSET … FETCH NEXT\` |
| \`db/cassandra.rs\` | Passes the full vec through; CQL is the gatekeeper since \`ORDER BY\` is only legal on clustering keys in clustering order |

The empty-vec case is the explicit \"no user sort\" signal; drivers fall back to PK columns for stable pagination, exactly as the \`None\` branch did before.

## Frontend

- **\`src/lib/tauri.ts\`** — \`FetchRowsRequest.sort\` is now \`SortSpec[]\`.
- **\`DataGrid.tsx\`**:
  - Sort state: \`SortSpec | null\` → \`SortSpec[]\`.
  - \`onSortChanged\`: stops truncating ag-grid's sortModel to \`[0]\`; maps every sorted column to a \`SortSpec\` in priority order. Structural equality check avoids re-fetches on no-op sortChanged events.
  - EXPLAIN query builder (the second place \`sort\` was read): same comma-joined ORDER BY composition so the EXPLAIN plan mirrors what the row-fetch query actually issues.
  - \`DataTypeHeader\`: reads \`column.getSortIndex()\` and renders \`.ag-custom-sort-priority\` next to the sort arrow when \`sortIndex >= 1\`. Primary column stays badge-free — the badge's presence elsewhere implicitly identifies the primary, which keeps the header clean in the common single-sort case.
- **\`ag-grid-theme.css\`** — \`.ag-custom-sort-priority\` styled to match the existing PK / FK badges.

## Tests

| Surface | Coverage |
|---|---|
| Backend integration (sqlite, postgres, mysql, mssql) | New \`*_fetch_rows_multi_column_sort\` builds a 5-row table with \`dept\` / \`salary\`, requests \`ORDER BY dept ASC, salary DESC\`, asserts the row order can only be produced by multi-sort. SQLite verified locally; others run in CI. |
| Backend integration (all engines) | Existing 7 single-sort tests migrated \`Some(SortSpec)\` → \`vec![SortSpec]\` |
| Backend mechanical | 99 other \`.fetch_rows(…, None, None)\` call sites across all integration test files rewritten to pass \`Vec::new()\` |
| Frontend unit | New \`emitSortModel\` pure-function block in \`DataGrid.test.ts\` with 6 cases — empty/single/multi/three-column/undefined-sortIndex fallback, plus an explicit \"no truncation to \`[0]\`\" guard so the original bug can't sneak back in |

## Verification

- \`cargo test --lib\` — 414 / 414 pass
- \`cargo test --test sqlite_integration\` (incl. new multi-sort) — 9 / 9 \`fetch_rows\` tests pass against a live SQLite driver
- \`cargo clippy --all-targets -- -D warnings\` — clean
- \`npm test\` — 660 / 660 pass (+6 over master's 654)
- \`tsc --noEmit\` — clean

## Acceptance criteria from #57

- [x] Shift+click in the grid header produces an ordered multi-column sort that is reflected in the rows fetched from the server
- [x] Single-column sort (the common case) keeps working without behaviour change — verified by the migrated existing tests and the unchanged PK fallback for empty-vec
- [x] Drivers that can't honour multi-column sort fall back gracefully — MSSQL keeps its mandatory-ORDER-BY ladder; Cassandra passes through and surfaces CQL's clustering-key constraint as a normal execution error rather than a hard panic
- [x] Cross-driver integration tests cover Postgres, MySQL, SQL Server, and SQLite for two-column sort
- [x] Frontend test covers the multi-sort emission path

## Out of scope (per the issue)

- Custom sort expressions (function calls in \`ORDER BY\`)
- Sort-by-aggregate