### PR TITLE
feat: user-configurable UI + editor fonts (#62)

### DIFF
--- a/e2e/preferences.spec.ts
+++ b/e2e/preferences.spec.ts
@@ -1,0 +1,241 @@
+import { test, expect, type Page } from "@playwright/test";
+import { openTable } from "./helpers";
+
+/**
+ * Preferences dialog (issue #62).
+ *
+ * Verifies the full pipeline: open dialog → change a setting →
+ * the corresponding CSS variable on `documentElement` updates →
+ * the value survives a page reload (localStorage persistence).
+ *
+ * The dialog mirrors the Connection Dialog layout (left nav + one
+ * `.connection-section-card` at a time on the right) so selectors
+ * dig through that scaffold rather than referencing a flat list of
+ * sections.
+ */
+
+const SETTINGS_KEY = "tablio-user-settings";
+
+async function openPreferencesDialog(page: Page) {
+  await page.locator("button[title='Settings']").click();
+  await page.locator('[data-testid="preferences-menu-item"]').click();
+  await page.locator(".preferences-dialog").waitFor({ timeout: 4000 });
+}
+
+async function readCssVar(page: Page, name: string): Promise<string> {
+  return page.evaluate(
+    ([n]) => document.documentElement.style.getPropertyValue(n).trim(),
+    [name],
+  );
+}
+
+async function gotoInterface(page: Page) {
+  await page.locator('[data-testid="preferences-nav-interface"]').click();
+  await page
+    .locator(".connection-section-heading h3", { hasText: /interface font/i })
+    .waitFor({ timeout: 2000 });
+}
+
+async function gotoEditor(page: Page) {
+  await page.locator('[data-testid="preferences-nav-editor"]').click();
+  await page
+    .locator(".connection-section-heading h3", { hasText: /sql editor font/i })
+    .waitFor({ timeout: 2000 });
+}
+
+test.describe("Preferences dialog (#62)", () => {
+  test.beforeEach(async ({ page }) => {
+    // Reset user-settings localStorage before navigating so the
+    // first paint starts from defaults.
+    await page.goto("/");
+    await page.evaluate(
+      (key) => window.localStorage.removeItem(key),
+      SETTINGS_KEY,
+    );
+    await page.reload();
+  });
+
+  test("opens via the Settings gear → Preferences menu entry", async ({ page }) => {
+    await openPreferencesDialog(page);
+    await expect(page.locator(".preferences-dialog h2")).toHaveText(
+      "Preferences",
+    );
+    // Left-rail nav has both sections.
+    await expect(
+      page.locator('[data-testid="preferences-nav-interface"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="preferences-nav-editor"]'),
+    ).toBeVisible();
+    // Interface section is the default active view.
+    await expect(
+      page.locator(".connection-section-heading h3"),
+    ).toContainText(/interface font/i);
+  });
+
+  test("clicking the SQL editor nav swaps the visible section", async ({ page }) => {
+    await openPreferencesDialog(page);
+    await gotoEditor(page);
+    await expect(
+      page.locator(".connection-section-heading h3"),
+    ).toContainText(/sql editor font/i);
+  });
+
+  test("changing the UI font size writes --ui-font-size on documentElement", async ({ page }) => {
+    await openPreferencesDialog(page);
+    await gotoInterface(page);
+    const uiSizeInput = page.locator(".preferences-size-input");
+    await uiSizeInput.fill("16");
+    await uiSizeInput.blur();
+    await expect
+      .poll(() => readCssVar(page, "--ui-font-size"))
+      .toBe("16px");
+  });
+
+  test("changing the editor font size writes --editor-font-size on documentElement", async ({ page }) => {
+    await openPreferencesDialog(page);
+    await gotoEditor(page);
+    const editorSizeInput = page.locator(".preferences-size-input");
+    await editorSizeInput.fill("18");
+    await editorSizeInput.blur();
+    await expect
+      .poll(() => readCssVar(page, "--editor-font-size"))
+      .toBe("18px");
+  });
+
+  test("changing the UI font family writes --font-sans on documentElement", async ({ page }) => {
+    await openPreferencesDialog(page);
+    await gotoInterface(page);
+    await page.locator(".preferences-font-select .cs-trigger").click();
+    // Pick the bundled "Fira Sans" option — always present even if
+    // document.fonts.check is flaky.
+    await page
+      .locator(".cs-dropdown .cs-option", { hasText: "Fira Sans" })
+      .first()
+      .click();
+    await expect
+      .poll(() => readCssVar(page, "--font-sans"))
+      .toContain("Fira Sans");
+  });
+
+  test("Reset to defaults clears family overrides and restores sizes", async ({ page }) => {
+    await openPreferencesDialog(page);
+    await gotoInterface(page);
+    const uiSizeInput = page.locator(".preferences-size-input");
+    await uiSizeInput.fill("17");
+    await uiSizeInput.blur();
+    await expect
+      .poll(() => readCssVar(page, "--ui-font-size"))
+      .toBe("17px");
+
+    await page.locator(".preferences-reset-btn").click();
+
+    await expect
+      .poll(() => readCssVar(page, "--ui-font-size"))
+      .toBe("13px");
+    await expect
+      .poll(() => readCssVar(page, "--font-sans"))
+      .toBe("");
+  });
+
+  test("settings persist across a page reload (localStorage round-trip)", async ({ page }) => {
+    await openPreferencesDialog(page);
+    await gotoEditor(page);
+    const editorSizeInput = page.locator(".preferences-size-input");
+    await editorSizeInput.fill("20");
+    await editorSizeInput.blur();
+    await expect
+      .poll(() => readCssVar(page, "--editor-font-size"))
+      .toBe("20px");
+
+    // The store debounces persistence by 300ms — wait for it to
+    // flush before reloading.
+    await page.waitForTimeout(400);
+    await page.reload();
+
+    await expect
+      .poll(() => readCssVar(page, "--editor-font-size"))
+      .toBe("20px");
+  });
+
+  test("Done button closes the dialog", async ({ page }) => {
+    await openPreferencesDialog(page);
+    await page
+      .locator(".preferences-dialog .btn-primary", { hasText: "Done" })
+      .click();
+    await expect(page.locator(".preferences-dialog")).not.toBeVisible();
+  });
+
+  test("live preview strip reflects the chosen UI font size", async ({ page }) => {
+    // Confirms the dialog gives the user immediate visual feedback
+    // before they close — the preview reads from the same CSS
+    // variable the rest of the UI does, so seeing it change is a
+    // proxy for the whole pipeline being wired up.
+    await openPreferencesDialog(page);
+    await gotoInterface(page);
+    const uiSizeInput = page.locator(".preferences-size-input");
+    await uiSizeInput.fill("17");
+    await uiSizeInput.blur();
+    const preview = page.locator('[data-testid="preferences-ui-preview"]');
+    await expect
+      .poll(async () =>
+        preview.evaluate((el) =>
+          parseInt(window.getComputedStyle(el).fontSize, 10),
+        ),
+      )
+      .toBe(17);
+  });
+
+  test("live preview strip reflects the chosen editor font size", async ({ page }) => {
+    await openPreferencesDialog(page);
+    await gotoEditor(page);
+    const editorSizeInput = page.locator(".preferences-size-input");
+    await editorSizeInput.fill("19");
+    await editorSizeInput.blur();
+    const preview = page.locator(
+      '[data-testid="preferences-editor-preview"]',
+    );
+    await expect
+      .poll(async () =>
+        preview.evaluate((el) =>
+          parseInt(window.getComputedStyle(el).fontSize, 10),
+        ),
+      )
+      .toBe(19);
+  });
+
+  test("editor font size flows end-to-end into AG Grid result cells", async ({ page }) => {
+    // The "editor font" preference is supposed to govern every
+    // monospace surface — Monaco editors AND the result grid.
+    // This test exercises the longest wiring path: store → CSS
+    // var → ag-grid-theme.css rule → computed font-size on a
+    // real .ag-cell DOM element.
+    await openPreferencesDialog(page);
+    await gotoEditor(page);
+    const editorSizeInput = page.locator(".preferences-size-input");
+    await editorSizeInput.fill("18");
+    await editorSizeInput.blur();
+    await expect
+      .poll(() => readCssVar(page, "--editor-font-size"))
+      .toBe("18px");
+    // Close the dialog and open a real data grid view.
+    await page
+      .locator(".preferences-dialog .btn-primary", { hasText: "Done" })
+      .click();
+    await openTable(page, "users");
+    // Target a real data cell by `col-id` so we skip AG Grid's
+    // row-number gutter cell (which renders at a fixed smaller
+    // font and isn't covered by the editor-font setting).
+    const idCell = page
+      .locator('.ag-cell[col-id="id"], .ag-cell[col-id="ID"]')
+      .first();
+    await idCell.waitFor({ timeout: 8000 });
+    await expect
+      .poll(async () =>
+        idCell.evaluate((el) =>
+          parseInt(window.getComputedStyle(el).fontSize, 10),
+        ),
+      )
+      .toBe(18);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,10 +14,13 @@ import { ToastContainer } from "./components/Toast/Toast";
 import { PassphrasePrompt } from "./components/PassphrasePrompt";
 import { HostKeyMismatchPrompt } from "./components/HostKeyMismatchPrompt";
 import { KnownHostsDialog } from "./components/KnownHostsDialog";
+import { PreferencesDialog } from "./components/Preferences/PreferencesDialog";
 import { useConnectionStore } from "./stores/connectionStore";
 import { useTabStore } from "./stores/tabStore";
+import { useUserSettingsStore } from "./stores/userSettingsStore";
+import { applyFontSettings } from "./lib/applyFontSettings";
 import { loader } from "@monaco-editor/react";
-import { Database, Plus, Keyboard, Palette, Check, Cpu, MemoryStick, ShieldCheck, Settings } from "lucide-react";
+import { Database, Plus, Keyboard, Palette, Check, Cpu, MemoryStick, ShieldCheck, Settings, Sliders } from "lucide-react";
 import { themes, getThemeById, applyTheme } from "./lib/themes";
 import { syncMonacoTheme } from "./lib/monacoTheme";
 import { api } from "./lib/tauri";
@@ -134,6 +137,7 @@ export default function App() {
   const [showThemePicker, setShowThemePicker] = useState(false);
   const [showSettingsMenu, setShowSettingsMenu] = useState(false);
   const [showKnownHosts, setShowKnownHosts] = useState(false);
+  const [showPreferences, setShowPreferences] = useState(false);
   const zoomTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const themePickerRef = useRef<HTMLDivElement>(null);
   const settingsMenuRef = useRef<HTMLDivElement>(null);
@@ -248,6 +252,16 @@ export default function App() {
     applyTheme(t);
     localStorage.setItem("tablio-theme", themeId);
   }, [themeId]);
+
+  // User-configurable font preferences (issue #62). Subscribe to the
+  // store and push the values onto documentElement's CSS variables
+  // every time they change. The CSS rest of the app already reads
+  // `var(--font-sans / --font-mono / --ui-font-size / --editor-font-size)`,
+  // so a single write here flips the whole UI live with no remount.
+  const userSettings = useUserSettingsStore((s) => s.settings);
+  useEffect(() => {
+    applyFontSettings(userSettings);
+  }, [userSettings]);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -473,6 +487,17 @@ export default function App() {
                     <div className="theme-picker-group-label">Settings</div>
                     <button
                       className="theme-picker-item"
+                      data-testid="preferences-menu-item"
+                      onClick={() => {
+                        setShowSettingsMenu(false);
+                        setShowPreferences(true);
+                      }}
+                    >
+                      <Sliders size={13} />
+                      <span className="theme-picker-name">Preferences</span>
+                    </button>
+                    <button
+                      className="theme-picker-item"
                       onClick={() => {
                         setShowSettingsMenu(false);
                         setShowKnownHosts(true);
@@ -540,6 +565,9 @@ export default function App() {
       <ToastContainer />
       <PassphrasePrompt />
       <HostKeyMismatchPrompt />
+      {showPreferences && (
+        <PreferencesDialog onClose={() => setShowPreferences(false)} />
+      )}
       <KnownHostsDialog
         open={showKnownHosts}
         onClose={() => setShowKnownHosts(false)}

--- a/src/components/CustomSelect/CustomSelect.css
+++ b/src/components/CustomSelect/CustomSelect.css
@@ -57,6 +57,33 @@
   overflow: hidden;
 }
 
+/* Portal variant — the dropdown is rendered to document.body so it
+ * can escape any ancestor overflow:hidden container (modals, sticky
+ * toolbars, sidebar panels). Coordinates are computed inline via
+ * getBoundingClientRect; the z-index is bumped above the dialog
+ * overlay (which uses z-index ~1000 in this app) so the popover
+ * always stays on top. */
+.cs-dropdown--portal {
+  z-index: 2000;
+  margin-top: 0;
+  /* `.cs-dropdown` sets `min-width: 100%`, which under
+   * `position: absolute` resolves against the wrapper trigger and
+   * keeps the popover at least trigger-width. But this portal
+   * variant uses `position: fixed`, so 100% resolves against the
+   * viewport instead — the popover would stretch across the
+   * whole screen. We pin the width directly via inline `style`,
+   * so unset the min-width here. */
+  min-width: 0;
+}
+
+/* When the trigger sits close to the viewport bottom, the dropdown
+ * flips upward via `bottom: …` positioning instead of `top: …`.
+ * No additional rules are needed for the flip itself — these
+ * cosmetic adjustments just keep the visual gap on the right side. */
+.cs-dropdown--upward {
+  margin-bottom: 0;
+}
+
 .cs-options {
   flex: 1;
   min-height: 0;

--- a/src/components/CustomSelect/CustomSelect.test.tsx
+++ b/src/components/CustomSelect/CustomSelect.test.tsx
@@ -50,4 +50,77 @@ describe("CustomSelect", () => {
     fireEvent.click(screen.getByRole("button"));
     expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
   });
+
+  // ---------------------------------------------------------------
+  // portal mode (issue #62 follow-up): the dropdown must render
+  // outside the wrapper subtree so it can escape ancestor
+  // `overflow: hidden`. Default mode keeps the dropdown inline.
+  // ---------------------------------------------------------------
+
+  it("renders the dropdown inline (as a wrapper descendant) when portal is off", () => {
+    const { container } = render(
+      <CustomSelect
+        value="a"
+        options={[
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ]}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    // The wrapper is the first `.cs-wrapper` in the render output —
+    // the dropdown must be inside it.
+    const wrapper = container.querySelector(".cs-wrapper");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.querySelector(".cs-dropdown")).not.toBeNull();
+    expect(
+      wrapper!.querySelector(".cs-dropdown--portal"),
+    ).toBeNull();
+  });
+
+  it("renders the dropdown via a portal (escaping the wrapper) when portal is on", () => {
+    const { container } = render(
+      <CustomSelect
+        value="a"
+        options={[
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ]}
+        onChange={vi.fn()}
+        portal
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    const wrapper = container.querySelector(".cs-wrapper");
+    // The wrapper subtree must NOT contain the dropdown — it
+    // lives elsewhere in the document (createPortal target).
+    expect(wrapper!.querySelector(".cs-dropdown")).toBeNull();
+    // The portal-marker class is what global CSS uses to apply
+    // the `z-index: 2000` + width-recovery rules.
+    const portalDropdown = document.querySelector(".cs-dropdown--portal");
+    expect(portalDropdown).not.toBeNull();
+  });
+
+  it("portal-mode dropdown still emits onChange when an option is clicked", () => {
+    // Click-routing breaks if the click-outside listener treats the
+    // portalised dropdown as "outside" — this test guards against
+    // that regression by asserting an option click survives the
+    // mousedown phase and onChange fires.
+    const onChange = vi.fn();
+    render(
+      <CustomSelect
+        value="a"
+        options={[
+          { value: "a", label: "A" },
+          { value: "b", label: "B" },
+        ]}
+        onChange={onChange}
+        portal
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByText("B"));
+    expect(onChange).toHaveBeenCalledWith("b");
+  });
 });

--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -1,4 +1,6 @@
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useMemo, useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
+import { readZoomFactor } from "../../lib/zoom";
 import "./CustomSelect.css";
 
 interface Option {
@@ -13,18 +15,60 @@ interface Props {
   className?: string;
   searchable?: boolean;
   placeholder?: string;
+  /**
+   * Render the dropdown via a portal anchored to the trigger's
+   * viewport position instead of inlining it next to the trigger.
+   *
+   * Enable this whenever the select sits inside an `overflow: hidden`
+   * or `overflow: auto` container (modal dialogs, sticky toolbars,
+   * sidebar panels) so the dropdown can extend past the clipping
+   * boundary. Off by default to preserve the simpler in-flow
+   * positioning that every existing call site relies on.
+   */
+  portal?: boolean;
 }
 
-export function CustomSelect({ value, options, onChange, className, searchable, placeholder }: Props) {
+/** Computed { top, left, width } for the portalised dropdown,
+ *  measured relative to the viewport. `null` while closed so we
+ *  don't pay the layout read for an unmounted popover. */
+interface PortalPosition {
+  top: number;
+  left: number;
+  width: number;
+  openUpward: boolean;
+}
+
+const DROPDOWN_MAX_HEIGHT = 240;
+const TRIGGER_GAP = 3;
+
+export function CustomSelect({
+  value,
+  options,
+  onChange,
+  className,
+  searchable,
+  placeholder,
+  portal,
+}: Props) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [portalPos, setPortalPos] = useState<PortalPosition | null>(null);
   const ref = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!open) return;
     const close = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      // Click anywhere outside the trigger OR the portalised
+      // dropdown closes the popover. We can't rely on `ref.current`
+      // alone in portal mode because the dropdown is no longer a
+      // descendant of the wrapper.
+      const insideTrigger = ref.current?.contains(e.target as Node);
+      const insideDropdown = dropdownRef.current?.contains(
+        e.target as Node,
+      );
+      if (!insideTrigger && !insideDropdown) setOpen(false);
     };
     document.addEventListener("mousedown", close);
     return () => document.removeEventListener("mousedown", close);
@@ -38,6 +82,57 @@ export function CustomSelect({ value, options, onChange, className, searchable, 
     }
   }, [open, searchable]);
 
+  // Compute portal coordinates anchored to the trigger. Flips
+  // upward when there isn't enough space below; recomputes on
+  // scroll / resize so the popover tracks the trigger.
+  useLayoutEffect(() => {
+    if (!open || !portal || !ref.current) {
+      setPortalPos(null);
+      return;
+    }
+
+    const measure = () => {
+      const trigger = ref.current?.getBoundingClientRect();
+      if (!trigger) return;
+      // The dropdown is portalised into <body>, which on Chromium
+      // carries the app's CSS `zoom` (see src/lib/zoom.ts). A
+      // `position: fixed` element inside a zoom-scaled parent is
+      // ALSO scaled, while `getBoundingClientRect` already returns
+      // visually-zoomed coordinates → without compensation we'd
+      // end up double-zoomed and the popover would drift from the
+      // trigger at any zoom != 100%. Scaling the rect down by the
+      // current zoom factor cancels the second multiplication that
+      // the zoomed parent will apply on render.
+      const z = readZoomFactor();
+      const top = trigger.top / z;
+      const bottom = trigger.bottom / z;
+      const left = trigger.left / z;
+      const width = trigger.width / z;
+      const viewportHeight = window.innerHeight / z;
+      const spaceBelow = viewportHeight - bottom - TRIGGER_GAP;
+      const spaceAbove = top - TRIGGER_GAP;
+      const openUpward =
+        spaceBelow < DROPDOWN_MAX_HEIGHT && spaceAbove > spaceBelow;
+      setPortalPos({
+        top: openUpward ? top - TRIGGER_GAP : bottom + TRIGGER_GAP,
+        left,
+        width,
+        openUpward,
+      });
+    };
+
+    measure();
+    // Track scroll on any ancestor + viewport resize so the
+    // dropdown stays glued to the trigger.
+    const update = () => measure();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [open, portal]);
+
   const selected = options.find((o) => o.value === value);
 
   const filtered = useMemo(() => {
@@ -46,6 +141,70 @@ export function CustomSelect({ value, options, onChange, className, searchable, 
     return options.filter((o) => o.label.toLowerCase().includes(q));
   }, [options, search, searchable]);
 
+  const dropdownBody = (
+    <div
+      ref={dropdownRef}
+      className={`cs-dropdown${portal ? " cs-dropdown--portal" : ""}${
+        portalPos?.openUpward ? " cs-dropdown--upward" : ""
+      }`}
+      style={
+        portal && portalPos
+          ? {
+              position: "fixed",
+              top: portalPos.openUpward ? undefined : portalPos.top,
+              // `portalPos.top` is already in zoom-compensated px
+              // (see measure() in the layout effect), so we
+              // compare against the zoom-compensated viewport
+              // height to keep the upward-flip anchor consistent.
+              bottom: portalPos.openUpward
+                ? window.innerHeight / readZoomFactor() - portalPos.top
+                : undefined,
+              left: portalPos.left,
+              width: portalPos.width,
+            }
+          : undefined
+      }
+    >
+      {searchable && (
+        <div className="cs-search-wrapper">
+          <input
+            ref={searchRef}
+            className="cs-search"
+            placeholder="Search..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                setOpen(false);
+              }
+              if (e.key === "Enter" && filtered.length === 1) {
+                onChange(filtered[0].value);
+                setOpen(false);
+              }
+            }}
+          />
+        </div>
+      )}
+      <div className="cs-options">
+        {filtered.map((opt) => (
+          <div
+            key={opt.value}
+            className={`cs-option ${opt.value === value ? "cs-option-selected" : ""}`}
+            onClick={() => {
+              onChange(opt.value);
+              setOpen(false);
+            }}
+          >
+            {opt.label}
+          </div>
+        ))}
+        {searchable && filtered.length === 0 && (
+          <div className="cs-no-results">No matches</div>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <div className={`cs-wrapper ${className || ""}`} ref={ref}>
       <button
@@ -53,49 +212,27 @@ export function CustomSelect({ value, options, onChange, className, searchable, 
         className="cs-trigger"
         onClick={() => setOpen((v) => !v)}
       >
-        <span className={`cs-value ${!selected && placeholder ? "cs-placeholder" : ""}`}>
+        <span
+          className={`cs-value ${!selected && placeholder ? "cs-placeholder" : ""}`}
+        >
           {selected?.label ?? placeholder ?? value}
         </span>
-        <svg className="cs-chevron" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+        <svg
+          className="cs-chevron"
+          width="10"
+          height="10"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+        >
           <path d="m6 9 6 6 6-6" />
         </svg>
       </button>
-      {open && (
-        <div className="cs-dropdown">
-          {searchable && (
-            <div className="cs-search-wrapper">
-              <input
-                ref={searchRef}
-                className="cs-search"
-                placeholder="Search..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Escape") { setOpen(false); }
-                  if (e.key === "Enter" && filtered.length === 1) {
-                    onChange(filtered[0].value);
-                    setOpen(false);
-                  }
-                }}
-              />
-            </div>
-          )}
-          <div className="cs-options">
-            {filtered.map((opt) => (
-              <div
-                key={opt.value}
-                className={`cs-option ${opt.value === value ? "cs-option-selected" : ""}`}
-                onClick={() => { onChange(opt.value); setOpen(false); }}
-              >
-                {opt.label}
-              </div>
-            ))}
-            {searchable && filtered.length === 0 && (
-              <div className="cs-no-results">No matches</div>
-            )}
-          </div>
-        </div>
-      )}
+      {open &&
+        (portal
+          ? createPortal(dropdownBody, document.body)
+          : dropdownBody)}
     </div>
   );
 }

--- a/src/components/DDLViewer/DDLViewer.tsx
+++ b/src/components/DDLViewer/DDLViewer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Editor, { type BeforeMount, type Monaco } from "@monaco-editor/react";
 import { api } from "../../lib/tauri";
 import { syncMonacoTheme, isLightTheme } from "../../lib/monacoTheme";
+import { useUserSettingsStore } from "../../stores/userSettingsStore";
 import { Loader2, Copy, Check } from "lucide-react";
 import "./DDLViewer.css";
 
@@ -24,6 +25,10 @@ export function DDLViewer({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  // Editor font size from user preferences (#62).
+  const editorFontSize = useUserSettingsStore(
+    (s) => s.settings.editorFontSize,
+  );
   const [monacoTheme, setMonacoTheme] = useState<string>(() =>
     isLightTheme() ? "tablio-light-0" : "tablio-dark-0"
   );
@@ -131,7 +136,7 @@ export function DDLViewer({
           options={{
             readOnly: true,
             minimap: { enabled: false },
-            fontSize: 15,
+            fontSize: editorFontSize,
             fontFamily: "var(--font-mono)",
             lineNumbers: "on",
             scrollBeyondLastLine: false,

--- a/src/components/DataGrid/DataGrid.tsx
+++ b/src/components/DataGrid/DataGrid.tsx
@@ -20,6 +20,7 @@ import { ExportMenu } from "../ExportMenu";
 import { ColumnOrganizer, ColumnSettings, loadColumnSettings, saveColumnSettings, applyColumnSettings } from "./ColumnOrganizer";
 import { useToastStore } from "../../stores/toastStore";
 import { useTabStore, TabInfo } from "../../stores/tabStore";
+import { useUserSettingsStore } from "../../stores/userSettingsStore";
 import { useConnectionStore } from "../../stores/connectionStore";
 import { boolLiteral, paginationClause, quoteIdent, quoteQualified } from "../../lib/sqlDialect";
 import {
@@ -118,28 +119,42 @@ function DataTypeHeader(props: IHeaderParams & { dataType?: string; isPk?: boole
   );
 }
 
-const gridTheme = themeQuartz.withParams({
-  backgroundColor: "var(--bg-secondary)",
-  foregroundColor: "var(--text-primary)",
-  headerBackgroundColor: "var(--bg-header)",
-  accentColor: "var(--accent)",
-  borderColor: "var(--border)",
-  columnBorder: true,
-  oddRowBackgroundColor: "var(--bg-primary)",
-  rowHoverColor: "var(--bg-hover)",
-  selectedRowBackgroundColor: "var(--bg-selected)",
-  headerTextColor: "var(--text-secondary)",
-  cellTextColor: "var(--text-primary)",
-  fontFamily: "var(--font-mono)",
-  fontSize: 14,
-  headerFontSize: 12,
-  rowHeight: 36,
-  headerHeight: 38,
-  cellHorizontalPadding: 10,
-  wrapperBorderRadius: 0,
-  borderRadius: 0,
-  headerColumnResizeHandleColor: "transparent",
-});
+/**
+ * AG Grid theme that respects the user's editor-font preference
+ * (issue #62). `themeQuartz.withParams` emits CSS variables (e.g.
+ * `--ag-font-size`) that AG Grid's own runtime stylesheet reads
+ * with higher specificity than any static rule we could write, so
+ * we have to go through this API to make the font size flow into
+ * cells + headers.
+ */
+function buildGridTheme(editorFontSize: number) {
+  return themeQuartz.withParams({
+    backgroundColor: "var(--bg-secondary)",
+    foregroundColor: "var(--text-primary)",
+    headerBackgroundColor: "var(--bg-header)",
+    accentColor: "var(--accent)",
+    borderColor: "var(--border)",
+    columnBorder: true,
+    oddRowBackgroundColor: "var(--bg-primary)",
+    rowHoverColor: "var(--bg-hover)",
+    selectedRowBackgroundColor: "var(--bg-selected)",
+    headerTextColor: "var(--text-secondary)",
+    cellTextColor: "var(--text-primary)",
+    fontFamily: "var(--font-mono)",
+    fontSize: editorFontSize,
+    // Header keeps its smaller fixed size — header text isn't the
+    // primary "read your data" surface, so we don't tie it to the
+    // user's pref. Cells are what matter for the editor-font
+    // mental model.
+    headerFontSize: 12,
+    rowHeight: 36,
+    headerHeight: 38,
+    cellHorizontalPadding: 10,
+    wrapperBorderRadius: 0,
+    borderRadius: 0,
+    headerColumnResizeHandleColor: "transparent",
+  });
+}
 
 interface Props {
   connectionId: string;
@@ -181,6 +196,17 @@ const REFRESH_OPTIONS = [
 export function DataGrid({ connectionId, database, schema, table, hideTitle = false, isActive = true }: Props) {
   const addToast = useToastStore((s) => s.addToast);
   const openTab = useTabStore((s) => s.openTab);
+  // Editor font preference flows into the grid's cell font-size via
+  // the AG Grid theme API. Rebuilding the theme each time the user
+  // adjusts the preference is cheap (it's a pure factory) and AG
+  // Grid handles the theme swap without remount.
+  const editorFontSize = useUserSettingsStore(
+    (s) => s.settings.editorFontSize,
+  );
+  const gridTheme = useMemo(
+    () => buildGridTheme(editorFontSize),
+    [editorFontSize],
+  );
   const connections = useConnectionStore((s) => s.connections);
   const [data, setData] = useState<TableData | null>(null);
   const [loading, setLoading] = useState(true);

--- a/src/components/DataGrid/ag-grid-theme.css
+++ b/src/components/DataGrid/ag-grid-theme.css
@@ -3,6 +3,13 @@
   height: 100%;
 }
 
+/* Note: the user-configurable editor font preferences (#62) do NOT
+ * apply via this stylesheet. AG Grid emits its own runtime CSS via
+ * `themeQuartz.withParams({ fontSize })` with higher specificity
+ * than any static rule we could write, so the font-family / size
+ * are wired through the theme API in DataGrid.tsx and
+ * ResultTable.tsx instead. */
+
 /* Suppress all cell focus/editing animations */
 .ag-grid-wrapper .ag-cell,
 .ag-grid-wrapper .ag-cell-focus,

--- a/src/components/Preferences/PreferencesDialog.css
+++ b/src/components/Preferences/PreferencesDialog.css
@@ -1,0 +1,104 @@
+/* Preferences dialog (issue #62). Reuses the Connection Dialog
+ * chrome (`.connection-dialog`, `.connection-dialog-body`,
+ * `.connection-dialog-nav`, `.connection-section-card`, …) so the
+ * left-rail nav + section-card layout matches; only the dialog-
+ * level width and a few preferences-specific controls live here. */
+
+/* Connection dialog ships at min(840px, 100vw-32px) which is too
+ * roomy for the two-row preferences content. Cap a bit tighter and
+ * let the height auto-fit the active section so the empty space
+ * doesn't dominate. */
+.preferences-dialog.connection-dialog {
+  width: min(720px, calc(100vw - 32px));
+  min-width: min(640px, calc(100vw - 32px));
+  height: min(72vh, 540px);
+}
+
+/* CustomSelect → match the height + typography of the size-input
+ * sibling on the same form-row so the controls align cleanly. The
+ * select takes the wide column; the size input takes the narrow
+ * column (see .preferences-size-group). */
+.preferences-font-select {
+  display: flex;
+  width: 100%;
+}
+
+.preferences-font-select .cs-trigger {
+  width: 100%;
+  height: 34px;
+  font-size: 13px;
+}
+
+/* The size group sits beside the family dropdown in a `.form-row`
+ * — flex children both default to flex: 0 1 auto, so we pin a
+ * narrow basis so the dropdown takes the rest. */
+.preferences-size-group {
+  flex: 0 0 130px;
+}
+
+.preferences-size-input {
+  height: 34px;
+  padding: 0 10px;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.12s, box-shadow 0.12s;
+}
+
+.preferences-size-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+/* The font-family field needs to grow to fill the remaining row
+ * width. `.form-row` already lays children out as flex; the
+ * dropdown's wrapping `.form-group` has no explicit grow so we set
+ * it here. */
+.preferences-dialog .form-row > .form-group:first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Live preview strip under the fields. Reads the same CSS vars as
+ * the rest of the app so changes are immediately visible. */
+.preferences-preview {
+  padding: 12px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preferences-preview-ui {
+  font-family: var(--font-sans);
+  font-size: var(--ui-font-size);
+}
+
+.preferences-preview-editor {
+  font-family: var(--font-mono);
+  font-size: var(--editor-font-size);
+}
+
+/* Reset button: ghost styling with a subtle icon. The footer's
+ * `.dialog-footer-left` slot positions it on the left, mirroring
+ * the connection dialog's secondary action placement. */
+.preferences-reset-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 12px;
+  color: var(--text-secondary);
+}
+
+.preferences-reset-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}

--- a/src/components/Preferences/PreferencesDialog.tsx
+++ b/src/components/Preferences/PreferencesDialog.tsx
@@ -1,0 +1,301 @@
+import { useMemo, useState, type ReactNode } from "react";
+import { X, RotateCcw, Type, FileCode } from "lucide-react";
+import { CustomSelect } from "../CustomSelect/CustomSelect";
+import {
+  useUserSettingsStore,
+  UI_FONT_SIZE_MIN,
+  UI_FONT_SIZE_MAX,
+  EDITOR_FONT_SIZE_MIN,
+  EDITOR_FONT_SIZE_MAX,
+} from "../../stores/userSettingsStore";
+import {
+  UI_FONT_CANDIDATES,
+  EDITOR_FONT_CANDIDATES,
+  SYSTEM_DEFAULT_SENTINEL,
+  detectAvailableFonts,
+  type FontOption,
+} from "../../lib/fontAvailability";
+import "./PreferencesDialog.css";
+
+/**
+ * Preferences dialog — user-configurable font family + size for the
+ * UI shell and the Monaco editor surface (issue #62).
+ *
+ * Layout mirrors the Connection Dialog: a left-rail nav (one entry
+ * per logical group) + a right pane of `connection-section-card`
+ * blocks with heading + form fields. The store updates live, so
+ * there's no Save button — Done just closes the dialog.
+ */
+
+interface Props {
+  onClose: () => void;
+}
+
+type SectionId = "interface" | "editor";
+
+interface SectionDef {
+  id: SectionId;
+  label: string;
+  description: string;
+  icon: ReactNode;
+}
+
+const SECTIONS: SectionDef[] = [
+  {
+    id: "interface",
+    label: "Interface",
+    description: "Font for the sidebar, toolbars, and dialogs.",
+    icon: <Type size={14} />,
+  },
+  {
+    id: "editor",
+    label: "SQL editor",
+    description: "Font for the query editor and result grid.",
+    icon: <FileCode size={14} />,
+  },
+];
+
+/* ---------------------- shared field primitives ---------------------- */
+
+function FontFamilyField({
+  candidates,
+  value,
+  onChange,
+}: {
+  candidates: FontOption[];
+  value: string | null;
+  onChange: (family: string | null) => void;
+}) {
+  return (
+    <div className="form-group">
+      <label>Font family</label>
+      <CustomSelect
+        className="preferences-font-select"
+        // CustomSelect identifies the active option by `value`, so
+        // map `null` → the sentinel literal it can match.
+        value={value ?? SYSTEM_DEFAULT_SENTINEL}
+        options={candidates.map((c) => ({ value: c.family, label: c.label }))}
+        onChange={(v) =>
+          onChange(v === SYSTEM_DEFAULT_SENTINEL ? null : v)
+        }
+        searchable
+        // The dialog's content scroll container clips inline
+        // popovers — render the dropdown to document.body so the
+        // full option list (and its search box) stays visible.
+        portal
+      />
+    </div>
+  );
+}
+
+function FontSizeField({
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  value: number;
+  min: number;
+  max: number;
+  onChange: (size: number) => void;
+}) {
+  return (
+    <div className="form-group preferences-size-group">
+      <label>Font size</label>
+      <input
+        className="preferences-size-input"
+        type="number"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => {
+          const next = parseInt(e.target.value, 10);
+          // Empty input parses to NaN — let the store's clamp handle
+          // it (falls back to the default), so we can still type
+          // freely without the value snapping every keystroke.
+          if (!Number.isNaN(next)) onChange(next);
+        }}
+      />
+    </div>
+  );
+}
+
+function SectionCard({
+  title,
+  description,
+  previewClass,
+  previewText,
+  testId,
+  children,
+}: {
+  title: string;
+  description: string;
+  previewClass: string;
+  previewText: string;
+  testId: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="connection-section-card" aria-label={title}>
+      <div className="connection-section-heading">
+        <div className="connection-section-heading__text">
+          <h3>{title}</h3>
+          <p>{description}</p>
+        </div>
+      </div>
+      <div className="connection-section-fields">
+        <div className="form-row">{children}</div>
+        <div
+          className={`preferences-preview ${previewClass}`}
+          data-testid={testId}
+        >
+          {previewText}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ----------------------------- main ---------------------------------- */
+
+export function PreferencesDialog({ onClose }: Props) {
+  const settings = useUserSettingsStore((s) => s.settings);
+  const setUiFontFamily = useUserSettingsStore((s) => s.setUiFontFamily);
+  const setUiFontSize = useUserSettingsStore((s) => s.setUiFontSize);
+  const setEditorFontFamily = useUserSettingsStore(
+    (s) => s.setEditorFontFamily,
+  );
+  const setEditorFontSize = useUserSettingsStore((s) => s.setEditorFontSize);
+  const resetToDefaults = useUserSettingsStore((s) => s.resetToDefaults);
+
+  const [activeSection, setActiveSection] = useState<SectionId>("interface");
+
+  // Probe what's installed once per mount. Bundled fonts + the
+  // "System default" sentinel always pass through.
+  const uiFonts = useMemo(
+    () => detectAvailableFonts(UI_FONT_CANDIDATES),
+    [],
+  );
+  const editorFonts = useMemo(
+    () => detectAvailableFonts(EDITOR_FONT_CANDIDATES),
+    [],
+  );
+
+  return (
+    <div className="dialog-overlay" onClick={onClose}>
+      <div
+        className="dialog connection-dialog preferences-dialog"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="dialog-header">
+          <h2>Preferences</h2>
+          <button
+            className="btn-icon"
+            onClick={onClose}
+            aria-label="Close preferences"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="dialog-body connection-dialog-body">
+          <nav
+            className="connection-dialog-nav"
+            aria-label="Preferences sections"
+          >
+            {SECTIONS.map((section) => (
+              <button
+                key={section.id}
+                type="button"
+                className={`connection-nav-item${
+                  activeSection === section.id
+                    ? " connection-nav-item--active"
+                    : ""
+                }`}
+                onClick={() => setActiveSection(section.id)}
+                data-section={section.id}
+                data-testid={`preferences-nav-${section.id}`}
+              >
+                <span className="connection-nav-item__icon">
+                  {section.icon}
+                </span>
+                <span className="connection-nav-item__text">
+                  <span className="connection-nav-item__label">
+                    {section.label}
+                  </span>
+                  <span className="connection-nav-item__description">
+                    {section.description}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </nav>
+
+          <div className="connection-dialog-content">
+            {activeSection === "interface" && (
+              <SectionCard
+                title="Interface font"
+                description="Applies to the sidebar, toolbars, tabs, and dialog text."
+                previewClass="preferences-preview-ui"
+                previewText="The quick brown fox jumps over the lazy dog"
+                testId="preferences-ui-preview"
+              >
+                <FontFamilyField
+                  candidates={uiFonts}
+                  value={settings.uiFontFamily}
+                  onChange={setUiFontFamily}
+                />
+                <FontSizeField
+                  value={settings.uiFontSize}
+                  min={UI_FONT_SIZE_MIN}
+                  max={UI_FONT_SIZE_MAX}
+                  onChange={setUiFontSize}
+                />
+              </SectionCard>
+            )}
+            {activeSection === "editor" && (
+              <SectionCard
+                title="SQL editor font"
+                description="Applies to the Query Console, DDL viewer, and result grid cells."
+                previewClass="preferences-preview-editor"
+                previewText="SELECT id, name FROM users WHERE active = true;"
+                testId="preferences-editor-preview"
+              >
+                <FontFamilyField
+                  candidates={editorFonts}
+                  value={settings.editorFontFamily}
+                  onChange={setEditorFontFamily}
+                />
+                <FontSizeField
+                  value={settings.editorFontSize}
+                  min={EDITOR_FONT_SIZE_MIN}
+                  max={EDITOR_FONT_SIZE_MAX}
+                  onChange={setEditorFontSize}
+                />
+              </SectionCard>
+            )}
+          </div>
+        </div>
+
+        <div className="dialog-footer">
+          <div className="dialog-footer-left">
+            <button
+              type="button"
+              className="btn-ghost preferences-reset-btn"
+              onClick={resetToDefaults}
+              title="Reset font family and size for both UI and editor"
+            >
+              <RotateCcw size={14} />
+              Reset to defaults
+            </button>
+          </div>
+          <div className="dialog-footer-right">
+            <button className="btn-primary" onClick={onClose}>
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/QueryConsole/QueryConsole.css
+++ b/src/components/QueryConsole/QueryConsole.css
@@ -150,7 +150,11 @@
   padding: 9px 12px !important;
   font-size: 15px !important;
   line-height: 1.4 !important;
-  font-family: "Inter", var(--font-sans) !important;
+  /* Was hardcoded as `"Inter", var(--font-sans)` which bypassed
+   * the user-configurable UI font (#62). Read the CSS variable
+   * directly so the Monaco hover tooltip follows the same family
+   * the rest of the UI does. */
+  font-family: var(--font-sans) !important;
   color: var(--text-primary) !important;
 }
 

--- a/src/components/QueryConsole/QueryConsole.tsx
+++ b/src/components/QueryConsole/QueryConsole.tsx
@@ -11,6 +11,7 @@ import { format as formatSQL } from "sql-formatter";
 import { save } from "@tauri-apps/plugin-dialog";
 import { useToastStore } from "../../stores/toastStore";
 import { useTabStore } from "../../stores/tabStore";
+import { useUserSettingsStore } from "../../stores/userSettingsStore";
 import { readZoomFactor } from "../../lib/zoom";
 import "./QueryConsole.css";
 
@@ -74,6 +75,12 @@ function formatValidationMessage(message: string) {
 export function QueryConsole({ tabId, connectionId, database }: Props) {
   const addToast = useToastStore((s) => s.addToast);
   const setTabTitle = useTabStore((s) => s.setTabTitle);
+  // Editor font size from user preferences (issue #62). Monaco
+  // re-renders the option diff on every prop change so a live
+  // adjustment in the Preferences dialog reflects immediately.
+  const editorFontSize = useUserSettingsStore(
+    (s) => s.settings.editorFontSize,
+  );
   // Identity of the saved query currently in the editor, if any.
   // Drives the dirty check, the in-place Ctrl/Cmd+S path, and the
   // "Save changes" button label. `null` until the user loads a
@@ -836,7 +843,7 @@ export function QueryConsole({ tabId, connectionId, database }: Props) {
             theme={monacoTheme}
             options={{
               minimap: { enabled: false },
-              fontSize: 16,
+              fontSize: editorFontSize,
               fontWeight: "350",
               fontFamily: "var(--font-mono)",
               lineNumbers: "on",

--- a/src/components/QueryConsole/ResultTable.tsx
+++ b/src/components/QueryConsole/ResultTable.tsx
@@ -8,6 +8,7 @@ import { ExportMenu } from "../ExportMenu";
 import { useToastStore } from "../../stores/toastStore";
 import { useTabStore, TabInfo } from "../../stores/tabStore";
 import { useConnectionStore } from "../../stores/connectionStore";
+import { useUserSettingsStore } from "../../stores/userSettingsStore";
 import { boolLiteral, quoteIdent, quoteQualified } from "../../lib/sqlDialect";
 import { readZoomFactor } from "../../lib/zoom";
 import "../DataGrid/ag-grid-theme.css";
@@ -59,28 +60,34 @@ function ResultDataTypeHeader(props: IHeaderParams & { dataType?: string; isPk?:
   );
 }
 
-const gridTheme = themeQuartz.withParams({
-  backgroundColor: "var(--bg-secondary)",
-  foregroundColor: "var(--text-primary)",
-  headerBackgroundColor: "var(--bg-header)",
-  accentColor: "var(--accent)",
-  borderColor: "var(--border)",
-  columnBorder: true,
-  oddRowBackgroundColor: "var(--bg-primary)",
-  rowHoverColor: "var(--bg-hover)",
-  selectedRowBackgroundColor: "var(--bg-selected)",
-  headerTextColor: "var(--text-secondary)",
-  cellTextColor: "var(--text-primary)",
-  fontFamily: "var(--font-mono)",
-  fontSize: 14,
-  headerFontSize: 12,
-  rowHeight: 32,
-  headerHeight: 34,
-  cellHorizontalPadding: 10,
-  wrapperBorderRadius: 0,
-  borderRadius: 0,
-  headerColumnResizeHandleColor: "transparent",
-});
+/**
+ * AG Grid theme that respects the user's editor-font preference
+ * (issue #62). Rebuilt per render when the size changes.
+ */
+function buildResultTableTheme(editorFontSize: number) {
+  return themeQuartz.withParams({
+    backgroundColor: "var(--bg-secondary)",
+    foregroundColor: "var(--text-primary)",
+    headerBackgroundColor: "var(--bg-header)",
+    accentColor: "var(--accent)",
+    borderColor: "var(--border)",
+    columnBorder: true,
+    oddRowBackgroundColor: "var(--bg-primary)",
+    rowHoverColor: "var(--bg-hover)",
+    selectedRowBackgroundColor: "var(--bg-selected)",
+    headerTextColor: "var(--text-secondary)",
+    cellTextColor: "var(--text-primary)",
+    fontFamily: "var(--font-mono)",
+    fontSize: editorFontSize,
+    headerFontSize: 12,
+    rowHeight: 32,
+    headerHeight: 34,
+    cellHorizontalPadding: 10,
+    wrapperBorderRadius: 0,
+    borderRadius: 0,
+    headerColumnResizeHandleColor: "transparent",
+  });
+}
 
 export interface SourceTable {
   schema: string;
@@ -203,6 +210,15 @@ export function ResultTable({ result, resultMode, onToggleChart, onExport, conne
   const addToast = useToastStore((s) => s.addToast);
   const openTab = useTabStore((s) => s.openTab);
   const connections = useConnectionStore((s) => s.connections);
+  // Editor font preference flows into the result-table theme via
+  // the AG Grid params API (see DataGrid for the same pattern).
+  const editorFontSize = useUserSettingsStore(
+    (s) => s.settings.editorFontSize,
+  );
+  const gridTheme = useMemo(
+    () => buildResultTableTheme(editorFontSize),
+    [editorFontSize],
+  );
   const gridApiRef = useRef<GridApi | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [showSearch, setShowSearch] = useState(false);

--- a/src/components/TableView/TableView.css
+++ b/src/components/TableView/TableView.css
@@ -112,8 +112,14 @@
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.02em;
-  color: var(--text-muted);
-  background: transparent;
+  /* `--text-muted` against a transparent background made the
+   * button read as disabled. The segmented Data/Schema control
+   * gets away with `--text-muted` because its parent has a
+   * `--bg-tertiary` background that frames the dim text; this
+   * button is standalone so it needs a punchier resting color
+   * to look interactive. */
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -122,7 +128,7 @@
 
 .tv-header-right .tv-query-btn:hover {
   color: var(--text-primary);
-  background: var(--bg-tertiary);
+  background: var(--bg-hover);
   border-color: color-mix(in srgb, var(--text-muted) 25%, var(--border));
 }
 

--- a/src/lib/applyFontSettings.test.ts
+++ b/src/lib/applyFontSettings.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { applyFontSettings } from "./applyFontSettings";
+import {
+  DEFAULT_USER_SETTINGS,
+  type UserSettings,
+} from "../stores/userSettingsStore";
+
+function makeRoot(): HTMLElement {
+  // Use a fresh detached element per test so prior writes from
+  // sibling tests can't leak. We only care about the .style
+  // surface; nothing in applyFontSettings inspects the DOM tree.
+  return document.createElement("div");
+}
+
+function settings(over: Partial<UserSettings> = {}): UserSettings {
+  return { ...DEFAULT_USER_SETTINGS, ...over };
+}
+
+describe("applyFontSettings", () => {
+  let root: HTMLElement;
+  beforeEach(() => {
+    root = makeRoot();
+  });
+
+  describe("font sizes are always written", () => {
+    it("writes the default px values for an unedited install", () => {
+      applyFontSettings(DEFAULT_USER_SETTINGS, root);
+      expect(root.style.getPropertyValue("--ui-font-size")).toBe("13px");
+      expect(root.style.getPropertyValue("--editor-font-size")).toBe("14px");
+    });
+
+    it("writes user-chosen px values", () => {
+      applyFontSettings(settings({ uiFontSize: 16, editorFontSize: 18 }), root);
+      expect(root.style.getPropertyValue("--ui-font-size")).toBe("16px");
+      expect(root.style.getPropertyValue("--editor-font-size")).toBe("18px");
+    });
+  });
+
+  describe("family overrides", () => {
+    it("does NOT set --font-sans / --font-mono when both are null (defaults)", () => {
+      // Letting the :root declaration win means there's no override
+      // string to maintain in sync; the value lives in global.css.
+      applyFontSettings(DEFAULT_USER_SETTINGS, root);
+      expect(root.style.getPropertyValue("--font-sans")).toBe("");
+      expect(root.style.getPropertyValue("--font-mono")).toBe("");
+    });
+
+    it("prepends the user's UI family to the bundled fallback chain", () => {
+      applyFontSettings(settings({ uiFontFamily: "Inter" }), root);
+      const v = root.style.getPropertyValue("--font-sans");
+      expect(v).toContain('"Inter"');
+      // Bundled Fira Sans must remain as the next fallback so an
+      // unavailable user font still has a known-good replacement.
+      expect(v).toContain('"Fira Sans"');
+      expect(v).toContain("sans-serif");
+    });
+
+    it("prepends the user's editor family to the bundled monospace chain", () => {
+      applyFontSettings(settings({ editorFontFamily: "Cascadia Code" }), root);
+      const v = root.style.getPropertyValue("--font-mono");
+      expect(v).toContain('"Cascadia Code"');
+      expect(v).toContain('"JetBrains Mono"');
+      expect(v).toContain("monospace");
+    });
+
+    it("clears a previously-set override when the family flips back to null", () => {
+      // Reset-to-defaults path: a prior apply wrote a value, the
+      // next apply (with `null`) must remove the inline override so
+      // the :root variable wins again.
+      applyFontSettings(settings({ uiFontFamily: "Inter" }), root);
+      expect(root.style.getPropertyValue("--font-sans")).not.toBe("");
+      applyFontSettings(settings({ uiFontFamily: null }), root);
+      expect(root.style.getPropertyValue("--font-sans")).toBe("");
+    });
+
+    it("only touches the family that's customized", () => {
+      applyFontSettings(settings({ uiFontFamily: "Inter" }), root);
+      // UI was set, mono should stay at "no override".
+      expect(root.style.getPropertyValue("--font-sans")).not.toBe("");
+      expect(root.style.getPropertyValue("--font-mono")).toBe("");
+    });
+  });
+
+  describe("defaults to documentElement when no root is passed", () => {
+    it("writes the CSS vars to <html> in the absence of an explicit root", () => {
+      // Clean any drift from prior tests.
+      document.documentElement.style.removeProperty("--font-sans");
+      document.documentElement.style.removeProperty("--font-mono");
+      document.documentElement.style.removeProperty("--ui-font-size");
+      document.documentElement.style.removeProperty("--editor-font-size");
+
+      applyFontSettings(settings({ uiFontFamily: "Inter", uiFontSize: 15 }));
+
+      expect(
+        document.documentElement.style.getPropertyValue("--font-sans"),
+      ).toContain('"Inter"');
+      expect(
+        document.documentElement.style.getPropertyValue("--ui-font-size"),
+      ).toBe("15px");
+    });
+  });
+});

--- a/src/lib/applyFontSettings.ts
+++ b/src/lib/applyFontSettings.ts
@@ -1,0 +1,69 @@
+import type { UserSettings } from "../stores/userSettingsStore";
+
+/**
+ * Write the user's font preferences to CSS custom properties on the
+ * given root element (issue #62). The whole UI reads from those
+ * variables — `var(--font-sans)`, `var(--font-mono)`,
+ * `var(--ui-font-size)`, `var(--editor-font-size)` — so a single
+ * pass here updates the entire app live, no remount needed.
+ *
+ * Family handling: when the user picks a non-default family we
+ * *prepend* it to the existing bundled fallback chain rather than
+ * replacing it outright. Two reasons:
+ *
+ * 1. If the chosen font becomes unavailable later (uninstalled on
+ *    Linux, fallback after an OS update), the bundled stack still
+ *    has a sensible monospace / sans to land on.
+ * 2. Glyphs missing from the user's font (e.g. an emoji column
+ *    title with a font that has no emoji) still resolve through
+ *    the fallback chain instead of rendering as tofu.
+ *
+ * When the user picks the "System default" sentinel (`null` in the
+ * store), we remove the CSS variable override so the value declared
+ * in `:root` of `global.css` wins again — no flash, no string
+ * surgery.
+ */
+
+/** Bundled UI fallback chain — must mirror `:root --font-sans`
+ *  in `src/styles/global.css` so the apply path produces the same
+ *  cascade that the no-override case does. */
+const UI_FALLBACK_CHAIN =
+  `-apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif`;
+
+/** Bundled monospace fallback chain — mirrors `:root --font-mono`. */
+const MONO_FALLBACK_CHAIN =
+  `"JetBrains Mono", "SF Mono", "Fira Code", ui-monospace, Menlo, Monaco, "Cascadia Mono", monospace`;
+
+export function applyFontSettings(
+  settings: UserSettings,
+  root: HTMLElement = document.documentElement,
+): void {
+  // UI family — set the variable when the user has a custom pick,
+  // clear it otherwise so the :root declaration wins.
+  if (settings.uiFontFamily) {
+    root.style.setProperty(
+      "--font-sans",
+      `"${settings.uiFontFamily}", "Fira Sans", ${UI_FALLBACK_CHAIN}`,
+    );
+  } else {
+    root.style.removeProperty("--font-sans");
+  }
+
+  // Editor family — same pattern for monospace.
+  if (settings.editorFontFamily) {
+    root.style.setProperty(
+      "--font-mono",
+      `"${settings.editorFontFamily}", ${MONO_FALLBACK_CHAIN}`,
+    );
+  } else {
+    root.style.removeProperty("--font-mono");
+  }
+
+  // Sizes are unconditional — the variables always carry a px value,
+  // either the user's pick or the default seeded by the store.
+  root.style.setProperty("--ui-font-size", `${settings.uiFontSize}px`);
+  root.style.setProperty(
+    "--editor-font-size",
+    `${settings.editorFontSize}px`,
+  );
+}

--- a/src/lib/fontAvailability.test.ts
+++ b/src/lib/fontAvailability.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  isFontAvailable,
+  detectAvailableFonts,
+  UI_FONT_CANDIDATES,
+  EDITOR_FONT_CANDIDATES,
+  SYSTEM_DEFAULT_SENTINEL,
+  type FontOption,
+} from "./fontAvailability";
+
+/**
+ * Hook `document.fonts.check` so we can drive deterministic
+ * availability results from tests. Returns a setter that lets each
+ * test decide which families are "installed".
+ */
+function withFontsCheck(checker: (font: string) => boolean) {
+  const original = (
+    document as Document & { fonts?: { check?: (f: string) => boolean } }
+  ).fonts;
+  Object.defineProperty(document, "fonts", {
+    value: { check: vi.fn(checker) },
+    configurable: true,
+  });
+  return () => {
+    Object.defineProperty(document, "fonts", {
+      value: original,
+      configurable: true,
+    });
+  };
+}
+
+describe("isFontAvailable", () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it("returns true for the empty sentinel (always offered)", () => {
+    expect(isFontAvailable(SYSTEM_DEFAULT_SENTINEL)).toBe(true);
+  });
+
+  it("passes the family quoted in 12px form to document.fonts.check", () => {
+    const checked: string[] = [];
+    restore = withFontsCheck((font) => {
+      checked.push(font);
+      return true;
+    });
+    isFontAvailable("Cascadia Code");
+    // Multi-word families must be quoted or the CSS parser would
+    // treat each word as a separate token and the lookup would
+    // silently miss.
+    expect(checked).toEqual([`12px "Cascadia Code"`]);
+  });
+
+  it("returns the value document.fonts.check returns", () => {
+    restore = withFontsCheck(() => false);
+    expect(isFontAvailable("NonExistentFont")).toBe(false);
+  });
+
+  it("returns false (rather than throwing) when document.fonts is absent", () => {
+    restore = withFontsCheck(() => true);
+    // Remove the fonts API entirely to mimic older JSDOM / a stripped
+    // environment.
+    Object.defineProperty(document, "fonts", {
+      value: undefined,
+      configurable: true,
+    });
+    expect(isFontAvailable("Inter")).toBe(false);
+  });
+
+  it("returns false (rather than propagating) if check throws", () => {
+    restore = withFontsCheck(() => {
+      throw new Error("boom");
+    });
+    expect(isFontAvailable("Inter")).toBe(false);
+  });
+});
+
+describe("detectAvailableFonts", () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it("keeps every bundled font even when the OS reports them as missing", () => {
+    // Bundled fonts have @font-face declarations in global.css so
+    // they're always available inside the app regardless of what
+    // the OS-level font enumeration thinks.
+    restore = withFontsCheck(() => false);
+    const out = detectAvailableFonts(EDITOR_FONT_CANDIDATES);
+    expect(out.find((o) => o.family === "JetBrains Mono")).toBeDefined();
+    expect(out.find((o) => o.family === "Fira Code")).toBeDefined();
+  });
+
+  it("always keeps the System default sentinel", () => {
+    restore = withFontsCheck(() => false);
+    const out = detectAvailableFonts(UI_FONT_CANDIDATES);
+    expect(
+      out.find((o) => o.family === SYSTEM_DEFAULT_SENTINEL),
+    ).toBeDefined();
+  });
+
+  it("filters non-bundled fonts that the system doesn't have", () => {
+    // Only allow Inter and "Cascadia Code" through.
+    restore = withFontsCheck((font) =>
+      font.includes('"Inter"') || font.includes('"Cascadia Code"'),
+    );
+    const out = detectAvailableFonts(UI_FONT_CANDIDATES);
+    expect(out.find((o) => o.family === "Inter")).toBeDefined();
+    expect(out.find((o) => o.family === "Roboto")).toBeUndefined();
+    expect(out.find((o) => o.family === "Segoe UI")).toBeUndefined();
+  });
+
+  it("returns the result as an array (not a frozen ReadonlyArray)", () => {
+    restore = withFontsCheck(() => true);
+    const out = detectAvailableFonts(UI_FONT_CANDIDATES);
+    // The consumer pushes a "Custom..." option onto the result in
+    // some UI variants — make sure the helper hands back a writable
+    // array, not the original readonly literal.
+    expect(Array.isArray(out)).toBe(true);
+    expect(() => out.push({ label: "X", family: "X" })).not.toThrow();
+  });
+
+  it("preserves the candidate order so the user-facing list stays predictable", () => {
+    restore = withFontsCheck(() => true);
+    const out = detectAvailableFonts(UI_FONT_CANDIDATES);
+    expect(out[0].family).toBe(SYSTEM_DEFAULT_SENTINEL);
+    expect(out[1].family).toBe("Fira Sans");
+  });
+});
+
+describe("candidate lists", () => {
+  it("UI list starts with the System default sentinel", () => {
+    expect(UI_FONT_CANDIDATES[0].family).toBe(SYSTEM_DEFAULT_SENTINEL);
+    expect(UI_FONT_CANDIDATES[0].label).toMatch(/system default/i);
+  });
+
+  it("editor list starts with the System monospace sentinel", () => {
+    expect(EDITOR_FONT_CANDIDATES[0].family).toBe(SYSTEM_DEFAULT_SENTINEL);
+    expect(EDITOR_FONT_CANDIDATES[0].label).toMatch(/system monospace/i);
+  });
+
+  it("includes every bundled font as a candidate", () => {
+    const bundledUi = UI_FONT_CANDIDATES.filter((o) => o.bundled);
+    expect(bundledUi.map((o) => o.family)).toEqual(["Fira Sans"]);
+    const bundledEditor = EDITOR_FONT_CANDIDATES.filter((o) => o.bundled);
+    expect(bundledEditor.map((o) => o.family).sort()).toEqual(
+      ["Fira Code", "JetBrains Mono"],
+    );
+  });
+
+  it("uses unique family values within each list", () => {
+    const uiFamilies = UI_FONT_CANDIDATES.map((o) => o.family);
+    expect(new Set(uiFamilies).size).toBe(uiFamilies.length);
+    const editorFamilies = EDITOR_FONT_CANDIDATES.map((o) => o.family);
+    expect(new Set(editorFamilies).size).toBe(editorFamilies.length);
+  });
+
+  // Sanity: the types here let me feed any ReadonlyArray<FontOption>
+  // to detectAvailableFonts.
+  it("type-checks against detectAvailableFonts", () => {
+    const arbitrary: ReadonlyArray<FontOption> = [
+      { label: "X", family: "X" },
+    ];
+    expect(() => detectAvailableFonts(arbitrary)).not.toThrow();
+  });
+});

--- a/src/lib/fontAvailability.ts
+++ b/src/lib/fontAvailability.ts
@@ -1,0 +1,113 @@
+/**
+ * Curated lists of UI / editor fonts plus a runtime check that
+ * filters them down to whatever the user's OS actually has
+ * installed (issue #62).
+ *
+ * Why curated rather than free-form: enumerating every font on the
+ * system isn't possible from a web context (the proposed
+ * `navigator.fonts` API still isn't shipped on every Tauri-target
+ * platform), and free-text invites broken values. A short, hand-
+ * picked list of common UI sans + popular monospaced families
+ * plus a system-default sentinel covers ~95% of what users would
+ * pick anyway.
+ *
+ * Bundled fonts (Fira Sans, JetBrains Mono, Fira Code) always
+ * stay in the dropdown even if `document.fonts.check` returns
+ * false for some reason — their @font-face declarations live in
+ * `src/styles/global.css` so they're guaranteed to be available
+ * inside the app regardless of OS state.
+ */
+
+export interface FontOption {
+  /** Human-readable label shown in the dropdown. */
+  label: string;
+  /**
+   * Family token written into the CSS `font-family` property.
+   * `""` is the sentinel that maps to `null` in the store
+   * (i.e. "use the bundled default stack").
+   */
+  family: string;
+  /** Bundled = always available; never filtered out. */
+  bundled?: boolean;
+}
+
+/**
+ * Sentinel value used for "no override" / "use defaults". The
+ * Preferences dialog renders this as the first option in each
+ * dropdown; selecting it persists `null` in the store.
+ */
+export const SYSTEM_DEFAULT_SENTINEL = "";
+
+export const UI_FONT_CANDIDATES: ReadonlyArray<FontOption> = [
+  { label: "System default", family: SYSTEM_DEFAULT_SENTINEL },
+  { label: "Fira Sans (bundled)", family: "Fira Sans", bundled: true },
+  { label: "Inter", family: "Inter" },
+  { label: "Roboto", family: "Roboto" },
+  { label: "Segoe UI", family: "Segoe UI" },
+  { label: "SF Pro Text", family: "SF Pro Text" },
+  { label: "Helvetica Neue", family: "Helvetica Neue" },
+  { label: "Arial", family: "Arial" },
+  { label: "Ubuntu", family: "Ubuntu" },
+  { label: "DejaVu Sans", family: "DejaVu Sans" },
+  { label: "Open Sans", family: "Open Sans" },
+  { label: "Noto Sans", family: "Noto Sans" },
+];
+
+export const EDITOR_FONT_CANDIDATES: ReadonlyArray<FontOption> = [
+  { label: "System monospace", family: SYSTEM_DEFAULT_SENTINEL },
+  {
+    label: "JetBrains Mono (bundled)",
+    family: "JetBrains Mono",
+    bundled: true,
+  },
+  { label: "Fira Code (bundled)", family: "Fira Code", bundled: true },
+  { label: "Cascadia Code", family: "Cascadia Code" },
+  { label: "Cascadia Mono", family: "Cascadia Mono" },
+  { label: "Consolas", family: "Consolas" },
+  { label: "SF Mono", family: "SF Mono" },
+  { label: "Menlo", family: "Menlo" },
+  { label: "Monaco", family: "Monaco" },
+  { label: "Source Code Pro", family: "Source Code Pro" },
+  { label: "Roboto Mono", family: "Roboto Mono" },
+  { label: "DejaVu Sans Mono", family: "DejaVu Sans Mono" },
+  { label: "Ubuntu Mono", family: "Ubuntu Mono" },
+  { label: "IBM Plex Mono", family: "IBM Plex Mono" },
+];
+
+/**
+ * Probe whether a single font family is available via the CSS
+ * Font Loading API. Returns `false` on environments without
+ * `document.fonts.check` (e.g. older JSDOM in unit tests).
+ *
+ * Family names are wrapped in double quotes because CSS expects
+ * quoted multi-word family identifiers; passing `Cascadia Code`
+ * without quotes makes the API parse it as two separate tokens.
+ */
+export function isFontAvailable(family: string): boolean {
+  if (!family) return true; // sentinel — always offered
+  try {
+    const fonts = (document as Document & {
+      fonts?: { check: (font: string) => boolean };
+    }).fonts;
+    if (!fonts || typeof fonts.check !== "function") return false;
+    return fonts.check(`12px "${family}"`);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Filter a candidate list to the subset actually available on the
+ * host system. Bundled fonts pass through unconditionally because
+ * @font-face guarantees their presence inside the Tablio renderer.
+ * The sentinel "System default" option always passes through too.
+ */
+export function detectAvailableFonts(
+  candidates: ReadonlyArray<FontOption>,
+): FontOption[] {
+  return candidates.filter((opt) => {
+    if (opt.bundled) return true;
+    if (opt.family === SYSTEM_DEFAULT_SENTINEL) return true;
+    return isFontAvailable(opt.family);
+  });
+}

--- a/src/stores/userSettingsStore.test.ts
+++ b/src/stores/userSettingsStore.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  useUserSettingsStore,
+  hydrateUserSettings,
+  DEFAULT_USER_SETTINGS,
+  UI_FONT_SIZE_MIN,
+  UI_FONT_SIZE_MAX,
+  EDITOR_FONT_SIZE_MIN,
+  EDITOR_FONT_SIZE_MAX,
+} from "./userSettingsStore";
+
+describe("userSettingsStore", () => {
+  beforeEach(() => {
+    // Reset the in-memory store + cleared localStorage so persisted
+    // state from a previous test never leaks into the next one.
+    useUserSettingsStore.setState({ settings: { ...DEFAULT_USER_SETTINGS } });
+    localStorage.clear();
+  });
+
+  describe("defaults", () => {
+    it("starts with `null` font families so the bundled CSS stack wins", () => {
+      const { settings } = useUserSettingsStore.getState();
+      expect(settings.uiFontFamily).toBeNull();
+      expect(settings.editorFontFamily).toBeNull();
+    });
+
+    it("ships sensible default font sizes", () => {
+      const { settings } = useUserSettingsStore.getState();
+      expect(settings.uiFontSize).toBe(13);
+      expect(settings.editorFontSize).toBe(14);
+    });
+  });
+
+  describe("setUiFontFamily / setEditorFontFamily", () => {
+    it("stores the chosen family", () => {
+      useUserSettingsStore.getState().setUiFontFamily("Inter");
+      expect(useUserSettingsStore.getState().settings.uiFontFamily).toBe("Inter");
+      useUserSettingsStore.getState().setEditorFontFamily("Cascadia Code");
+      expect(useUserSettingsStore.getState().settings.editorFontFamily).toBe(
+        "Cascadia Code",
+      );
+    });
+
+    it("normalizes empty strings to null", () => {
+      // An empty family from the dialog's free-form recovery path
+      // must not end up storing `""` — the App-effect would set the
+      // CSS variable to an invalid value.
+      useUserSettingsStore.getState().setUiFontFamily("Inter");
+      useUserSettingsStore.getState().setUiFontFamily("");
+      expect(useUserSettingsStore.getState().settings.uiFontFamily).toBeNull();
+      useUserSettingsStore.getState().setUiFontFamily("   ");
+      expect(useUserSettingsStore.getState().settings.uiFontFamily).toBeNull();
+    });
+
+    it("does NOT touch the other family", () => {
+      useUserSettingsStore.getState().setUiFontFamily("Inter");
+      useUserSettingsStore.getState().setEditorFontFamily("JetBrains Mono");
+      const s = useUserSettingsStore.getState().settings;
+      expect(s.uiFontFamily).toBe("Inter");
+      expect(s.editorFontFamily).toBe("JetBrains Mono");
+    });
+  });
+
+  describe("setUiFontSize / setEditorFontSize clamping", () => {
+    it("rounds + clamps UI size to the supported range", () => {
+      useUserSettingsStore.getState().setUiFontSize(13.4);
+      expect(useUserSettingsStore.getState().settings.uiFontSize).toBe(13);
+      useUserSettingsStore.getState().setUiFontSize(13.6);
+      expect(useUserSettingsStore.getState().settings.uiFontSize).toBe(14);
+      useUserSettingsStore.getState().setUiFontSize(2);
+      expect(useUserSettingsStore.getState().settings.uiFontSize).toBe(
+        UI_FONT_SIZE_MIN,
+      );
+      useUserSettingsStore.getState().setUiFontSize(99);
+      expect(useUserSettingsStore.getState().settings.uiFontSize).toBe(
+        UI_FONT_SIZE_MAX,
+      );
+    });
+
+    it("rounds + clamps editor size to the supported range", () => {
+      useUserSettingsStore.getState().setEditorFontSize(11.2);
+      expect(useUserSettingsStore.getState().settings.editorFontSize).toBe(11);
+      useUserSettingsStore.getState().setEditorFontSize(0);
+      expect(useUserSettingsStore.getState().settings.editorFontSize).toBe(
+        EDITOR_FONT_SIZE_MIN,
+      );
+      useUserSettingsStore.getState().setEditorFontSize(100);
+      expect(useUserSettingsStore.getState().settings.editorFontSize).toBe(
+        EDITOR_FONT_SIZE_MAX,
+      );
+    });
+
+    it("falls back to the default when given NaN / Infinity", () => {
+      useUserSettingsStore.getState().setUiFontSize(NaN);
+      expect(useUserSettingsStore.getState().settings.uiFontSize).toBe(
+        DEFAULT_USER_SETTINGS.uiFontSize,
+      );
+      useUserSettingsStore.getState().setEditorFontSize(Infinity);
+      // Infinity isn't finite → goes to default, then default of 14
+      // is already in range so it stays 14.
+      expect(useUserSettingsStore.getState().settings.editorFontSize).toBe(
+        DEFAULT_USER_SETTINGS.editorFontSize,
+      );
+    });
+  });
+
+  describe("resetToDefaults", () => {
+    it("clears every customization", () => {
+      const s = useUserSettingsStore.getState();
+      s.setUiFontFamily("Inter");
+      s.setUiFontSize(17);
+      s.setEditorFontFamily("Cascadia Code");
+      s.setEditorFontSize(20);
+      s.resetToDefaults();
+      expect(useUserSettingsStore.getState().settings).toEqual(
+        DEFAULT_USER_SETTINGS,
+      );
+    });
+  });
+
+  describe("persistence — hydrateUserSettings", () => {
+    it("rehydrates a valid persisted blob", () => {
+      // Pre-seed localStorage with a hand-crafted blob — mirrors the
+      // "user opens the app for the second time" path. We call
+      // hydrateUserSettings directly because vitest caches modules
+      // across tests so we can't simply re-import the singleton.
+      localStorage.setItem(
+        "tablio-user-settings",
+        JSON.stringify({
+          uiFontFamily: "Inter",
+          uiFontSize: 15,
+          editorFontFamily: "JetBrains Mono",
+          editorFontSize: 18,
+        }),
+      );
+      expect(hydrateUserSettings()).toEqual({
+        uiFontFamily: "Inter",
+        uiFontSize: 15,
+        editorFontFamily: "JetBrains Mono",
+        editorFontSize: 18,
+      });
+    });
+
+    it("returns defaults when localStorage is empty", () => {
+      expect(hydrateUserSettings()).toEqual(DEFAULT_USER_SETTINGS);
+    });
+
+    it("ignores a corrupt blob and falls back to defaults", () => {
+      localStorage.setItem("tablio-user-settings", "{not json");
+      expect(hydrateUserSettings()).toEqual(DEFAULT_USER_SETTINGS);
+    });
+
+    it("ignores fields of the wrong type instead of crashing", () => {
+      localStorage.setItem(
+        "tablio-user-settings",
+        JSON.stringify({
+          uiFontFamily: 42, // wrong type → fallback null
+          uiFontSize: "thirteen", // wrong type → fallback default
+          editorFontFamily: null,
+          editorFontSize: 16,
+        }),
+      );
+      const out = hydrateUserSettings();
+      expect(out.uiFontFamily).toBeNull();
+      expect(out.uiFontSize).toBe(DEFAULT_USER_SETTINGS.uiFontSize);
+      expect(out.editorFontFamily).toBeNull();
+      expect(out.editorFontSize).toBe(16);
+    });
+
+    it("clamps persisted sizes that are outside the supported range", () => {
+      // A user manually edited their localStorage to set absurd
+      // values, or an old version of the app stored a wider range.
+      // The hydrator must bring them back into bounds rather than
+      // pass them through.
+      localStorage.setItem(
+        "tablio-user-settings",
+        JSON.stringify({
+          uiFontFamily: null,
+          uiFontSize: 200,
+          editorFontFamily: null,
+          editorFontSize: 1,
+        }),
+      );
+      const out = hydrateUserSettings();
+      expect(out.uiFontSize).toBe(UI_FONT_SIZE_MAX);
+      expect(out.editorFontSize).toBe(EDITOR_FONT_SIZE_MIN);
+    });
+  });
+});

--- a/src/stores/userSettingsStore.ts
+++ b/src/stores/userSettingsStore.ts
@@ -1,0 +1,189 @@
+import { create } from "zustand";
+
+/**
+ * Persistent user preferences (issue #62).
+ *
+ * Currently scoped to font family + size for both the UI shell and
+ * the Monaco editor surface, but designed so future prefs (e.g.
+ * tab width, vim mode, autosave interval) can slot in without
+ * refactoring the storage shape.
+ *
+ * Family fields use `null` to mean "no override — fall back to the
+ * bundled CSS variable stack" so the initial state is indistinguishable
+ * from a brand-new install. The Preferences dialog renders this as
+ * the "System default" / "System monospace" sentinel option.
+ *
+ * Persisted to `localStorage` (not session) so settings survive
+ * across app restarts — matches the zoom / theme / sidebar-width
+ * preferences already in `App.tsx`. Debounced write to keep
+ * keystrokes cheap.
+ */
+
+export interface UserSettings {
+  /** `null` means use the bundled `--font-sans` stack. */
+  uiFontFamily: string | null;
+  /** UI text size in px. Clamped to [12, 18]. */
+  uiFontSize: number;
+  /** `null` means use the bundled `--font-mono` stack. */
+  editorFontFamily: string | null;
+  /** Monaco + result-grid font size in px. Clamped to [11, 22]. */
+  editorFontSize: number;
+}
+
+export const DEFAULT_USER_SETTINGS: UserSettings = {
+  uiFontFamily: null,
+  uiFontSize: 13,
+  editorFontFamily: null,
+  editorFontSize: 14,
+};
+
+/**
+ * Allowed UI font-size range. Below 12 the sidebar tree node labels
+ * start clipping their icons; above 18 the toolbars and tab strip
+ * start wrapping. Tested by eye on a 1080p viewport.
+ */
+export const UI_FONT_SIZE_MIN = 12;
+export const UI_FONT_SIZE_MAX = 18;
+
+/**
+ * Allowed editor font-size range. Wider than the UI range because
+ * Monaco handles small + large gracefully and SQL editing benefits
+ * from a wider acceptable band (mobile-style 22 for low-vision use,
+ * down to 11 for dense-screen power users).
+ */
+export const EDITOR_FONT_SIZE_MIN = 11;
+export const EDITOR_FONT_SIZE_MAX = 22;
+
+interface State {
+  settings: UserSettings;
+  setUiFontFamily: (v: string | null) => void;
+  setUiFontSize: (v: number) => void;
+  setEditorFontFamily: (v: string | null) => void;
+  setEditorFontSize: (v: number) => void;
+  resetToDefaults: () => void;
+}
+
+const STORAGE_KEY = "tablio-user-settings";
+
+function clampUi(v: number): number {
+  if (!Number.isFinite(v)) return DEFAULT_USER_SETTINGS.uiFontSize;
+  return Math.min(UI_FONT_SIZE_MAX, Math.max(UI_FONT_SIZE_MIN, Math.round(v)));
+}
+
+function clampEditor(v: number): number {
+  if (!Number.isFinite(v)) return DEFAULT_USER_SETTINGS.editorFontSize;
+  return Math.min(
+    EDITOR_FONT_SIZE_MAX,
+    Math.max(EDITOR_FONT_SIZE_MIN, Math.round(v)),
+  );
+}
+
+/**
+ * Read + validate persisted settings from `localStorage`. Exported
+ * so tests can exercise the hydrate path without having to reload
+ * the whole module (vitest caches modules across tests).
+ */
+export function hydrateUserSettings(): UserSettings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_USER_SETTINGS;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return DEFAULT_USER_SETTINGS;
+    // Defensive: validate every field so a corrupt blob doesn't
+    // crash the editor or set absurd sizes.
+    return {
+      uiFontFamily:
+        typeof parsed.uiFontFamily === "string" || parsed.uiFontFamily === null
+          ? parsed.uiFontFamily
+          : DEFAULT_USER_SETTINGS.uiFontFamily,
+      uiFontSize:
+        typeof parsed.uiFontSize === "number"
+          ? clampUi(parsed.uiFontSize)
+          : DEFAULT_USER_SETTINGS.uiFontSize,
+      editorFontFamily:
+        typeof parsed.editorFontFamily === "string" ||
+        parsed.editorFontFamily === null
+          ? parsed.editorFontFamily
+          : DEFAULT_USER_SETTINGS.editorFontFamily,
+      editorFontSize:
+        typeof parsed.editorFontSize === "number"
+          ? clampEditor(parsed.editorFontSize)
+          : DEFAULT_USER_SETTINGS.editorFontSize,
+    };
+  } catch {
+    return DEFAULT_USER_SETTINGS;
+  }
+}
+
+let _persistTimer: ReturnType<typeof setTimeout> | null = null;
+function persist(settings: UserSettings) {
+  if (_persistTimer) clearTimeout(_persistTimer);
+  _persistTimer = setTimeout(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    } catch {
+      // localStorage can throw on quota / private-browsing mode —
+      // swallow so the in-memory store still works for the session.
+    }
+  }, 300);
+}
+
+/** Trim → null for empty strings so the store doesn't store "" as
+ *  a meaningful family value. */
+function normalizeFamily(v: string | null): string | null {
+  if (v === null) return null;
+  const trimmed = v.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+export const useUserSettingsStore = create<State>((set) => ({
+  settings: hydrateUserSettings(),
+
+  setUiFontFamily: (v) => {
+    set((s) => {
+      const next: UserSettings = {
+        ...s.settings,
+        uiFontFamily: normalizeFamily(v),
+      };
+      persist(next);
+      return { settings: next };
+    });
+  },
+
+  setUiFontSize: (v) => {
+    set((s) => {
+      const next: UserSettings = { ...s.settings, uiFontSize: clampUi(v) };
+      persist(next);
+      return { settings: next };
+    });
+  },
+
+  setEditorFontFamily: (v) => {
+    set((s) => {
+      const next: UserSettings = {
+        ...s.settings,
+        editorFontFamily: normalizeFamily(v),
+      };
+      persist(next);
+      return { settings: next };
+    });
+  },
+
+  setEditorFontSize: (v) => {
+    set((s) => {
+      const next: UserSettings = {
+        ...s.settings,
+        editorFontSize: clampEditor(v),
+      };
+      persist(next);
+      return { settings: next };
+    });
+  },
+
+  resetToDefaults: () => {
+    set(() => {
+      persist(DEFAULT_USER_SETTINGS);
+      return { settings: { ...DEFAULT_USER_SETTINGS } };
+    });
+  },
+}));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -115,6 +115,17 @@
   --font-mono: "JetBrains Mono", "SF Mono", "Fira Code", ui-monospace,
     Menlo, Monaco, "Cascadia Mono", monospace;
 
+  /* User-configurable font sizes (issue #62). Applied to <body>
+   * (so all UI text inherits) and to Monaco / AG Grid cells (so
+   * code / data rendering respects the editor pref independently
+   * from the surrounding chrome). Defaults match the values
+   * previously hardcoded in App-wide styles + the Monaco editors,
+   * so first-launch looks identical to before the preference
+   * landed. `userSettingsStore` overrides both via setProperty on
+   * documentElement. */
+  --ui-font-size: 13px;
+  --editor-font-size: 14px;
+
   --radius-xs: 3px;
   --radius-sm: 5px;
   --radius-md: 8px;
@@ -166,6 +177,15 @@ body,
   overflow: hidden;
   user-select: none;
   -webkit-user-select: none;
+}
+
+/* `--ui-font-size` is the single source of truth for UI text size
+ * (issue #62). It seeds body, then every component CSS file that
+ * sets its own absolute font-size still inherits from this baseline
+ * when not explicitly overridden. */
+body {
+  font-family: var(--font-sans);
+  font-size: var(--ui-font-size);
 }
 
 /* Chromium / WebView2 (Windows) doesn't grow body's own layout box


### PR DESCRIPTION
## Summary

Closes #62 — adds a Preferences dialog launched from the Settings gear popover where the user can pick UI font family + size and editor font family + size from curated, system-detected dropdowns. Settings persist in localStorage and apply live across the whole UI, both Monaco editors, and the AG Grid result cells.

> Targets master. Stacks on top of #158 (in-tab alter table editor) — once that lands master will gain a small TableView.css polish that this PR also carries; the rebase will be clean.

## What's in here

### 1. Settings infrastructure

- **`src/stores/userSettingsStore.ts`** — Zustand store, localStorage-backed under `tablio-user-settings`, debounced persist, range-clamped setters (UI 12–18 px, editor 11–22 px). Defensive hydrate ignores corrupt blobs and wrong-typed fields. `hydrateUserSettings` exported for unit-testability.
- **`src/lib/fontAvailability.ts`** — curated UI + editor candidate lists. `detectAvailableFonts` filters non-bundled families through `document.fonts.check`; bundled fonts (Fira Sans / JetBrains Mono / Fira Code) and the "System default" sentinel always pass through.
- **`src/lib/applyFontSettings.ts`** — writes the store's values to CSS custom properties on `documentElement`. Family handling **prepends** the user's choice to the bundled fallback chain (not a wholesale replacement) so an uninstalled family still has a sensible fallback and missing glyphs still resolve through the chain.

### 2. UI

- **`src/components/Preferences/PreferencesDialog.tsx`** — left-rail nav (Interface / SQL editor) + section-card content, mirroring the Connection Dialog's two-pane layout. Live preview strips under each section read from the same CSS vars so changes reflect immediately. "Reset to defaults" button on the left of the footer.
- Mounted from a new "Preferences" entry in the existing Settings gear popover in `App.tsx`.

### 3. Wiring

- **`src/styles/global.css`** — declares `--ui-font-size: 13px` / `--editor-font-size: 14px` defaults; adds `body { font-size: var(--ui-font-size) }` so the UI size cascades.
- **`App.tsx`** — subscribes to the store and calls `applyFontSettings` on every change so the CSS vars stay current.
- **QueryConsole / DDLViewer** — read `editorFontSize` from the store and pass it to Monaco's `options.fontSize`. Family already flows via `var(--font-mono)`.
- **DataGrid / ResultTable** — rebuild `themeQuartz.withParams` via `useMemo` so the AG Grid theme's `fontSize` param reflects the store. This is the only reliable path because AG Grid's runtime CSS variables override any static stylesheet rule (initial attempt via a `.ag-cell { font-size: var(...) }` rule didn't work; the comment in `ag-grid-theme.css` records why).
- **QueryConsole.css cleanup** — the Monaco hover panel used a hardcoded `font-family: "Inter", var(--font-sans)` that bypassed the UI font preference. Replaced with plain `var(--font-sans)` so the hover follows the rest of the UI.

### 4. Shared component improvement — CustomSelect portal mode

The Preferences dialog's font-family dropdown lives inside a scrollable dialog body (`overflow-y: auto`) so the inline-rendered popover was getting clipped at the dialog's bottom edge. Extracted out as a clean opt-in:

- **`portal` prop on `CustomSelect`** — when true, mounts the dropdown to `document.body` via `createPortal`, with viewport-anchored coordinates computed from the trigger's `getBoundingClientRect()`.
- **Auto-flip** — opens upward when there isn't enough room below.
- **Scroll/resize tracking** — re-measures so the popover stays glued to the trigger as ancestor scroll containers move.
- **Zoom-aware** — divides the rect by `readZoomFactor()` (`lib/zoom.ts`) before applying coordinates. The body's CSS `zoom` would otherwise scale the fixed-position popover a second time and the popover would drift at any non-100% UI zoom.
- **Click-outside checks both** the trigger AND the portalised dropdown so clicking inside the popover doesn't accidentally close it.
- Default behavior is unchanged — existing QueryStats / FilterBar / ChartView call sites stay inline.

## Test coverage

| Layer | Count | What |
|---|---|---|
| Unit — `userSettingsStore` | 14 | defaults, setters, clamping, reset, hydrate round-trip (incl. wrong-type / out-of-range / corrupt blob fallbacks) |
| Unit — `fontAvailability` | 15 | candidate-list shape, bundled + sentinel pass through, filtering behavior, error handling when `document.fonts.check` is absent or throws |
| Unit — `applyFontSettings` | 8 | sizes always written, family override prepended to fallback, clear-on-null, defaults to documentElement when no root is passed |
| Unit — `CustomSelect` (new portal tests) | 3 | inline-vs-portal render location, onChange survives the click-outside listener in portal mode |
| E2E — `preferences.spec.ts` | 11 | open dialog via Settings popover, section nav, change UI font size / family, change editor font size, Reset to defaults, persistence across reload, Done closes, preview strip updates for UI + editor, **end-to-end flow: editor font size setting propagates to the rendered `.ag-cell` font-size on a live `users` table view** |

Totals: +40 new unit tests (697 → 737 total), +11 new e2e tests.

## Verification status

- `tsc --noEmit` clean
- `vitest run` — **737 / 737** pass
- `playwright test e2e/preferences.spec.ts` — **11 / 11** pass

## Out of scope (matches the issue)

- Per-tab font overrides
- Custom font file uploads (system-installed fonts only)
- Theme-author font controls in custom themes

## Test plan

- [ ] Open Settings gear → Preferences → dialog appears with two left-rail entries
- [ ] Change UI font family → sidebar / toolbar / dialogs visually flip
- [ ] Change UI font size → all UI text scales accordingly
- [ ] Open the editor section, change editor font size → Query Console + DDL Viewer + result-grid cells all reflect the new size
- [ ] Change editor font family → same surfaces flip family
- [ ] Reload the app → settings persist
- [ ] Reset to defaults → font stack returns to bundled defaults