### PR TITLE
chore(deps): apply non-breaking renovate updates and fix clippy

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -130,13 +130,13 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5439,6 +5439,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5460,9 +5471,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.5"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
@@ -5714,9 +5725,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -6003,9 +6014,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -6466,9 +6477,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6797,9 +6808,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.4"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
 ]

--- a/src-tauri/src/db/cockroachdb.rs
+++ b/src-tauri/src/db/cockroachdb.rs
@@ -40,7 +40,7 @@ impl CockroachdbDriver {
             "postgres://{}:{}@{}:{}{}?sslmode={}",
             urlencoding::encode(&config.user),
             urlencoding::encode(&config.password),
-            &config.host,
+            config.host,
             config.port,
             db_segment,
             ssl_mode

--- a/src-tauri/src/db/mariadb.rs
+++ b/src-tauri/src/db/mariadb.rs
@@ -32,7 +32,7 @@ impl MariadbDriver {
             "mysql://{}:{}@{}:{}{}?ssl-mode={}",
             urlencoding::encode(&config.user),
             urlencoding::encode(&config.password),
-            &config.host,
+            config.host,
             config.port,
             db_segment,
             ssl_mode

--- a/src-tauri/src/db/mysql.rs
+++ b/src-tauri/src/db/mysql.rs
@@ -38,7 +38,7 @@ impl MysqlDriver {
             "mysql://{}:{}@{}:{}{}?ssl-mode={}",
             urlencoding::encode(&config.user),
             urlencoding::encode(&config.password),
-            &config.host,
+            config.host,
             config.port,
             db_segment,
             ssl_mode

--- a/src-tauri/src/db/postgres.rs
+++ b/src-tauri/src/db/postgres.rs
@@ -40,7 +40,7 @@ impl PostgresDriver {
             "postgres://{}:{}@{}:{}{}?sslmode={}",
             urlencoding::encode(&config.user),
             urlencoding::encode(&config.password),
-            &config.host,
+            config.host,
             config.port,
             db_segment,
             ssl_mode

--- a/src-tauri/src/db/tidb.rs
+++ b/src-tauri/src/db/tidb.rs
@@ -36,7 +36,7 @@ impl TidbDriver {
             "mysql://{}:{}@{}:{}{}?ssl-mode={}",
             urlencoding::encode(&config.user),
             urlencoding::encode(&config.password),
-            &config.host,
+            config.host,
             config.port,
             db_segment,
             ssl_mode


### PR DESCRIPTION
## Summary
- Fixes `clippy::useless_borrows_in_formatting` on `&config.host` in Postgres/MySQL/MariaDB/CockroachDB/TiDB URL builders — this was blocking automerge on all Renovate PRs after rustc 1.97.
- Applies non-breaking Renovate lockfile bumps:
  - async-trait `0.1.89` → `0.1.91` (#237)
  - anyhow `1.0.103` → `1.0.104` (#236)
  - tauri-plugin-dialog `2.7.1` → `2.7.2` (#234)
  - tokio `1.52.3` → `1.53.1` (#231)
  - which `8.0.4` → `8.0.5` (#228)
  - uuid `1.23.4` → `1.24.0` (#225)
  - sysinfo `0.39.5` → `0.39.6` (#223)

## Skipped (potentially breaking)
- **#235** russh `0.61` → `0.62` — 0.x minor / API surface change (security advisory; needs dedicated review)
- **#220** calamine `0.35` → `0.36` — 0.x minor + MSRV bump
- **#167** sqlx alpha → `0.9.0` — MySQL CI failing on that PR

After merge, close or let Renovate supersede #237, #236, #234, #231, #228, #225, #223.